### PR TITLE
Now pinning to rel-500

### DIFF
--- a/docker/openemr/Dockerfile
+++ b/docker/openemr/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.5
 RUN apk add --no-cache apache2 git php7 php7-ctype php7-session php7-apache2 php7-xml php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-mcrypt php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-mysqli curl imagemagick-dev
 #php7-tokenizer will be needed when migrating to 7.1
 #clone openemr
-RUN git clone https://github.com/openemr/openemr.git --depth 1 \
+RUN git clone https://github.com/openemr/openemr.git --branch rel-500 --depth 1 \
     && rm -rf openemr/.git \
     && chmod 666 openemr/sites/default/sqlconf.php \
     && chmod 666 openemr/interface/modules/zend_modules/config/application.config.php \


### PR DESCRIPTION
Pulling the rel-500 branch, now that the adodb issue has been mitigated by holding alpine at 3.5 (which holds php at 7.0)