### PR TITLE
Remove hardcoding from mysql-xtrabackup docker

### DIFF
--- a/docker-images/mysql-xtrabackup/README.md
+++ b/docker-images/mysql-xtrabackup/README.md
@@ -20,7 +20,12 @@ The [official Docker](https://hub.docker.com/_/mysql/) should be consulted for i
 
   * Do you need to copy the backup files into the instance? `cd $(docker volume inspect <volume_name> | jq -r ".[0].Mountpoint")` to visit the volume on the host.
   * Call `/root/xrecovery.sh` by itself or with a specific backup's `-info.log` file.
-  * `xrecovery.sh` will determine if it's loading a full or incremental backup, construct a chain of incrementals to backtrack to a full backup if required, apply all required backups, and restart the docker to complete the alterations to the local MySQL datadir.  
+    * `-m <memory_pool>` will set XtraBackup's allowed allocation, given as `750M` or `2.5G`.
+  * `xrecovery.sh` will determine if it's loading a full or incremental backup, construct a chain of incrementals to backtrack to a full backup if required, apply all required backups, and restart the docker to complete the alterations to the local MySQL datadir.
+
+#### Low Memory Users
+
+If the backup process fails citing problems with open files, and you have less than a gigabyte of memory in total, try launching `xrecovery.sh` with an `-m` option like `125M` or even `25M`.
 
 ### Administration
 

--- a/docker-images/mysql-xtrabackup/xbackup-wrapper.sh
+++ b/docker-images/mysql-xtrabackup/xbackup-wrapper.sh
@@ -5,7 +5,7 @@ exec > /tmp/xtrabackup-launch.log 2>&1
 cd /root
 
 if [ ! -f allsetup.ok ]; then
-  ./xbackup.sh -a && ./xbackup.sh -t full && touch allsetup.ok && exit 0
+  ./xbackup.sh -u openemr -a && ./xbackup.sh -t full && touch allsetup.ok && exit 0
   exit 1
 fi
 

--- a/stacks/single-server/duplicity-restore.sh
+++ b/stacks/single-server/duplicity-restore.sh
@@ -41,7 +41,7 @@ if [[ $(free --total --mega | grep Total | awk '{ print $4 }') -lt 1024 ]]; then
   fi
 fi
 
-docker exec $(docker ps | grep mysql | cut -f 1 -d " ") /root/xrecovery.sh
+docker exec $(docker ps | grep mysql | cut -f 1 -d " ") /root/xrecovery.sh -m 125M
 
 if [[ $DR_SETSWAP -eq 1 ]]; then
   echo

--- a/stacks/single-server/duplicity-restore.sh
+++ b/stacks/single-server/duplicity-restore.sh
@@ -11,7 +11,7 @@ echo recovery in a test copy or instance of this system before you proceed.
 echo
 echo Edit this file and remove the \'exit\' line after your tests are
 echo complete.
-echo.
+echo
 exit 1
 
 # todo: add getopts support, passthrough options for things like duplicity --time


### PR DESCRIPTION
 * Docker, scripts no longer depends on `openemr` database for functionality
 * More commandline parameters, better use of getops