### PR TITLE
update permissions and remove scripts only once

### DIFF
--- a/docker/openemr/5.0.0/autoconfig.sh
+++ b/docker/openemr/5.0.0/autoconfig.sh
@@ -14,15 +14,15 @@ if ! [ -f /etc/ssl/private/selfsigned.key.pem ]; then
     -keyout /etc/ssl/private/selfsigned.key.pem \
     -out /etc/ssl/certs/selfsigned.cert.pem \
     -days 365 -nodes \
-    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost" 
+    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost"
 fi
 rm -f /etc/ssl/certs/webserver.cert.pem
 rm -f /etc/ssl/private/webserver.key.pem
-ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem 
-ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem 
+ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
+ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
 
 if [ "$DOMAIN" != "" ]; then
-    if [ "$EMAIL" != "" ]; then 
+    if [ "$EMAIL" != "" ]; then
         echo "WARNING: SETTING AN EMAIL VIA \$EMAIL is HIGHLY RECOMMENDED IN ORDER TO"
         echo "         RECEIVE ALERTS FROM LETSENCRYPT ABOUT YOUR SSL CERTIFICATE."
     fi
@@ -35,8 +35,8 @@ if [ "$DOMAIN" != "" ]; then
         /usr/sbin/httpd -k stop
         echo "1 23  *   *   *   certbot renew -q --post-hook \"httpd -k graceful\"" >> /etc/crontabs/root
     fi
-    
-    
+
+
     # run letsencrypt as a daemon and reference the correct cert
     rm -f /etc/ssl/certs/webserver.cert.pem
     rm -f /etc/ssl/private/webserver.key.pem
@@ -95,33 +95,37 @@ if [ "$CONFIG" == "0" ] &&
 fi
 
 if [ "$CONFIG" == "1" ]; then
-    echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
-    #set all directories to 500
-    find . -type d -print0 | xargs -0 chmod 500
-    #set all file access to 400
-    find . -type f -print0 | xargs -0 chmod 400
+    # OpenEMR has been configured
+    if [ -f auto_configure.php ]; then
+        # This section only runs once after above configuration since auto_configure.php gets removed after this script
+        echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
+        #set all directories to 500
+        find . -type d -print0 | xargs -0 chmod 500
+        #set all file access to 400
+        find . -type f -print0 | xargs -0 chmod 400
 
-    echo "Default file permissions and ownership set, allowing writing to specific directories"
-    chmod 700 run_openemr.sh
-    # Set file and directory permissions
-    chmod 600 interface/modules/zend_modules/config/application.config.php
-    find sites/default/documents -type d -print0 | xargs -0 chmod 700
-    find sites/default/edi -type d -print0 | xargs -0 chmod 700
-    find sites/default/era -type d -print0 | xargs -0 chmod 700
-    find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
-    find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
+        echo "Default file permissions and ownership set, allowing writing to specific directories"
+        chmod 700 run_openemr.sh
+        # Set file and directory permissions
+        chmod 600 interface/modules/zend_modules/config/application.config.php
+        find sites/default/documents -type d -print0 | xargs -0 chmod 700
+        find sites/default/edi -type d -print0 | xargs -0 chmod 700
+        find sites/default/era -type d -print0 | xargs -0 chmod 700
+        find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
+        find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
 
-    echo "Removing remaining setup scripts"
-    #remove all setup scripts
-    rm -f acl_setup.php
-    rm -f acl_upgrade.php
-    rm -f setup.php
-    rm -f sql_upgrade.php
-    rm -f ippf_upgrade.php
-    rm -f gacl/setup.php
-    echo "Setup scripts removed, we should be ready to go now!"
+        echo "Removing remaining setup scripts"
+        #remove all setup scripts
+        rm -f acl_setup.php
+        rm -f acl_upgrade.php
+        rm -f setup.php
+        rm -f sql_upgrade.php
+        rm -f ippf_upgrade.php
+        rm -f gacl/setup.php
+        echo "Setup scripts removed, we should be ready to go now!"
+    fi
 fi
 # ensure the auto_configure.php script has been removed
 rm -f auto_configure.php

--- a/docker/openemr/5.0.0/run_openemr.sh
+++ b/docker/openemr/5.0.0/run_openemr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # to be run by root with OpenEMR root dir as the CWD
 
-./autoconfig.sh
+sh autoconfig.sh
 
 echo ""
 echo "Love OpenEMR? You can now support the project via the open collective:"

--- a/docker/openemr/5.0.1/autoconfig.sh
+++ b/docker/openemr/5.0.1/autoconfig.sh
@@ -14,15 +14,15 @@ if ! [ -f /etc/ssl/private/selfsigned.key.pem ]; then
     -keyout /etc/ssl/private/selfsigned.key.pem \
     -out /etc/ssl/certs/selfsigned.cert.pem \
     -days 365 -nodes \
-    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost" 
+    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost"
 fi
 rm -f /etc/ssl/certs/webserver.cert.pem
 rm -f /etc/ssl/private/webserver.key.pem
-ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem 
-ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem 
+ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
+ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
 
 if [ "$DOMAIN" != "" ]; then
-    if [ "$EMAIL" != "" ]; then 
+    if [ "$EMAIL" != "" ]; then
         echo "WARNING: SETTING AN EMAIL VIA \$EMAIL is HIGHLY RECOMMENDED IN ORDER TO"
         echo "         RECEIVE ALERTS FROM LETSENCRYPT ABOUT YOUR SSL CERTIFICATE."
     fi
@@ -35,8 +35,8 @@ if [ "$DOMAIN" != "" ]; then
         /usr/sbin/httpd -k stop
         echo "1 23  *   *   *   certbot renew -q --post-hook \"httpd -k graceful\"" >> /etc/crontabs/root
     fi
-    
-    
+
+
     # run letsencrypt as a daemon and reference the correct cert
     rm -f /etc/ssl/certs/webserver.cert.pem
     rm -f /etc/ssl/private/webserver.key.pem
@@ -95,33 +95,37 @@ if [ "$CONFIG" == "0" ] &&
 fi
 
 if [ "$CONFIG" == "1" ]; then
-    echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
-    #set all directories to 500
-    find . -type d -print0 | xargs -0 chmod 500
-    #set all file access to 400
-    find . -type f -print0 | xargs -0 chmod 400
+    # OpenEMR has been configured
+    if [ -f auto_configure.php ]; then
+        # This section only runs once after above configuration since auto_configure.php gets removed after this script
+        echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
+        #set all directories to 500
+        find . -type d -print0 | xargs -0 chmod 500
+        #set all file access to 400
+        find . -type f -print0 | xargs -0 chmod 400
 
-    echo "Default file permissions and ownership set, allowing writing to specific directories"
-    chmod 700 run_openemr.sh
-    # Set file and directory permissions
-    chmod 600 interface/modules/zend_modules/config/application.config.php
-    find sites/default/documents -type d -print0 | xargs -0 chmod 700
-    find sites/default/edi -type d -print0 | xargs -0 chmod 700
-    find sites/default/era -type d -print0 | xargs -0 chmod 700
-    find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
-    find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
+        echo "Default file permissions and ownership set, allowing writing to specific directories"
+        chmod 700 run_openemr.sh
+        # Set file and directory permissions
+        chmod 600 interface/modules/zend_modules/config/application.config.php
+        find sites/default/documents -type d -print0 | xargs -0 chmod 700
+        find sites/default/edi -type d -print0 | xargs -0 chmod 700
+        find sites/default/era -type d -print0 | xargs -0 chmod 700
+        find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
+        find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
 
-    echo "Removing remaining setup scripts"
-    #remove all setup scripts
-    rm -f acl_setup.php
-    rm -f acl_upgrade.php
-    rm -f setup.php
-    rm -f sql_upgrade.php
-    rm -f ippf_upgrade.php
-    rm -f gacl/setup.php
-    echo "Setup scripts removed, we should be ready to go now!"
+        echo "Removing remaining setup scripts"
+        #remove all setup scripts
+        rm -f acl_setup.php
+        rm -f acl_upgrade.php
+        rm -f setup.php
+        rm -f sql_upgrade.php
+        rm -f ippf_upgrade.php
+        rm -f gacl/setup.php
+        echo "Setup scripts removed, we should be ready to go now!"
+    fi
 fi
 # ensure the auto_configure.php script has been removed
 rm -f auto_configure.php

--- a/docker/openemr/5.0.1/run_openemr.sh
+++ b/docker/openemr/5.0.1/run_openemr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # to be run by root with OpenEMR root dir as the CWD
 
-./autoconfig.sh
+sh autoconfig.sh
 
 echo ""
 echo "Love OpenEMR? You can now support the project via the open collective:"

--- a/docker/openemr/5.0.2/autoconfig.sh
+++ b/docker/openemr/5.0.2/autoconfig.sh
@@ -14,15 +14,15 @@ if ! [ -f /etc/ssl/private/selfsigned.key.pem ]; then
     -keyout /etc/ssl/private/selfsigned.key.pem \
     -out /etc/ssl/certs/selfsigned.cert.pem \
     -days 365 -nodes \
-    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost" 
+    -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost"
 fi
 rm -f /etc/ssl/certs/webserver.cert.pem
 rm -f /etc/ssl/private/webserver.key.pem
-ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem 
-ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem 
+ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
+ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
 
 if [ "$DOMAIN" != "" ]; then
-    if [ "$EMAIL" != "" ]; then 
+    if [ "$EMAIL" != "" ]; then
         echo "WARNING: SETTING AN EMAIL VIA \$EMAIL is HIGHLY RECOMMENDED IN ORDER TO"
         echo "         RECEIVE ALERTS FROM LETSENCRYPT ABOUT YOUR SSL CERTIFICATE."
     fi
@@ -35,8 +35,8 @@ if [ "$DOMAIN" != "" ]; then
         /usr/sbin/httpd -k stop
         echo "1 23  *   *   *   certbot renew -q --post-hook \"httpd -k graceful\"" >> /etc/crontabs/root
     fi
-    
-    
+
+
     # run letsencrypt as a daemon and reference the correct cert
     rm -f /etc/ssl/certs/webserver.cert.pem
     rm -f /etc/ssl/private/webserver.key.pem
@@ -95,33 +95,37 @@ if [ "$CONFIG" == "0" ] &&
 fi
 
 if [ "$CONFIG" == "1" ]; then
-    echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
-    #set all directories to 500
-    find . -type d -print0 | xargs -0 chmod 500
-    #set all file access to 400
-    find . -type f -print0 | xargs -0 chmod 400
+    # OpenEMR has been configured
+    if [ -f auto_configure.php ]; then
+        # This section only runs once after above configuration since auto_configure.php gets removed after this script
+        echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
+        #set all directories to 500
+        find . -type d -print0 | xargs -0 chmod 500
+        #set all file access to 400
+        find . -type f -print0 | xargs -0 chmod 400
 
-    echo "Default file permissions and ownership set, allowing writing to specific directories"
-    chmod 700 run_openemr.sh
-    # Set file and directory permissions
-    chmod 600 interface/modules/zend_modules/config/application.config.php
-    find sites/default/documents -type d -print0 | xargs -0 chmod 700
-    find sites/default/edi -type d -print0 | xargs -0 chmod 700
-    find sites/default/era -type d -print0 | xargs -0 chmod 700
-    find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
-    find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
+        echo "Default file permissions and ownership set, allowing writing to specific directories"
+        chmod 700 run_openemr.sh
+        # Set file and directory permissions
+        chmod 600 interface/modules/zend_modules/config/application.config.php
+        find sites/default/documents -type d -print0 | xargs -0 chmod 700
+        find sites/default/edi -type d -print0 | xargs -0 chmod 700
+        find sites/default/era -type d -print0 | xargs -0 chmod 700
+        find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
+        find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
 
-    echo "Removing remaining setup scripts"
-    #remove all setup scripts
-    rm -f acl_setup.php
-    rm -f acl_upgrade.php
-    rm -f setup.php
-    rm -f sql_upgrade.php
-    rm -f ippf_upgrade.php
-    rm -f gacl/setup.php
-    echo "Setup scripts removed, we should be ready to go now!"
+        echo "Removing remaining setup scripts"
+        #remove all setup scripts
+        rm -f acl_setup.php
+        rm -f acl_upgrade.php
+        rm -f setup.php
+        rm -f sql_upgrade.php
+        rm -f ippf_upgrade.php
+        rm -f gacl/setup.php
+        echo "Setup scripts removed, we should be ready to go now!"
+    fi
 fi
 # ensure the auto_configure.php script has been removed
 rm -f auto_configure.php

--- a/docker/openemr/5.0.2/run_openemr.sh
+++ b/docker/openemr/5.0.2/run_openemr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # to be run by root with OpenEMR root dir as the CWD
 
-./autoconfig.sh
+sh autoconfig.sh
 
 echo ""
 echo "Love OpenEMR? You can now support the project via the open collective:"

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -130,33 +130,37 @@ if [ "$CONFIG" == "0" ] &&
 fi
 
 if [ "$CONFIG" == "1" ]; then
-    echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
-    #set all directories to 500
-    find . -type d -print0 | xargs -0 chmod 500
-    #set all file access to 400
-    find . -type f -print0 | xargs -0 chmod 400
+    # OpenEMR has been configured
+    if [ -f auto_configure.php ]; then
+        # This section only runs once after above configuration since auto_configure.php gets removed after this script
+        echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
+        #set all directories to 500
+        find . -type d -print0 | xargs -0 chmod 500
+        #set all file access to 400
+        find . -type f -print0 | xargs -0 chmod 400
 
-    echo "Default file permissions and ownership set, allowing writing to specific directories"
-    chmod 700 run_openemr.sh
-    # Set file and directory permissions
-    chmod 600 interface/modules/zend_modules/config/application.config.php
-    find sites/default/documents -type d -print0 | xargs -0 chmod 700
-    find sites/default/edi -type d -print0 | xargs -0 chmod 700
-    find sites/default/era -type d -print0 | xargs -0 chmod 700
-    find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
-    find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
-    find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
+        echo "Default file permissions and ownership set, allowing writing to specific directories"
+        chmod 700 run_openemr.sh
+        # Set file and directory permissions
+        chmod 600 interface/modules/zend_modules/config/application.config.php
+        find sites/default/documents -type d -print0 | xargs -0 chmod 700
+        find sites/default/edi -type d -print0 | xargs -0 chmod 700
+        find sites/default/era -type d -print0 | xargs -0 chmod 700
+        find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
+        find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
+        find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
 
-    echo "Removing remaining setup scripts"
-    #remove all setup scripts
-    rm -f acl_setup.php
-    rm -f acl_upgrade.php
-    rm -f setup.php
-    rm -f sql_upgrade.php
-    rm -f ippf_upgrade.php
-    rm -f gacl/setup.php
-    echo "Setup scripts removed, we should be ready to go now!"
+        echo "Removing remaining setup scripts"
+        #remove all setup scripts
+        rm -f acl_setup.php
+        rm -f acl_upgrade.php
+        rm -f setup.php
+        rm -f sql_upgrade.php
+        rm -f ippf_upgrade.php
+        rm -f gacl/setup.php
+        echo "Setup scripts removed, we should be ready to go now!"
+    fi
 fi
 # ensure the auto_configure.php script has been removed
 rm -f auto_configure.php

--- a/docker/openemr/flex/run_openemr.sh
+++ b/docker/openemr/flex/run_openemr.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # to be run by root with OpenEMR root dir as the CWD
 
-./autoconfig.sh
+sh autoconfig.sh
 
 echo ""
 echo "Love OpenEMR? You can now support the project via the open collective:"


### PR DESCRIPTION
hi @jesdynf and @TheToolbox ,
During the board meeting yesterday, Jit discussed some issues with the dockers. One issue was that everytime they restarted the docker, all the permissions (and script removals), were changed (rather than just doing once after an install/configuration). It seems reasonable to only do this once (and not make users have to modify these everytime they restart the docker. Here's my proposal to do this(I still haven't tested this, so don't bring this into codebase yet). Hoping to get your thoughts?
(@sjpadgett , since you asked a related question regarding this, also mentioning you on this :) )
thanks, -brady