### PR TITLE
removing php-mcrypt and using php-openssl instead

### DIFF
--- a/docker/openemr/5.0.1/Dockerfile
+++ b/docker/openemr/5.0.1/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7
 #Install dependencies
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
-    php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-mcrypt php7-iconv \
+    php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7
 #Install dependencies
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
-    php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-mcrypt php7-iconv \
+    php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \


### PR DESCRIPTION
removing php-mcrypt and using php-openssl instead, since mcrypt not supported in PHP 7.2
(testing well and already updated the dockers with this)