### PR TITLE
support package building in the flex dockers

### DIFF
--- a/docker/openemr/flex-3.7/Dockerfile
+++ b/docker/openemr/flex-3.7/Dockerfile
@@ -6,15 +6,15 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis php7-simplexml php7-xmlwriter \
+    perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     rsync shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
     RUN usermod -u 1000 apache
 #Stuff for developers since this predominantly a developer/tester docker
 RUN apk add --no-cache \
-    php7-phar nodejs unzip vim nano bash bash-doc bash-completion tree
-RUN npm install -g bower
+    php7-phar unzip vim nano bash bash-doc bash-completion tree
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
 # is predominantly a developer/tester docker)

--- a/docker/openemr/flex-3.7/autoconfig.sh
+++ b/docker/openemr/flex-3.7/autoconfig.sh
@@ -152,12 +152,14 @@ if [ -f /etc/docker-leader ] ||
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
        [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        cd /var/www/localhost/htdocs/openemr
         composer install
         composer global require phing/phing
         /root/.composer/vendor/bin/phing vendor-clean
         /root/.composer/vendor/bin/phing assets-clean
         composer global remove phing/phing
         composer dump-autoload -o
+        cd /var/www/localhost/htdocs
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then

--- a/docker/openemr/flex-3.7/autoconfig.sh
+++ b/docker/openemr/flex-3.7/autoconfig.sh
@@ -149,6 +149,17 @@ if [ -f /etc/docker-leader ] ||
         cd /var/www/localhost/htdocs/
     fi
 
+    if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
+       [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
+       [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        composer install
+        composer global require phing/phing
+        /root/.composer/vendor/bin/phing vendor-clean
+        /root/.composer/vendor/bin/phing assets-clean
+        composer global remove phing/phing
+        composer dump-autoload -o
+    fi
+
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
         chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
         chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php

--- a/docker/openemr/flex-3.8/Dockerfile
+++ b/docker/openemr/flex-3.8/Dockerfile
@@ -6,16 +6,15 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis php7-simplexml php7-xmlwriter \
+    perl mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     rsync shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
     RUN usermod -u 1000 apache
 #Stuff for developers since this predominantly a developer/tester docker
-#Note that Edge/3.8 (and not 3.7) needs to have nodejs-npm for npm to work
 RUN apk add --no-cache \
-    php7-phar nodejs unzip vim nano bash bash-doc bash-completion tree nodejs-npm
-RUN npm install -g bower
+    php7-phar unzip vim nano bash bash-doc bash-completion tree
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
 # is predominantly a developer/tester docker)

--- a/docker/openemr/flex-3.8/autoconfig.sh
+++ b/docker/openemr/flex-3.8/autoconfig.sh
@@ -152,12 +152,14 @@ if [ -f /etc/docker-leader ] ||
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
        [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        cd /var/www/localhost/htdocs/openemr
         composer install
         composer global require phing/phing
         /root/.composer/vendor/bin/phing vendor-clean
         /root/.composer/vendor/bin/phing assets-clean
         composer global remove phing/phing
         composer dump-autoload -o
+        cd /var/www/localhost/htdocs
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then

--- a/docker/openemr/flex-3.8/autoconfig.sh
+++ b/docker/openemr/flex-3.8/autoconfig.sh
@@ -149,6 +149,17 @@ if [ -f /etc/docker-leader ] ||
         cd /var/www/localhost/htdocs/
     fi
 
+    if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
+       [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
+       [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        composer install
+        composer global require phing/phing
+        /root/.composer/vendor/bin/phing vendor-clean
+        /root/.composer/vendor/bin/phing assets-clean
+        composer global remove phing/phing
+        composer dump-autoload -o
+    fi
+
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
         chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
         chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -6,16 +6,15 @@ RUN apk add --no-cache \
     apache2 apache2-ssl git php7 php7-tokenizer php7-ctype php7-session php7-apache2 \
     php7-json php7-pdo php7-pdo_mysql php7-curl php7-ldap php7-openssl php7-iconv \
     php7-xml php7-xsl php7-gd php7-zip php7-soap php7-mbstring php7-zlib \
-    php7-mysqli php7-sockets php7-xmlreader php7-redis perl mysql-client tar curl imagemagick-dev \
+    php7-mysqli php7-sockets php7-xmlreader php7-redis perl php7-simplexml php7-xmlwriter \
+    mysql-client tar curl imagemagick-dev \
     python openssl git libffi-dev py-pip python-dev build-base openssl-dev dcron \
     rsync shadow
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
     RUN usermod -u 1000 apache
 #Stuff for developers since this predominantly a developer/tester docker
-#Note that Edge (and not 3.7) needs to have nodejs-npm for npm to work
 RUN apk add --no-cache \
-    php7-phar nodejs unzip vim nano bash bash-doc bash-completion tree nodejs-npm
-RUN npm install -g bower
+    php7-phar unzip vim nano bash bash-doc bash-completion tree
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
 # is predominantly a developer/tester docker)

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -152,12 +152,14 @@ if [ -f /etc/docker-leader ] ||
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
        [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        cd /var/www/localhost/htdocs/openemr
         composer install
         composer global require phing/phing
         /root/.composer/vendor/bin/phing vendor-clean
         /root/.composer/vendor/bin/phing assets-clean
         composer global remove phing/phing
         composer dump-autoload -o
+        cd /var/www/localhost/htdocs
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -149,6 +149,17 @@ if [ -f /etc/docker-leader ] ||
         cd /var/www/localhost/htdocs/
     fi
 
+    if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
+       [ ! -d /var/www/localhost/htdocs/openemr/vendor ] &&
+       [ "$FORCE_NO_BUILD_MODE" != "yes" ]; then
+        composer install
+        composer global require phing/phing
+        /root/.composer/vendor/bin/phing vendor-clean
+        /root/.composer/vendor/bin/phing assets-clean
+        composer global remove phing/phing
+        composer dump-autoload -o
+    fi
+
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
         chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
         chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php


### PR DESCRIPTION
Note had to add 2 more php7 packages that were needed for composer run to work(php7-simplexml php7-xmlwriter; will need to bring this into 5.0.2 docker at some point). Also will be no need for bower or npm/nodejs packages (this will be run via a composer package)(will need to remove these and add composer support to the 5.0.2 docker at some point).