### PR TITLE
changes to allow sharing website volume with nginx and php-fpm dockers

### DIFF
--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -7,7 +7,8 @@ RUN apk add --no-cache \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
-    python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron shadow
+    python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
+    shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
 RUN usermod -u 1000 apache
 #clone openemr

--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -7,7 +7,9 @@ RUN apk add --no-cache \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
-    python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron
+    python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron shadow
+# Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
+RUN usermod -u 1000 apache
 #clone openemr
 RUN git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
@@ -20,7 +22,7 @@ RUN git clone https://github.com/openemr/openemr.git --depth 1 \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
     && apk del --no-cache git build-base libffi-dev python-dev
 WORKDIR /var/www/localhost/htdocs/openemr
-VOLUME [ "/var/www/localhost/htdocs/openemr/sites", "/etc/letsencrypt/", "/etc/ssl" ]
+VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly
 ENV APACHE_LOG_DIR=/var/log/apache2
 COPY php.ini /etc/php7/php.ini

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --no-cache \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
-    rsync
+    rsync shadow
+# Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
+    RUN usermod -u 1000 apache
 #Stuff for developers since this predominantly a developer/tester docker
 #Note that Edge (and not 3.7) needs to have nodejs-npm for npm to work
 RUN apk add --no-cache \

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -8,7 +8,9 @@ RUN apk add --no-cache \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
     php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
-    rsync
+    rsync shadow
+# Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
+    RUN usermod -u 1000 apache
 #Stuff for developers since this predominantly a developer/tester docker
 RUN apk add --no-cache \
     php7-phar nodejs unzip vim nano bash bash-doc bash-completion tree


### PR DESCRIPTION
@TheToolbox and @jesdynf ,

I was able to solve the problem of getting shared volumes across openemr, nginx, and php-fpm dockers to work. There were 2 issues:

1. The first was that all the owner uid's need to be the same. After some research, it looks like a option is to set the uid to 1000 for applicable users (in openemr docker is apache user, in nginx docker is nginx user, in php-fpm docker is www-data user); here are corresponding changes in the nginx/php-fpm dockers: https://github.com/openemr/openemr/commit/df4ab4945804d73c87f50978e6030404840bde04

2. Shared volumes do not work when they overlap. So the volume setting in the dockerfile for /var/www/localhost/htdocs/openemr/sites was basically not allowing me to create a volume for /var/www/localhost/htdocs/openemr/ . Super strange it seemed, but I confirmed this by showing that the path for the shared volume (via inspect) was not getting updated. This forced me to need to remove the /var/www/localhost/htdocs/openemr/sites from the dockerfile, which seems reasonable, since this is not needed and really does not do anything (can instead just set up the shared volumes in the docker-compose.yml script)

Here is the docker-compose.yml that is being used to glue together the openemr/mysql/nginx/php-fpm dockers just so you can see what I am doing:
https://gist.github.com/bradymiller/fb8f0fbf9fff74b7666a217f0e9c28a1

Thoughts?