### PR TITLE
replace links with depends_on

### DIFF
--- a/docker/openemr/5.0.0/README.md
+++ b/docker/openemr/5.0.0/README.md
@@ -45,7 +45,7 @@ services:
       MYSQL_PASS: openemr
       OE_USER: admin
       OE_PASS: pass
-    links:
+    depends_on:
     - mysql
 volumes:
   logvolume01: {}


### PR DESCRIPTION
`links` is deprecated in docker: https://docs.docker.com/compose/compose-file/#links
Docker-compose v3 will already create a user defined bridge network and put both services in there so they will be linked.

`depends_on` will declare mysql as a dependency for openemr and docker-compose will make sure it is started first in any scenario (restart, update, recreation, etc.) and is a substitute for `links` for dependency control

One thing to keep in mind is that this will not share environment variables between containers. Not sure if that is something these images utilize.

Not a crucial change but if you approve, I can go ahead and submit PRs for this change as well as adding the mysql volume to 5.0.1, 5.0.2 and flex