### PR TITLE
Fix for updates to core alpine packages

### DIFF
--- a/docker/openemr/5.0.0/Dockerfile
+++ b/docker/openemr/5.0.0/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.5
 
 #Install dependencies
 #php7-tokenizer will be needed when migrating to 7.1
+RUN apk --no-cache upgrade
 RUN apk add --no-cache \
     apache2 git php7 php7-ctype php7-session php7-apache2 php7-xml \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-mcrypt php7-iconv \

--- a/docker/openemr/5.0.1/Dockerfile
+++ b/docker/openemr/5.0.1/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 
 #Install dependencies
+RUN apk --no-cache upgrade
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \

--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 
 #Install dependencies
+RUN apk --no-cache upgrade
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:edge
 
 #Install dependencies
+RUN apk --no-cache upgrade
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.7
 
 #Install dependencies
+RUN apk --no-cache upgrade
 RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \


### PR DESCRIPTION
The `apache2-ssl` package was throwing a fit when trying to install, due to its post-install hook throwing 127. References online seemed to suggest it was due to a libressl change, and could be fixed by first doing an `apk upgrade` before attempting installation. This seems like reasonable behavior to add to all images (in case upgrades to musl/libressl/apk-tools/etc need to be picked up in the future). If this passes all builds, I think it should be good, but there's no rush to push a new image to docker hub.