### PR TITLE
Adding php symlink in openemr-docker

### DIFF
--- a/docker/openemr/Dockerfile
+++ b/docker/openemr/Dockerfile
@@ -13,6 +13,7 @@ RUN git clone https://github.com/openemr/openemr.git --branch rel-500 --depth 1 
 #configure apache & php properly
 COPY php.ini /etc/php7/php.ini
 COPY openemr.conf /etc/apache2/conf.d/
+RUN ln -s /usr/bin/php7 /usr/bin/php
 #fix issue with apache2 dying prematurely
 RUN mkdir -p /run/apache2
 #go


### PR DESCRIPTION
Makes it so you can use `php` instead of `php7` as reference to the php binary in openemr docker.