### PR TITLE
remove admin.php after docker install

### DIFF
--- a/docker/openemr/5.0.1/autoconfig.sh
+++ b/docker/openemr/5.0.1/autoconfig.sh
@@ -120,6 +120,7 @@ if [ "$CONFIG" == "1" ]; then
 
         echo "Removing remaining setup scripts"
         #remove all setup scripts
+        rm -f admin.php
         rm -f acl_setup.php
         rm -f acl_upgrade.php
         rm -f setup.php

--- a/docker/openemr/5.0.2/autoconfig.sh
+++ b/docker/openemr/5.0.2/autoconfig.sh
@@ -152,6 +152,7 @@ if [ -f /etc/docker-leader ] ||
 
             echo "Removing remaining setup scripts"
             #remove all setup scripts
+            rm -f admin.php
             rm -f acl_setup.php
             rm -f acl_upgrade.php
             rm -f setup.php

--- a/docker/openemr/flex-3.7/autoconfig.sh
+++ b/docker/openemr/flex-3.7/autoconfig.sh
@@ -227,6 +227,7 @@ if [ -f /etc/docker-leader ] ||
 
             echo "Removing remaining setup scripts"
             #remove all setup scripts
+            rm -f admin.php
             rm -f acl_setup.php
             rm -f acl_upgrade.php
             rm -f setup.php

--- a/docker/openemr/flex-3.8/autoconfig.sh
+++ b/docker/openemr/flex-3.8/autoconfig.sh
@@ -227,6 +227,7 @@ if [ -f /etc/docker-leader ] ||
 
             echo "Removing remaining setup scripts"
             #remove all setup scripts
+            rm -f admin.php
             rm -f acl_setup.php
             rm -f acl_upgrade.php
             rm -f setup.php

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -227,6 +227,7 @@ if [ -f /etc/docker-leader ] ||
 
             echo "Removing remaining setup scripts"
             #remove all setup scripts
+            rm -f admin.php
             rm -f acl_setup.php
             rm -f acl_upgrade.php
             rm -f setup.php


### PR DESCRIPTION
Removing this since it gives information (the openemr version) without authentication, and is only really needed to support multisite. And multisite feature requires bringing in setup.php script and couple other scripts to work on docker, so might as well also not include admin.php (it can be brought in if needed by user after the install).