### PR TITLE
issue-181: remove default apache cgi files & chown

### DIFF
--- a/docker/openemr/5.0.2/Dockerfile
+++ b/docker/openemr/5.0.2/Dockerfile
@@ -50,7 +50,10 @@ COPY openemr.conf /etc/apache2/conf.d/
 COPY run_openemr.sh autoconfig.sh auto_configure.php /var/www/localhost/htdocs/openemr/
 COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
 RUN chmod 500 run_openemr.sh autoconfig.sh /root/unlock_admin.sh \
-    && chmod 000 auto_configure.php /root/unlock_admin.php
+    && chmod 000 auto_configure.php /root/unlock_admin.php \
+    && rm -rf /var/www/localhost/cgi-bin \
+    && rm -f /var/www/localhost/htdocs/index.html \
+    && chown -R /var/www/localhost apache:apache
 #fix issue with apache2 dying prematurely
 RUN mkdir -p /run/apache2
 #go


### PR DESCRIPTION
#181 @jesdynf Can you checkout lines 54 - 56 in the only file I changed? The cgi-bin folder should definitely go (line 54), the index.html should probably go (line 55), but I'm not sure if I did the ownership correctly for line (56). Everything seems to still work correctly though / testing was fine.

FYI this issue came about because I was contributing to OWASP ModSecurity, and together as a group we discovered quite a few ownership issues for that Dockerfile, which caused me to take a second look at ours. 
