### PR TITLE
added redis support to 5.0.2, flex, and flex-edge dockers

### DIFF
--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers

--- a/docker/openemr/5.0.2/autoconfig.sh
+++ b/docker/openemr/5.0.2/autoconfig.sh
@@ -131,10 +131,13 @@ if [ "$CONFIG" == "1" ] &&
     fi
 fi
 
-if [ "$REDIS_SERVER" != "" ]; then
+if [ "$REDIS_SERVER" != "" ] &&
+   [ ! -f /etc/php-redis-configured ]; then
     # Variable for $REDIS_SERVER is usually going to be something like 'redis'
     sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
     sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    # Ensure only configure this one time
+    touch /etc/php-redis-configured
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/5.0.2/autoconfig.sh
+++ b/docker/openemr/5.0.2/autoconfig.sh
@@ -129,5 +129,15 @@ if [ "$CONFIG" == "1" ]; then
         echo "Setup scripts removed, we should be ready to go now!"
     fi
 fi
+
+if [ -f auto_configure.php ]; then
+    # This section only runs once since auto_configure.php gets removed at the end of this script
+    if [ "$REDIS_SERVER" != "" ]; then
+        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    fi
+fi
+
 # ensure the auto_configure.php script has been removed
 rm -f auto_configure.php

--- a/docker/openemr/5.0.2/autoconfig.sh
+++ b/docker/openemr/5.0.2/autoconfig.sh
@@ -96,7 +96,8 @@ if [ "$CONFIG" == "0" ] &&
     echo "Setup Complete!"
 fi
 
-if [ "$CONFIG" == "1" ]; then
+if [ "$CONFIG" == "1" ] &&
+   [ "$MANUAL_SETUP" != "yes" ]; then
     # OpenEMR has been configured
     if [ -f auto_configure.php ]; then
         # This section only runs once after above configuration since auto_configure.php gets removed after this script
@@ -130,13 +131,10 @@ if [ "$CONFIG" == "1" ]; then
     fi
 fi
 
-if [ -f auto_configure.php ]; then
-    # This section only runs once since auto_configure.php gets removed at the end of this script
-    if [ "$REDIS_SERVER" != "" ]; then
-        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
-        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
-        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
-    fi
+if [ "$REDIS_SERVER" != "" ]; then
+    # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+    sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -19,7 +19,8 @@ RUN npm install -g bower
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
 # is predominantly a developer/tester docker)
-RUN mkdir -p /var/www/localhost/htdocs/openemr/sites \
+RUN mkdir -p /var/www/localhost/htdocs/openemr \
+    && chown -R apache /var/www/localhost/htdocs/openemr \
     && git clone https://github.com/letsencrypt/letsencrypt /opt/certbot \
     && pip install -e /opt/certbot/acme -e /opt/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     rsync shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -110,10 +110,12 @@ if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
     rsync --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
     rm -fr openemr
     cd /var/www/localhost/htdocs/
+fi
 
+if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
     chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
     chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
-    chown -R apache /var/www/localhost/htdocs/openemr
+    chown -R apache /var/www/localhost/htdocs/openemr/
 fi
 
 CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -110,12 +110,10 @@ if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
     rsync --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
     rm -fr openemr
     cd /var/www/localhost/htdocs/
-fi
 
-if [ -f /var/www/localhost/htdocs/auto_configure.php ] ; then
     chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
     chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
-    chown -R apache /var/www/localhost/htdocs/openemr/
+    chown -R apache /var/www/localhost/htdocs/openemr
 fi
 
 CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -136,7 +136,9 @@ if [ "$CONFIG" == "0" ] &&
     echo "Setup Complete!"
 fi
 
-if [ "$CONFIG" == "1" ]; then
+if [ "$CONFIG" == "1" ] &&
+   [ "$MANUAL_SETUP" != "yes" ] &&
+   [ "$EMPTY" != "yes" ]; then
     # OpenEMR has been configured
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
         cd /var/www/localhost/htdocs/openemr/
@@ -172,13 +174,10 @@ if [ "$CONFIG" == "1" ]; then
     fi
 fi
 
-if [ -f auto_configure.php ]; then
-    # This section only runs once since auto_configure.php gets removed at the end of this script
-    if [ "$REDIS_SERVER" != "" ]; then
-        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
-        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
-        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
-    fi
+if [ "$REDIS_SERVER" != "" ]; then
+    # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+    sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -172,10 +172,13 @@ if [ "$CONFIG" == "1" ] &&
     fi
 fi
 
-if [ "$REDIS_SERVER" != "" ]; then
+if [ "$REDIS_SERVER" != "" ] &&
+   [ ! -f /etc/php-redis-configured ]; then
     # Variable for $REDIS_SERVER is usually going to be something like 'redis'
     sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
     sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    # Ensure only configure this one time
+    touch /etc/php-redis-configured
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -172,5 +172,14 @@ if [ "$CONFIG" == "1" ]; then
     fi
 fi
 
+if [ -f auto_configure.php ]; then
+    # This section only runs once since auto_configure.php gets removed at the end of this script
+    if [ "$REDIS_SERVER" != "" ]; then
+        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    fi
+fi
+
 # ensure the auto_configure.php script has been removed
 rm -f /var/www/localhost/htdocs/auto_configure.php

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -18,7 +18,8 @@ RUN npm install -g bower
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
 # is predominantly a developer/tester docker)
-RUN mkdir -p /var/www/localhost/htdocs/openemr/sites \
+RUN mkdir -p /var/www/localhost/htdocs/openemr \
+    && chown -R apache /var/www/localhost/htdocs/openemr \
     && git clone https://github.com/letsencrypt/letsencrypt /opt/certbot \
     && pip install -e /opt/certbot/acme -e /opt/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     rsync shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -110,10 +110,12 @@ if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
     rsync --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
     rm -fr openemr
     cd /var/www/localhost/htdocs/
+fi
 
+if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
     chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
     chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
-    chown -R apache /var/www/localhost/htdocs/openemr
+    chown -R apache /var/www/localhost/htdocs/openemr/
 fi
 
 CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -110,12 +110,10 @@ if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
     rsync --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
     rm -fr openemr
     cd /var/www/localhost/htdocs/
-fi
 
-if [ -f /var/www/localhost/htdocs/auto_configure.php ] ; then
     chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
     chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
-    chown -R apache /var/www/localhost/htdocs/openemr/
+    chown -R apache /var/www/localhost/htdocs/openemr
 fi
 
 CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -136,7 +136,9 @@ if [ "$CONFIG" == "0" ] &&
     echo "Setup Complete!"
 fi
 
-if [ "$CONFIG" == "1" ]; then
+if [ "$CONFIG" == "1" ] &&
+   [ "$MANUAL_SETUP" != "yes" ] &&
+   [ "$EMPTY" != "yes" ]; then
     # OpenEMR has been configured
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
         cd /var/www/localhost/htdocs/openemr/
@@ -172,13 +174,10 @@ if [ "$CONFIG" == "1" ]; then
     fi
 fi
 
-if [ -f auto_configure.php ]; then
-    # This section only runs once since auto_configure.php gets removed at the end of this script
-    if [ "$REDIS_SERVER" != "" ]; then
-        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
-        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
-        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
-    fi
+if [ "$REDIS_SERVER" != "" ]; then
+    # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+    sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -172,10 +172,13 @@ if [ "$CONFIG" == "1" ] &&
     fi
 fi
 
-if [ "$REDIS_SERVER" != "" ]; then
+if [ "$REDIS_SERVER" != "" ] &&
+   [ ! -f /etc/php-redis-configured ]; then
     # Variable for $REDIS_SERVER is usually going to be something like 'redis'
     sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
     sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    # Ensure only configure this one time
+    touch /etc/php-redis-configured
 fi
 
 # ensure the auto_configure.php script has been removed

--- a/docker/openemr/flex/autoconfig.sh
+++ b/docker/openemr/flex/autoconfig.sh
@@ -172,5 +172,14 @@ if [ "$CONFIG" == "1" ]; then
     fi
 fi
 
+if [ -f auto_configure.php ]; then
+    # This section only runs once since auto_configure.php gets removed at the end of this script
+    if [ "$REDIS_SERVER" != "" ]; then
+        # Variable for $REDIS_SERVER is usually going to be something like 'redis'
+        sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
+        sed -i "s@;session.save_path = \"/var/lib/php/sessions\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    fi
+fi
+
 # ensure the auto_configure.php script has been removed
 rm -f /var/www/localhost/htdocs/auto_configure.php


### PR DESCRIPTION
@jesdynf and @TheToolbox ,
I added redis support to the dockers, and is testing well. Note we can't do this to the 5.0.1 docker until after the next patch (5.0.1 breaks when redis php extension is installed and not used locally; actually is a doctrine bug; it will be addressed in patch 4 for 5.0.1)