### PR TITLE
change the example docker-compose scripts from mysql to mariadb

### DIFF
--- a/docker/openemr/5.0.0/README.md
+++ b/docker/openemr/5.0.0/README.md
@@ -23,7 +23,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mysql
+    image: mariadb
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -52,7 +52,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/988d5105e38ffd8f6fb3cf49bbfae9f0/raw/26fa8e7e3e1d7cd97d60185a96a033cff33df346/openemr-500-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/988d5105e38ffd8f6fb3cf49bbfae9f0/raw/8fa7f19d77b5bd7365c54fd0464fce5d87645c8e/openemr-500-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/5.0.0/README.md
+++ b/docker/openemr/5.0.0/README.md
@@ -23,7 +23,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mariadb
+    image: mariadb:10.2
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -52,7 +52,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/988d5105e38ffd8f6fb3cf49bbfae9f0/raw/8fa7f19d77b5bd7365c54fd0464fce5d87645c8e/openemr-500-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/988d5105e38ffd8f6fb3cf49bbfae9f0/raw/1811364f169261286dbaf72d78f5d51b37914d90/openemr-500-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/5.0.1/README.md
+++ b/docker/openemr/5.0.1/README.md
@@ -24,7 +24,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mariadb
+    image: mariadb:10.2
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -53,7 +53,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/b629738d5d9aee6c2e8c036e7916c719/raw/a6dc4943ea19d151cc1a2c6d5db7af8eb7a63e46/openemr-501-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/b629738d5d9aee6c2e8c036e7916c719/raw/1e5b63b3963334a11c7d54e6c466cbf9197ac4ff/openemr-501-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/5.0.1/README.md
+++ b/docker/openemr/5.0.1/README.md
@@ -24,7 +24,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mysql
+    image: mariadb
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -53,7 +53,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/b629738d5d9aee6c2e8c036e7916c719/raw/bc67e377d3329564810158f32ea9d6500e67c5d5/openemr-501-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/b629738d5d9aee6c2e8c036e7916c719/raw/a6dc4943ea19d151cc1a2c6d5db7af8eb7a63e46/openemr-501-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/5.0.2/README.md
+++ b/docker/openemr/5.0.2/README.md
@@ -26,7 +26,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mysql
+    image: mariadb
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -55,7 +55,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/8f8dc5215b07d287f7dc0fed80bf2b9d/raw/4f05017ccad17cee1cd3f309f63c3470233eb179/openemr-502-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/8f8dc5215b07d287f7dc0fed80bf2b9d/raw/a5019ea47824be6186b5ef3a31dcbf9842628743/openemr-502-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/5.0.2/README.md
+++ b/docker/openemr/5.0.2/README.md
@@ -26,7 +26,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mariadb
+    image: mariadb:10.2
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -55,7 +55,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/8f8dc5215b07d287f7dc0fed80bf2b9d/raw/a5019ea47824be6186b5ef3a31dcbf9842628743/openemr-502-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/8f8dc5215b07d287f7dc0fed80bf2b9d/raw/6525b61ec2472b394d841839a40e42d4fcad2d5b/openemr-502-docker-example-docker-compose.yml)
 
 ## Environment Variables
 

--- a/docker/openemr/flex/README.md
+++ b/docker/openemr/flex/README.md
@@ -25,7 +25,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mysql
+    image: mariadb
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -56,7 +56,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/6972c32d0af9dc42b96f2ad7c11f06ef/raw/4dc42d6e3bac535ef06f409ad5b9d423a0f5e137/openemr-flex-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/6972c32d0af9dc42b96f2ad7c11f06ef/raw/8cec003c103e0fd29b5ba34215e2f8f5af86c439/openemr-flex-docker-example-docker-compose.yml)
 
 ## Environment Variables
 Required environment settings for flex are `FLEX_REPOSITORY` and (`FLEX_REPOSITORY_BRANCH` or `FLEX_REPOSITORY_TAG`). `FLEX_REPOSITORY` is the public git repository holding the openemr version that will be used. And `FLEX_REPOSITORY_BRANCH` or `FLEX_REPOSITORY_TAG` represent the branch or tag to use in this git repository, respectively.

--- a/docker/openemr/flex/README.md
+++ b/docker/openemr/flex/README.md
@@ -25,7 +25,7 @@ version: '3.1'
 services:
   mysql:
     restart: always
-    image: mariadb
+    image: mariadb:10.2
     command: ['mysqld','--character-set-server=utf8']
     volumes:
     - databasevolume:/var/lib/mysql
@@ -56,7 +56,7 @@ volumes:
   sitevolume: {}
   databasevolume: {}
 ```
-[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/6972c32d0af9dc42b96f2ad7c11f06ef/raw/8cec003c103e0fd29b5ba34215e2f8f5af86c439/openemr-flex-docker-example-docker-compose.yml)
+[![Try it!](https://github.com/play-with-docker/stacks/raw/cff22438cb4195ace27f9b15784bbb497047afa7/assets/images/button.png)](http://play-with-docker.com/?stack=https://gist.githubusercontent.com/bradymiller/6972c32d0af9dc42b96f2ad7c11f06ef/raw/0549cfacc77cd537fa36568e3db41d8879b395ec/openemr-flex-docker-example-docker-compose.yml)
 
 ## Environment Variables
 Required environment settings for flex are `FLEX_REPOSITORY` and (`FLEX_REPOSITORY_BRANCH` or `FLEX_REPOSITORY_TAG`). `FLEX_REPOSITORY` is the public git repository holding the openemr version that will be used. And `FLEX_REPOSITORY_BRANCH` or `FLEX_REPOSITORY_TAG` represent the branch or tag to use in this git repository, respectively.


### PR DESCRIPTION
Turns out that if we do mysql image (that defaults to latest tag), it is now using mysql 8.x which causes issues:
1. main issue being mysql 5.6/5.7 client is not compatible with mysql 8 server (get some login authentication not supported issues). so can't really do this until most operating systems are using mysql 8
2. also brought the demo farm to its knees resource wise

2 options are using mysql:5.7 or going to mariadb docker. Ended up going with mariadb, for now, which works very well (from their latest tag docker which uses a version that maintains compatibiltiy with mysql 5.6/5.7).

This is testing well.