### PR TITLE
Increased stability and security of 5.0.2 Docker

### DIFF
--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -40,6 +40,8 @@ RUN apk add --no-cache git build-base libffi-dev python-dev \
     && pip install -e /opt/certbot/acme -e /opt/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
     && apk del --no-cache git build-base libffi-dev python-dev
+
+RUN openssl req -x509 -newkey rsa:4096 -keyout /etc/ssl/private/selfsigned.key.pem -out /etc/ssl/certs/selfsigned.cert.pem -days 1065 -nodes -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost"
 WORKDIR /var/www/localhost/htdocs/openemr
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -41,7 +41,6 @@ RUN apk add --no-cache git build-base libffi-dev python-dev \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
     && apk del --no-cache git build-base libffi-dev python-dev
 
-RUN openssl req -x509 -newkey rsa:4096 -keyout /etc/ssl/private/selfsigned.key.pem -out /etc/ssl/certs/selfsigned.cert.pem -days 1065 -nodes -subj "/C=xx/ST=x/L=x/O=x/OU=x/CN=localhost"
 WORKDIR /var/www/localhost/htdocs/openemr
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -11,25 +11,31 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
 
 	## Security Options
     Protocols http/1.1
+    # Removes revealing HTTP Headers
     ServerSignature off
     ServerTokens Prod
     TraceEnable Off
     FileETag None
     Header unset ETag
+    # Set HSTS and X-XSS protection
     Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
     Header set X-XSS-Protection "1; mode=block"
 	ServerAdmin webmaster@localhost
+	# Narrow document root
 	DocumentRoot /var/www/localhost/htdocs/openemr
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 
     <Directory /var/www/localhost/htdocs/openemr>
+        # Only allow these HTTP Methods
         AllowMethods GET POST HEAD OPTIONS
+        # No indexes anywhere
         Options -Indexes
         Require all granted
     </Directory>
 
     <Directory "/var/www/localhost/htdocs/openemr">
+         # Keeping this it might do something important
          AllowOverride FileInfo
      </Directory>
 

--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -1,4 +1,5 @@
 LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule allowmethods_module modules/mod_allowmethods.so
 	# The ServerName directive sets the request scheme, hostname and port that
 	# the server uses to identify itself. This is used when creating
 	# redirection URLs. In the context of virtual hosts, the ServerName
@@ -8,64 +9,68 @@ LoadModule rewrite_module modules/mod_rewrite.so
 	# However, you must set it for any further virtual host explicitly.
 	#ServerName www.example.com
 
+	## Security Options
+    Protocols http/1.1
+    ServerSignature off
+    ServerTokens Prod
+    TraceEnable Off
+    FileETag None
+    Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/localhost/htdocs/openemr
-	<Directory /var/www/localhost/htdocs/openemr>
-		Options Indexes FollowSymLinks
-	        AllowOverride None
-		Require all granted
-	</Directory>
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
 
- <Directory "/var/www/localhost/htdocs/openemr">
-      AllowOverride FileInfo
-  </Directory>
-  <Directory "/var/www/localhost/htdocs/openemr/sites">
-      AllowOverride None
-  </Directory>
-  <Directory "/var/www/localhost/htdocs/openemr/sites/*/documents">
-      order deny,allow
-      Deny from all
-  </Directory>
-  <Directory "/var/www/localhost/htdocs/openemr/sites/*/edi">
-      order deny,allow
-      Deny from all
-  </Directory>
-  <Directory "/var/www/localhost/htdocs/openemr/sites/*/era">
-      order deny,allow
-      Deny from all
-  </Directory>
+    <Directory /var/www/localhost/htdocs/openemr>
+        AllowMethods GET POST HEAD
+        Options Indexes FollowSymLinks
+        Require all granted
+    </Directory>
 
-	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
-	# error, crit, alert, emerg.
-	# It is also possible to configure the loglevel for particular
-	# modules, e.g.
-	#LogLevel info ssl:warn
-	ErrorLog ${APACHE_LOG_DIR}/error.log
-	CustomLog ${APACHE_LOG_DIR}/access.log combined
+    <Directory "/var/www/localhost/htdocs/openemr">
+         AllowOverride FileInfo
+     </Directory>
+
+     <Directory "/var/www/localhost/htdocs/openemr/sites">
+         AllowOverride None
+     </Directory>
+
+     <Directory "/var/www/localhost/htdocs/openemr/sites/*/documents">
+         Require all denied
+     </Directory>
+
+     <Directory "/var/www/localhost/htdocs/openemr/sites/*/edi">
+         Require all denied
+     </Directory>
+
+     <Directory "/var/www/localhost/htdocs/openemr/sites/*/era">
+         Require all denied
+     </Directory>
+
 
 <VirtualHost *:80>
-
+        RewriteEngine On
+        RewriteCond %{HTTPS} off
+        RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
 </VirtualHost>
-        <VirtualHost _default_:443>
 
-                #   SSL Engine Switch:
-                #   Enable/Disable SSL for this virtual host.
-                SSLEngine on
-				
-				SSLCipherSuite HIGH:!MEDIUM:!aNULL:!MD5:!RC4
-				SSLProtocol -ALL +TLSv1.2
-                #   SSLCertificateFile directive is needed.
-                SSLCertificateFile      /etc/ssl/certs/webserver.cert.pem
-                SSLCertificateKeyFile /etc/ssl/private/webserver.key.pem
+<VirtualHost _default_:443>
+        #   SSL Engine Switch:
+        #   Enable/Disable SSL for this virtual host.
+        SSLEngine on
 
-                #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
-                <FilesMatch "\.(cgi|shtml|phtml|php)$">
-                                SSLOptions +StdEnvVars
-                </FilesMatch>
-                <Directory /usr/lib/cgi-bin>
-                                SSLOptions +StdEnvVars
-                </Directory>
+        SSLCipherSuite HIGH:!MEDIUM:!aNULL:!MD5:!RC4
+        SSLProtocol -ALL +TLSv1.2
+        #SSLCertificateFile directive is needed.
+        SSLCertificateFile      /etc/ssl/certs/selfsigned.cert.pem
+        SSLCertificateKeyFile /etc/ssl/private/selfsigned.key.pem
 
-        </VirtualHost>
-
-# vim: syntax=apache ts=4 sw=4 sts=4 sr noet
+        #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
+        <FilesMatch "\.(cgi|shtml|phtml|php)$">
+            SSLOptions +StdEnvVars
+        </FilesMatch>
+        <Directory /usr/lib/cgi-bin>
+            SSLOptions +StdEnvVars
+        </Directory>
+</VirtualHost>

--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -31,13 +31,9 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
         AllowMethods GET POST HEAD OPTIONS
         # No indexes anywhere
         Options -Indexes
+        AllowOverride FileInfo
         Require all granted
     </Directory>
-
-    <Directory "/var/www/localhost/htdocs/openemr">
-         # Keeping this it might do something important
-         AllowOverride FileInfo
-     </Directory>
 
      <Directory "/var/www/localhost/htdocs/openemr/sites">
          AllowOverride None

--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -15,16 +15,17 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
     ServerTokens Prod
     TraceEnable Off
     FileETag None
+    Header unset ETag
     Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-
+    Header set X-XSS-Protection "1; mode=block"
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/localhost/htdocs/openemr
     ErrorLog ${APACHE_LOG_DIR}/error.log
     CustomLog ${APACHE_LOG_DIR}/access.log combined
 
     <Directory /var/www/localhost/htdocs/openemr>
-        AllowMethods GET POST HEAD
-        Options Indexes FollowSymLinks
+        AllowMethods GET POST HEAD OPTIONS
+        Options -Indexes
         Require all granted
     </Directory>
 
@@ -50,9 +51,9 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
 
 
 <VirtualHost *:80>
-        RewriteEngine On
-        RewriteCond %{HTTPS} off
-        RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
+        #RewriteEngine On
+        #RewriteCond %{HTTPS} off
+        #RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
 </VirtualHost>
 
 <VirtualHost _default_:443>
@@ -60,17 +61,10 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
         #   Enable/Disable SSL for this virtual host.
         SSLEngine on
 
-        SSLCipherSuite HIGH:!MEDIUM:!aNULL:!MD5:!RC4
+        SSLCipherSuite "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 \
+                       EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 \
+                       EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS"
         SSLProtocol -ALL +TLSv1.2
-        #SSLCertificateFile directive is needed.
         SSLCertificateFile      /etc/ssl/certs/selfsigned.cert.pem
         SSLCertificateKeyFile /etc/ssl/private/selfsigned.key.pem
-
-        #SSLOptions +FakeBasicAuth +ExportCertData +StrictRequire
-        <FilesMatch "\.(cgi|shtml|phtml|php)$">
-            SSLOptions +StdEnvVars
-        </FilesMatch>
-        <Directory /usr/lib/cgi-bin>
-            SSLOptions +StdEnvVars
-        </Directory>
 </VirtualHost>

--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -1,30 +1,34 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule allowmethods_module modules/mod_allowmethods.so
-	# The ServerName directive sets the request scheme, hostname and port that
-	# the server uses to identify itself. This is used when creating
-	# redirection URLs. In the context of virtual hosts, the ServerName
-	# specifies what hostname must appear in the request's Host: header to
-	# match this virtual host. For the default virtual host (this file) this
-	# value is not decisive as it is used as a last resort host regardless.
-	# However, you must set it for any further virtual host explicitly.
-	#ServerName www.example.com
 
-	## Security Options
-    Protocols http/1.1
-    # Removes revealing HTTP Headers
-    ServerSignature off
-    ServerTokens Prod
-    TraceEnable Off
-    FileETag None
-    Header unset ETag
-    # Set HSTS and X-XSS protection
-    Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-    Header set X-XSS-Protection "1; mode=block"
-	ServerAdmin webmaster@localhost
-	# Narrow document root
-	DocumentRoot /var/www/localhost/htdocs/openemr
-    ErrorLog ${APACHE_LOG_DIR}/error.log
-    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+# The ServerName directive sets the request scheme, hostname and port that
+# the server uses to identify itself. This is used when creating
+# redirection URLs. In the context of virtual hosts, the ServerName
+# specifies what hostname must appear in the request's Host: header to
+# match this virtual host. For the default virtual host (this file) this
+# value is not decisive as it is used as a last resort host regardless.
+# However, you must set it for any further virtual host explicitly.
+#ServerName www.example.com
+
+
+## Security Options
+Protocols http/1.1
+# Removes revealing HTTP Headers
+ServerSignature off
+ServerTokens Prod
+TraceEnable Off
+FileETag None
+Header unset ETag
+# Set HSTS and X-XSS protection
+Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+Header set X-XSS-Protection "1; mode=block"
+ServerAdmin webmaster@localhost
+# Narrow document root
+DocumentRoot /var/www/localhost/htdocs/openemr
+ErrorLog ${APACHE_LOG_DIR}/error.log
+CustomLog ${APACHE_LOG_DIR}/access.log combined
+
 
     <Directory /var/www/localhost/htdocs/openemr>
         # Only allow these HTTP Methods
@@ -52,11 +56,17 @@ LoadModule allowmethods_module modules/mod_allowmethods.so
      </Directory>
 
 
+#######################################
+### Uncomment the following 3 lines ###
+### to enable HTTPS redirection #######
+### and require HTTPS only ############
+#######################################
 <VirtualHost *:80>
         #RewriteEngine On
         #RewriteCond %{HTTPS} off
         #RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]
 </VirtualHost>
+
 
 <VirtualHost _default_:443>
         #   SSL Engine Switch:

--- a/docker/openemr/5.0.2/php.ini
+++ b/docker/openemr/5.0.2/php.ini
@@ -15,7 +15,7 @@
 ; 5. The web server's directory (for SAPI modules), or directory of PHP
 ; (otherwise in Windows)
 ; 6. The directory from the --with-config-file-path compile time option, or the
-; Windows directory (C:\windows or C:\winnt)
+; Windows directory (usually C:\windows)
 ; See the PHP docs for more specific information.
 ; http://php.net/configuration.file
 
@@ -58,9 +58,9 @@
 ; An empty string can be denoted by simply not writing anything after the equal
 ; sign, or by using the None keyword:
 
-;  foo =         ; sets foo to an empty string
-;  foo = None    ; sets foo to an empty string
-;  foo = "None"  ; sets foo to the string 'None'
+; foo =         ; sets foo to an empty string
+; foo = None    ; sets foo to an empty string
+; foo = "None"  ; sets foo to the string 'None'
 
 ; If you use constants in your value, and these constants belong to a
 ; dynamically loaded extension (either a PHP extension or a Zend extension),
@@ -83,7 +83,7 @@
 ; development version only in development environments, as errors shown to
 ; application users can inadvertently leak otherwise secure information.
 
-; This is php.ini-production INI file.
+; This is the php.ini-production INI file.
 
 ;;;;;;;;;;;;;;;;;;;
 ; Quick Reference ;
@@ -143,7 +143,7 @@
 ;   Development Value: 1000
 ;   Production Value: 1000
 
-; session.hash_bits_per_character
+; session.sid_bits_per_character
 ;   Default Value: 4
 ;   Development Value: 5
 ;   Production Value: 5
@@ -158,11 +158,6 @@
 ;   Development Value: On
 ;   Production Value: Off
 
-; url_rewriter.tags
-;   Default Value: "a=href,area=href,frame=src,form=,fieldset="
-;   Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
-;   Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
-
 ; variables_order
 ;   Default Value: "EGPCS"
 ;   Development Value: "GPCS"
@@ -174,7 +169,7 @@
 ; Name for user-defined php.ini (.htaccess) files. Default is ".user.ini"
 ;user_ini.filename = ".user.ini"
 
-; To disable this feature set this option to empty value
+; To disable this feature set this option to an empty value
 ;user_ini.filename =
 
 ; TTL for user-defined php.ini files (time-to-live) in seconds. Default is 300 seconds (5 minutes)
@@ -244,6 +239,23 @@ output_buffering = 4096
 ; http://php.net/output-handler
 ;output_handler =
 
+; URL rewriter function rewrites URL on the fly by using
+; output buffer. You can set target tags by this configuration.
+; "form" tag is special tag. It will add hidden input tag to pass values.
+; Refer to session.trans_sid_tags for usage.
+; Default Value: "form="
+; Development Value: "form="
+; Production Value: "form="
+;url_rewriter.tags
+
+; URL rewriter will not rewrite absolute URL nor form by default. To enable
+; absolute URL rewrite, allowed hosts must be defined at RUNTIME.
+; Refer to session.trans_sid_hosts for more details.
+; Default Value: ""
+; Development Value: ""
+; Production Value: ""
+;url_rewriter.hosts
+
 ; Transparent output compression using the zlib library
 ; Valid values for this option are 'off', 'on', or a specific buffer size
 ; to be used for compression (default is 4KB)
@@ -282,10 +294,13 @@ implicit_flush = Off
 ; callback-function.
 unserialize_callback_func =
 
-; When floats & doubles are serialized store serialize_precision significant
+; When floats & doubles are serialized, store serialize_precision significant
 ; digits after the floating point. The default value ensures that when floats
 ; are decoded with unserialize, the data will remain the same.
-serialize_precision = 17
+; The value is also used for json_encode when encoding double values.
+; If -1 is used, then dtoa mode 0 is used which automatically select the best
+; precision.
+serialize_precision = -1
 
 ; open_basedir, if set, limits all file operations to the defined directory
 ; and below.  This directive makes most sense if used in a per-directory
@@ -296,8 +311,7 @@ serialize_precision = 17
 ; This directive allows you to disable certain functions for security reasons.
 ; It receives a comma-delimited list of function names.
 ; http://php.net/disable-functions
-disable_functions = pcntl_alarm,pcntl_fork,pcntl_waitpid,pcntl_wait,pcntl_wifexited,pcntl_wifstopped,pcntl_wifsignaled,pcntl_wifcontinued,pcntl_wexitstatus,pcntl_wtermsig,pcntl_wstopsig,pcntl_signal,pcntl_signal_dispatch,pcntl_get_last_error,pcntl_strerror,pcntl_sigprocmask,pcntl_sigwaitinfo,pcntl_sigtimedwait,pcntl_exec,pcntl_getpriority,pcntl_setpriority,
-
+disable_functions = proc_open, popen, disk_free_space, diskfreespace, set_time_limit, leak, tmpfile, exec, system, shell_exec, passthru, show_source, system, phpinfo, pcntl_alarm, pcntl_fork, pcntl_waitpid, pcntl_wait, pcntl_wifexited, pcntl_wifstopped, pcntl_wifsignaled, pcntl_wexitstatus, pcntl_wtermsig, pcntl_wstopsig, pcntl_signal, pcntl_signal_dispatch, pcntl_get_last_error, pcntl_strerror, pcntl_sigprocmask, pcntl_sigwaitinfo, pcntl_sigtimedwait, pcntl_exec, pcntl_getpriority, pcntl_setpriority
 ; This directive allows you to disable certain classes for security reasons.
 ; It receives a comma-delimited list of class names.
 ; http://php.net/disable-classes
@@ -365,7 +379,7 @@ expose_php = Off
 ; Maximum execution time of each script, in seconds
 ; http://php.net/max-execution-time
 ; Note: This directive is hardcoded to 0 for the CLI SAPI
-max_execution_time = 60
+max_execution_time = 30
 
 ; Maximum amount of time each script may spend parsing request data. It's a good
 ; idea to limit this time on productions servers in order to eliminate unexpectedly
@@ -375,18 +389,18 @@ max_execution_time = 60
 ; Development Value: 60 (60 seconds)
 ; Production Value: 60 (60 seconds)
 ; http://php.net/max-input-time
-max_input_time = -1
+max_input_time = 60
 
 ; Maximum input variable nesting level
 ; http://php.net/max-input-nesting-level
 ;max_input_nesting_level = 64
 
 ; How many GET/POST/COOKIE input variables may be accepted
-max_input_vars = 3000
+;max_input_vars = 1000
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 128M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -442,7 +456,7 @@ memory_limit = 256M
 ; Development Value: E_ALL
 ; Production Value: E_ALL & ~E_DEPRECATED & ~E_STRICT
 ; http://php.net/error-reporting
-error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT
 
 ; This directive controls whether or not and where PHP will output errors,
 ; notices and warnings too. Error output is very useful during development, but
@@ -499,7 +513,7 @@ ignore_repeated_errors = Off
 ignore_repeated_source = Off
 
 ; If this parameter is set to Off, then memory leaks will not be shown (on
-; stdout or in the log). This has only effect in a debug compile, and if
+; stdout or in the log). This is only effective in a debug compile, and if
 ; error reporting includes E_WARNING in the allowed list
 ; http://php.net/report-memleaks
 report_memleaks = On
@@ -510,11 +524,12 @@ report_memleaks = On
 ; Store the last error/warning message in $php_errormsg (boolean). Setting this value
 ; to On can assist in debugging and is appropriate for development servers. It should
 ; however be disabled on production servers.
+; This directive is DEPRECATED.
 ; Default Value: Off
-; Development Value: On
+; Development Value: Off
 ; Production Value: Off
 ; http://php.net/track-errors
-track_errors = Off
+;track_errors = Off
 
 ; Turn off normal error reporting and emit XML-RPC error XML
 ; http://php.net/xmlrpc-errors
@@ -568,6 +583,24 @@ html_errors = On
 ;error_log = php_errors.log
 ; Log errors to syslog (Event Log on Windows).
 ;error_log = syslog
+
+; The syslog ident is a string which is prepended to every message logged
+; to syslog. Only used when error_log is set to syslog.
+;syslog.ident = php
+
+; The syslog facility is used to specify what type of program is logging
+; the message. Only used when error_log is set to syslog.
+;syslog.facility = user
+
+; Set this to disable filtering control characters (the default).
+; Some loggers only accept NVT-ASCII, others accept anything that's not
+; control characters. If your logger accepts everything, then no filtering
+; is needed at all.
+; Allowed values are:
+;   ascii (only base ASCII characters)
+;   no_ctrl (all characters except control characters)
+;   all (all characters)
+;syslog.filter = ascii
 
 ;windows.show_crt_warning
 ; Default value: 0
@@ -636,7 +669,7 @@ register_argc_argv = Off
 ; first used (Just In Time) instead of when the script starts. If these
 ; variables are not used within a script, having this directive on will result
 ; in a performance gain. The PHP directive register_argc_argv must be disabled
-; for this directive to have any affect.
+; for this directive to have any effect.
 ; http://php.net/auto-globals-jit
 auto_globals_jit = On
 
@@ -653,7 +686,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 30M
+post_max_size = 8M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -695,7 +728,7 @@ default_charset = "UTF-8"
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ; UNIX: "/path1:/path2"
-;include_path = ".:/usr/share/php"
+;include_path = ".:/php/includes"
 ;
 ; Windows: "\path1;\path2"
 ;include_path = ".;c:\php\includes"
@@ -718,13 +751,13 @@ user_dir =
 
 ; Directory in which the loadable extensions (modules) reside.
 ; http://php.net/extension-dir
-; extension_dir = "./"
+;extension_dir = "./"
 ; On windows:
-; extension_dir = "ext"
+;extension_dir = "ext"
 
 ; Directory where the temporary files should be placed.
 ; Defaults to the system default (see sys_get_temp_dir)
-; sys_temp_dir = "/tmp"
+;sys_temp_dir = "/tmp"
 
 ; Whether or not to enable the dl() function.  The dl() function does NOT work
 ; properly in multithreaded servers, such as IIS or Zeus, and is automatically
@@ -761,10 +794,9 @@ enable_dl = Off
 
 ; if cgi.discard_path is enabled, the PHP CGI binary can safely be placed outside
 ; of the web tree and people will not be able to circumvent .htaccess security.
-; http://php.net/cgi.dicard-path
 ;cgi.discard_path=1
 
-; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
+; FastCGI under IIS supports the ability to impersonate
 ; security tokens of the calling client.  This allows IIS to define the
 ; security context that the request runs under.  mod_fastcgi under Apache
 ; does not currently support this feature (03/17/2002)
@@ -806,7 +838,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 30M
+upload_max_filesize = 2M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20
@@ -817,7 +849,7 @@ max_file_uploads = 20
 
 ; Whether to allow the treatment of URLs (like http:// or ftp://) as files.
 ; http://php.net/allow-url-fopen
-allow_url_fopen = On
+allow_url_fopen = Off
 
 ; Whether to allow include/require to open URLs (like http:// or ftp://) as files.
 ; http://php.net/allow-url-include
@@ -851,64 +883,64 @@ default_socket_timeout = 60
 ; If you wish to have an extension loaded automatically, use the following
 ; syntax:
 ;
-;   extension=modulename.extension
+;   extension=modulename
 ;
-; For example, on Windows:
+; For example:
 ;
-;   extension=msql.dll
+;   extension=mysqli
 ;
-; ... or under UNIX:
+; When the extension library to load is not located in the default extension
+; directory, You may specify an absolute path to the library file:
 ;
-;   extension=msql.so
+;   extension=/path/to/extension/mysqli.so
 ;
-; ... or with a path:
+; Note : The syntax used in previous PHP versions ('extension=<ext>.so' and
+; 'extension='php_<ext>.dll') is supported for legacy reasons and may be
+; deprecated in a future PHP major version. So, when it is possible, please
+; move to the new ('extension=<ext>) syntax.
 ;
-;   extension=/path/to/extension/msql.so
+; Notes for Windows environments :
 ;
-; If you only provide the name of the extension, PHP will look for it in its
-; default extension directory.
+; - Many DLL files are located in the extensions/ (PHP 4) or ext/ (PHP 5+)
+;   extension folders as well as the separate PECL DLL download (PHP 5+).
+;   Be sure to appropriately set the extension_dir directive.
 ;
-; Windows Extensions
-; Note that ODBC support is built in, so no dll is needed for it.
-; Note that many DLL files are located in the extensions/ (PHP 4) ext/ (PHP 5+)
-; extension folders as well as the separate PECL DLL download (PHP 5+).
-; Be sure to appropriately set the extension_dir directive.
-;
-;extension=php_bz2.dll
-;extension=php_curl.dll
-;extension=php_fileinfo.dll
-;extension=php_ftp.dll
-;extension=php_gd2.dll
-;extension=php_gettext.dll
-;extension=php_gmp.dll
-;extension=php_intl.dll
-;extension=php_imap.dll
-;extension=php_interbase.dll
-;extension=php_ldap.dll
-;extension=php_mbstring.dll
-;extension=php_exif.dll      ; Must be after mbstring as it depends on it
-;extension=php_mysqli.dll
-;extension=php_oci8_12c.dll  ; Use with Oracle Database 12c Instant Client
-;extension=php_openssl.dll
-;extension=php_pdo_firebird.dll
-;extension=php_pdo_mysql.dll
-;extension=php_pdo_oci.dll
-;extension=php_pdo_odbc.dll
-;extension=php_pdo_pgsql.dll
-;extension=php_pdo_sqlite.dll
-;extension=php_pgsql.dll
-;extension=php_shmop.dll
+;extension=bz2
+;extension=curl
+;extension=fileinfo
+;extension=gd2
+;extension=gettext
+;extension=gmp
+;extension=intl
+;extension=imap
+;extension=interbase
+;extension=ldap
+;extension=mbstring
+;extension=exif      ; Must be after mbstring as it depends on it
+;extension=mysqli
+;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
+;extension=odbc
+;extension=openssl
+;extension=pdo_firebird
+;extension=pdo_mysql
+;extension=pdo_oci
+;extension=pdo_odbc
+;extension=pdo_pgsql
+;extension=pdo_sqlite
+;extension=pgsql
+;extension=shmop
 
 ; The MIBS data available in the PHP distribution must be installed.
 ; See http://www.php.net/manual/en/snmp.installation.php
-;extension=php_snmp.dll
+;extension=snmp
 
-;extension=php_soap.dll
-;extension=php_sockets.dll
-;extension=php_sqlite3.dll
-;extension=php_tidy.dll
-;extension=php_xmlrpc.dll
-;extension=php_xsl.dll
+;extension=soap
+;extension=sockets
+;extension=sodium
+;extension=sqlite3
+;extension=tidy
+;extension=xmlrpc
+;extension=xsl
 
 ;;;;;;;;;;;;;;;;;;;
 ; Module Settings ;
@@ -945,7 +977,7 @@ cli_server.color = On
 [iconv]
 ; Use of this INI entry is deprecated, use global input_encoding instead.
 ; If empty, default_charset or input_encoding or iconv.input_encoding is used.
-; The precedence is: default_charset < intput_encoding < iconv.input_encoding
+; The precedence is: default_charset < input_encoding < iconv.input_encoding
 ;iconv.input_encoding =
 
 ; Use of this INI entry is deprecated, use global internal_encoding instead.
@@ -960,6 +992,13 @@ cli_server.color = On
 ; otherwise output encoding conversion cannot be performed.
 ;iconv.output_encoding =
 
+[imap]
+; rsh/ssh logins are disabled by default. Use this INI entry if you want to
+; enable them. Note that the IMAP library does not filter mailbox names before
+; passing them to rsh/ssh command, thus passing untrusted data to this function
+; with rsh/ssh enabled is insecure.
+;imap.enable_insecure_rsh=0
+
 [intl]
 ;intl.default_locale =
 ; This directive allows you to produce PHP errors when some error
@@ -972,19 +1011,19 @@ cli_server.color = On
 ;sqlite3.extension_dir =
 
 [Pcre]
-;PCRE library backtracking limit.
+; PCRE library backtracking limit.
 ; http://php.net/pcre.backtrack-limit
 ;pcre.backtrack_limit=100000
 
-;PCRE library recursion limit.
-;Please note that if you set this value to a high number you may consume all
-;the available process stack and eventually crash PHP (due to reaching the
-;stack size limit imposed by the Operating System).
+; PCRE library recursion limit.
+; Please note that if you set this value to a high number you may consume all
+; the available process stack and eventually crash PHP (due to reaching the
+; stack size limit imposed by the Operating System).
 ; http://php.net/pcre.recursion-limit
 ;pcre.recursion_limit=100000
 
-;Enables or disables JIT compilation of patterns. This requires the PCRE
-;library to be compiled with JIT support.
+; Enables or disables JIT compilation of patterns. This requires the PCRE
+; library to be compiled with JIT support.
 ;pcre.jit=1
 
 [Pdo]
@@ -995,13 +1034,8 @@ cli_server.color = On
 ;pdo_odbc.db2_instance_name
 
 [Pdo_mysql]
-; If mysqlnd is used: Number of cache slots for the internal result set cache
-; http://php.net/pdo_mysql.cache_size
-pdo_mysql.cache_size = 2000
-
 ; Default socket name for local MySQL connects.  If empty, uses the built-in
 ; MySQL defaults.
-; http://php.net/pdo_mysql.default-socket
 pdo_mysql.default_socket=
 
 [Phar]
@@ -1034,17 +1068,13 @@ smtp_port = 25
 ;mail.force_extra_parameters =
 
 ; Add X-PHP-Originating-Script: that will include uid of the script followed by the filename
-mail.add_x_header = On
+mail.add_x_header = Off
 
 ; The path to a log file that will log all mail() calls. Log entries include
 ; the full path of the script, line number, To address and headers.
 ;mail.log =
 ; Log mail to syslog (Event Log on Windows).
 ;mail.log = syslog
-
-[SQL]
-; http://php.net/sql.safe-mode
-sql.safe_mode = Off
 
 [ODBC]
 ; http://php.net/odbc.default-db
@@ -1086,8 +1116,6 @@ odbc.defaultlrl = 4096
 ; of odbc.defaultlrl and odbc.defaultbinmode
 ; http://php.net/odbc.defaultbinmode
 odbc.defaultbinmode = 1
-
-;birdstep.max_links = -1
 
 [Interbase]
 ; Allow or prevent persistent links.
@@ -1138,10 +1166,6 @@ mysqli.allow_persistent = On
 ; http://php.net/mysqli.max-links
 mysqli.max_links = -1
 
-; If mysqlnd is used: Number of cache slots for the internal result set cache
-; http://php.net/mysqli.cache_size
-mysqli.cache_size = 2000
-
 ; Default port number for mysqli_connect().  If unset, mysqli_connect() will use
 ; the $MYSQL_TCP_PORT or the mysql-tcp entry in /etc/services or the
 ; compile-time value defined MYSQL_PORT (in that order).  Win32 will only look
@@ -1176,12 +1200,10 @@ mysqli.reconnect = Off
 [mysqlnd]
 ; Enable / Disable collection of general statistics by mysqlnd which can be
 ; used to tune and monitor MySQL operations.
-; http://php.net/mysqlnd.collect_statistics
 mysqlnd.collect_statistics = On
 
 ; Enable / Disable collection of memory usage statistics by mysqlnd which can be
 ; used to tune and monitor MySQL operations.
-; http://php.net/mysqlnd.collect_memory_statistics
 mysqlnd.collect_memory_statistics = Off
 
 ; Records communication from all extensions using mysqlnd to the specified log
@@ -1190,29 +1212,23 @@ mysqlnd.collect_memory_statistics = Off
 ;mysqlnd.debug =
 
 ; Defines which queries will be logged.
-; http://php.net/mysqlnd.log_mask
 ;mysqlnd.log_mask = 0
 
 ; Default size of the mysqlnd memory pool, which is used by result sets.
-; http://php.net/mysqlnd.mempool_default_size
 ;mysqlnd.mempool_default_size = 16000
 
 ; Size of a pre-allocated buffer used when sending commands to MySQL in bytes.
-; http://php.net/mysqlnd.net_cmd_buffer_size
 ;mysqlnd.net_cmd_buffer_size = 2048
 
 ; Size of a pre-allocated buffer used for reading data sent by the server in
 ; bytes.
-; http://php.net/mysqlnd.net_read_buffer_size
 ;mysqlnd.net_read_buffer_size = 32768
 
 ; Timeout for network requests in seconds.
-; http://php.net/mysqlnd.net_read_timeout
 ;mysqlnd.net_read_timeout = 31536000
 
 ; SHA-256 Authentication Plugin related. File with the MySQL server public RSA
 ; key.
-; http://php.net/mysqlnd.sha256_server_public_key
 ;mysqlnd.sha256_server_public_key =
 
 [OCI8]
@@ -1337,13 +1353,14 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://php.net/session.save-path
-;session.save_path = "/var/lib/php/sessions"
+;session.save_path = "/tmp"
 
 ; Whether to use strict session mode.
-; Strict session mode does not accept uninitialized session ID and regenerate
-; session ID if browser sends uninitialized session ID. Strict mode protects
-; applications from session fixation via session adoption vulnerability. It is
-; disabled by default for maximum compatibility, but enabling it is encouraged.
+; Strict session mode does not accept an uninitialized session ID, and
+; regenerates the session ID if the browser sends an uninitialized session ID.
+; Strict mode protects applications from session fixation via a session adoption
+; vulnerability. It is disabled by default for maximum compatibility, but
+; enabling it is encouraged.
 ; https://wiki.php.net/rfc/strict_sessions
 session.use_strict_mode = 1
 
@@ -1352,7 +1369,7 @@ session.use_strict_mode = 1
 session.use_cookies = 1
 
 ; http://php.net/session.cookie-secure
-session.cookie_secure = 0
+;session.cookie_secure = 1
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
 ; the session id. We encourage this operation as it's very helpful in combating
@@ -1377,15 +1394,22 @@ session.cookie_lifetime = 28000
 ; http://php.net/session.cookie-path
 session.cookie_path = /var/www/localhost/htdocs/openemr
 
+
 ; The domain for which the cookie is valid.
 ; http://php.net/session.cookie-domain
 session.cookie_domain =
 
-; Whether or not to add the httpOnly flag to the cookie, which makes it inaccessible to browser scripting languages such as JavaScript.
+; Whether or not to add the httpOnly flag to the cookie, which makes it
+; inaccessible to browser scripting languages such as JavaScript.
 ; http://php.net/session.cookie-httponly
-session.cookie_httponly =
+session.cookie_httponly = 0
 
-; Handler used to serialize data.  php is the standard serializer of PHP.
+; Add SameSite attribute to cookie to help mitigate Cross-Site Request Forgery (CSRF/XSRF)
+; Current valid values are "Lax" or "Strict"
+; https://tools.ietf.org/html/draft-west-first-party-cookies-07
+session.cookie_samesite = Strict
+
+; Handler used to serialize data. php is the standard serializer of PHP.
 ; http://php.net/session.serialize-handler
 session.serialize_handler = php
 
@@ -1394,7 +1418,7 @@ session.serialize_handler = php
 ; gc_probability/gc_divisor. Where session.gc_probability is the numerator
 ; and gc_divisor is the denominator in the equation. Setting this value to 1
 ; when the session.gc_divisor value is 100 will give you approximately a 1% chance
-; the gc will run on any give request.
+; the gc will run on any given request.
 ; Default Value: 1
 ; Development Value: 1
 ; Production Value: 1
@@ -1404,10 +1428,10 @@ session.gc_probability = 1
 ; Defines the probability that the 'garbage collection' process is started on every
 ; session initialization. The probability is calculated by using the following equation:
 ; gc_probability/gc_divisor. Where session.gc_probability is the numerator and
-; session.gc_divisor is the denominator in the equation. Setting this value to 1
-; when the session.gc_divisor value is 100 will give you approximately a 1% chance
-; the gc will run on any give request. Increasing this value to 1000 will give you
-; a 0.1% chance the gc will run on any give request. For high volume production servers,
+; session.gc_divisor is the denominator in the equation. Setting this value to 100
+; when the session.gc_probability value is 1 will give you approximately a 1% chance
+; the gc will run on any given request. Increasing this value to 1000 will give you
+; a 0.1% chance the gc will run on any given request. For high volume production servers,
 ; this is a more efficient approach.
 ; Default Value: 100
 ; Development Value: 1000
@@ -1418,7 +1442,7 @@ session.gc_divisor = 1000
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.
 ; http://php.net/session.gc-maxlifetime
-session.gc_maxlifetime =
+session.gc_maxlifetime = 1440
 
 ; NOTE: If you are using the subdirectory option for storing session files
 ;       (see session.save_path above), then garbage collection does *not*
@@ -1433,19 +1457,6 @@ session.gc_maxlifetime =
 ; considered as valid.
 ; http://php.net/session.referer-check
 session.referer_check =
-
-; How many bytes to read from the file.
-; http://php.net/session.entropy-length
-session.entropy_length = 256
-
-; Specified here to create the session id.
-; http://php.net/session.entropy-file
-; Defaults to /dev/urandom
-; On systems that don't have /dev/urandom but do have /dev/arandom, this will default to /dev/arandom
-; If neither are found at compile time, the default is no entropy file.
-; On windows, setting the entropy_length setting will activate the
-; Windows random source (using the CryptoAPI)
-;session.entropy_file = /dev/urandom
 
 ; Set to {nocache,private,public,} to determine HTTP caching aspects
 ; or leave this empty to avoid sending anti-caching headers.
@@ -1468,15 +1479,39 @@ session.cache_expire = 180
 ; http://php.net/session.use-trans-sid
 session.use_trans_sid = 0
 
-; Select a hash function for use in generating session ids.
-; Possible Values
-;   0  (MD5 128 bits)
-;   1  (SHA-1 160 bits)
-; This option may also be set to the name of any hash function supported by
-; the hash extension. A list of available hashes is returned by the hash_algos()
-; function.
-; http://php.net/session.hash-function
-session.hash_function = 1
+; Set session ID character length. This value could be between 22 to 256.
+; Shorter length than default is supported only for compatibility reason.
+; Users should use 32 or more chars.
+; http://php.net/session.sid-length
+; Default Value: 32
+; Development Value: 26
+; Production Value: 26
+session.sid_length = 256
+
+; The URL rewriter will look for URLs in a defined set of HTML tags.
+; <form> is special; if you include them here, the rewriter will
+; add a hidden <input> field with the info which is otherwise appended
+; to URLs. <form> tag's action attribute URL will not be modified
+; unless it is specified.
+; Note that all valid entries require a "=", even if no value follows.
+; Default Value: "a=href,area=href,frame=src,form="
+; Development Value: "a=href,area=href,frame=src,form="
+; Production Value: "a=href,area=href,frame=src,form="
+; http://php.net/url-rewriter.tags
+session.trans_sid_tags = "a=href,area=href,frame=src,form="
+
+; URL rewriter does not rewrite absolute URLs by default.
+; To enable rewrites for absolute paths, target hosts must be specified
+; at RUNTIME. i.e. use ini_set()
+; <form> tags is special. PHP will check action attribute's URL regardless
+; of session.trans_sid_tags setting.
+; If no host is defined, HTTP_HOST will be used for allowed host.
+; Example value: php.net,www.php.net,wiki.php.net
+; Use "," for multiple hosts. No spaces are allowed.
+; Default Value: ""
+; Development Value: ""
+; Production Value: ""
+;session.trans_sid_hosts=""
 
 ; Define how many bits are stored in each character when converting
 ; the binary hash data to something readable.
@@ -1488,18 +1523,7 @@ session.hash_function = 1
 ; Development Value: 5
 ; Production Value: 5
 ; http://php.net/session.hash-bits-per-character
-session.hash_bits_per_character = 6
-
-; The URL rewriter will look for URLs in a defined set of HTML tags.
-; form/fieldset are special; if you include them here, the rewriter will
-; add a hidden <input> field with the info which is otherwise appended
-; to URLs.  If you want XHTML conformity, remove the form entry.
-; Note that all valid entries require a "=", even if no value follows.
-; Default Value: "a=href,area=href,frame=src,form=,fieldset="
-; Development Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
-; Production Value: "a=href,area=href,frame=src,input=src,form=fakeentry"
-; http://php.net/url-rewriter.tags
-url_rewriter.tags = "a=href,area=href,frame=src,input=src,form=fakeentry"
+session.sid_bits_per_character = 6
 
 ; Enable upload progress tracking in $_SESSION
 ; Default Value: On
@@ -1566,7 +1590,7 @@ zend.assertions = -1
 ; http://php.net/assert.active
 ;assert.active = On
 
-; Throw an AssertationException on failed assertions
+; Throw an AssertionError on failed assertions
 ; http://php.net/assert.exception
 ;assert.exception = On
 
@@ -1596,7 +1620,7 @@ zend.assertions = -1
 ; http://php.net/com.allow-dcom
 ;com.allow_dcom = true
 
-; autoregister constants of a components typlib on com_load()
+; autoregister constants of a component's typlib on com_load()
 ; http://php.net/com.autoregister-typelib
 ;com.autoregister_typelib = true
 
@@ -1627,9 +1651,9 @@ zend.assertions = -1
 
 ; Use of this INI entry is deprecated, use global input_encoding instead.
 ; http input encoding.
-; mbstring.encoding_traslation = On is needed to use this setting.
+; mbstring.encoding_translation = On is needed to use this setting.
 ; If empty, default_charset or input_encoding or mbstring.input is used.
-; The precedence is: default_charset < intput_encoding < mbsting.http_input
+; The precedence is: default_charset < input_encoding < mbsting.http_input
 ; http://php.net/mbstring.http-input
 ;mbstring.http_input =
 
@@ -1686,7 +1710,7 @@ zend.assertions = -1
 ; a gd image. The warning will then be displayed as notices
 ; disabled by default
 ; http://php.net/gd.jpeg-ignore-warning
-;gd.jpeg_ignore_warning = 0
+;gd.jpeg_ignore_warning = 1
 
 [exif]
 ; Exif UNICODE user comments are handled as UCS-2BE/UCS-2LE and JIS as JIS.
@@ -1748,36 +1772,25 @@ soap.wsdl_cache_limit = 5
 ; Sets the maximum number of open links or -1 for unlimited.
 ldap.max_links = -1
 
-[mcrypt]
-; For more information about mcrypt settings see http://php.net/mcrypt-module-open
-
-; Directory where to load mcrypt algorithms
-; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-;mcrypt.algorithms_dir=
-
-; Directory where to load mcrypt modes
-; Default: Compiled in into libmcrypt (usually /usr/local/lib/libmcrypt)
-;mcrypt.modes_dir=
-
 [dba]
 ;dba.default_handler=
 
 [opcache]
 ; Determines if Zend OPCache is enabled
-;opcache.enable=0
+;opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-;opcache.memory_consumption=64
+;opcache.memory_consumption=128
 
 ; The amount of memory for interned strings in Mbytes.
-;opcache.interned_strings_buffer=4
+;opcache.interned_strings_buffer=8
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
-; Only numbers between 200 and 100000 are allowed.
-;opcache.max_accelerated_files=2000
+; Only numbers between 200 and 1000000 are allowed.
+;opcache.max_accelerated_files=10000
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5
@@ -1804,18 +1817,13 @@ ldap.max_links = -1
 ; size of the optimized code.
 ;opcache.save_comments=1
 
-; If enabled, a fast shutdown sequence is used for the accelerated code
-; Depending on the used Memory Manager this may cause some incompatibilities.
-;opcache.fast_shutdown=0
-
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0
 
 ; A bitmask, where each bit enables or disables the appropriate OPcache
 ; passes
-;opcache.optimization_level=0xffffffff
+;opcache.optimization_level=0x7FFFBFFF
 
-;opcache.inherited_hack=1
 ;opcache.dups_fix=0
 
 ; The location of the OPcache blacklist file (wildcards allowed).
@@ -1885,10 +1893,14 @@ ldap.max_links = -1
 ;opcache.huge_code_pages=1
 
 ; Validate cached file permissions.
-; opcache.validate_permission=0
+;opcache.validate_permission=0
 
 ; Prevent name collisions in chroot'ed environment.
-; opcache.validate_root=0
+;opcache.validate_root=0
+
+; If specified, it produces opcode dumps for debugging different stages of
+; optimizations.
+;opcache.opt_debug_level=0
 
 [curl]
 ; A default value for the CURLOPT_CAINFO option. This is required to be an

--- a/docker/openemr/5.0.2/php.ini
+++ b/docker/openemr/5.0.2/php.ini
@@ -1345,14 +1345,14 @@ session.save_handler = files
 ; applications from session fixation via session adoption vulnerability. It is
 ; disabled by default for maximum compatibility, but enabling it is encouraged.
 ; https://wiki.php.net/rfc/strict_sessions
-session.use_strict_mode = 0
+session.use_strict_mode = 1
 
 ; Whether to use cookies.
 ; http://php.net/session.use-cookies
 session.use_cookies = 1
 
 ; http://php.net/session.cookie-secure
-session.cookie_secure = 1
+session.cookie_secure = 0
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
 ; the session id. We encourage this operation as it's very helpful in combating
@@ -1371,11 +1371,11 @@ session.auto_start = 0
 
 ; Lifetime in seconds of cookie or, if 0, until browser is restarted.
 ; http://php.net/session.cookie-lifetime
-session.cookie_lifetime = 0
+session.cookie_lifetime = 28000
 
 ; The path for which the cookie is valid.
 ; http://php.net/session.cookie-path
-session.cookie_path = /
+session.cookie_path = /var/www/localhost/htdocs/openemr
 
 ; The domain for which the cookie is valid.
 ; http://php.net/session.cookie-domain
@@ -1399,7 +1399,7 @@ session.serialize_handler = php
 ; Development Value: 1
 ; Production Value: 1
 ; http://php.net/session.gc-probability
-session.gc_probability = 0
+session.gc_probability = 1
 
 ; Defines the probability that the 'garbage collection' process is started on every
 ; session initialization. The probability is calculated by using the following equation:
@@ -1418,7 +1418,7 @@ session.gc_divisor = 1000
 ; After this number of seconds, stored data will be seen as 'garbage' and
 ; cleaned up by the garbage collection process.
 ; http://php.net/session.gc-maxlifetime
-session.gc_maxlifetime = 1440
+session.gc_maxlifetime =
 
 ; NOTE: If you are using the subdirectory option for storing session files
 ;       (see session.save_path above), then garbage collection does *not*
@@ -1436,7 +1436,7 @@ session.referer_check =
 
 ; How many bytes to read from the file.
 ; http://php.net/session.entropy-length
-;session.entropy_length = 32
+session.entropy_length = 256
 
 ; Specified here to create the session id.
 ; http://php.net/session.entropy-file

--- a/docker/openemr/5.0.2/php.ini
+++ b/docker/openemr/5.0.2/php.ini
@@ -1352,7 +1352,7 @@ session.use_strict_mode = 0
 session.use_cookies = 1
 
 ; http://php.net/session.cookie-secure
-;session.cookie_secure =
+session.cookie_secure = 1
 
 ; This option forces PHP to fetch and use a cookie for storing and maintaining
 ; the session id. We encourage this operation as it's very helpful in combating
@@ -1476,7 +1476,7 @@ session.use_trans_sid = 0
 ; the hash extension. A list of available hashes is returned by the hash_algos()
 ; function.
 ; http://php.net/session.hash-function
-session.hash_function = 0
+session.hash_function = 1
 
 ; Define how many bits are stored in each character when converting
 ; the binary hash data to something readable.
@@ -1488,7 +1488,7 @@ session.hash_function = 0
 ; Development Value: 5
 ; Production Value: 5
 ; http://php.net/session.hash-bits-per-character
-session.hash_bits_per_character = 5
+session.hash_bits_per_character = 6
 
 ; The URL rewriter will look for URLs in a defined set of HTML tags.
 ; form/fieldset are special; if you include them here, the rewriter will


### PR DESCRIPTION
These updates increase the stability and security of the beta OpenEMR 5.0.2 container.

Improvements:
- Increased hash bits and moved from MD5 to SHA-1 of the PHP session encryption algorithm in `php.ini`
- Hid Apache version, redirect to HTTPS from Port 80 , STS Header, and allowing only GET POST and HEAD requests to the server
- Also converted configuration directives from 2.2 to 2.4 syntax

NOTE: Added a generic `RUN openssl...` command in the Dockerfile because certbot appears not to be working. 