### PR TITLE
Fixed bugs in Openemr Apache conf file

### DIFF
--- a/docker/openemr/5.0.2/openemr.conf
+++ b/docker/openemr/5.0.2/openemr.conf
@@ -1,29 +1,24 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule allowmethods_module modules/mod_allowmethods.so
 
-
-# The ServerName directive sets the request scheme, hostname and port that
-# the server uses to identify itself. This is used when creating
-# redirection URLs. In the context of virtual hosts, the ServerName
-# specifies what hostname must appear in the request's Host: header to
-# match this virtual host. For the default virtual host (this file) this
-# value is not decisive as it is used as a last resort host regardless.
-# However, you must set it for any further virtual host explicitly.
-#ServerName www.example.com
-
-
 ## Security Options
+# Strong HTTP Protocol
+HTTPProtocolOptions Strict
 Protocols http/1.1
-# Removes revealing HTTP Headers
+        
+# Don't Reveal Server
 ServerSignature off
 ServerTokens Prod
-TraceEnable Off
+Header unset Server
+
+# No ETag
 FileETag None
 Header unset ETag
+
 # Set HSTS and X-XSS protection
 Header set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 Header set X-XSS-Protection "1; mode=block"
-ServerAdmin webmaster@localhost
+
 # Narrow document root
 DocumentRoot /var/www/localhost/htdocs/openemr
 ErrorLog ${APACHE_LOG_DIR}/error.log
@@ -31,10 +26,8 @@ CustomLog ${APACHE_LOG_DIR}/access.log combined
 
 
     <Directory /var/www/localhost/htdocs/openemr>
-        # Only allow these HTTP Methods
-        AllowMethods GET POST HEAD OPTIONS
-        # No indexes anywhere
-        Options -Indexes
+        AllowMethods GET POST #Only allow these HTTP Methods
+        Options None 
         AllowOverride FileInfo
         Require all granted
     </Directory>
@@ -58,8 +51,8 @@ CustomLog ${APACHE_LOG_DIR}/access.log combined
 
 #######################################
 ### Uncomment the following 3 lines ###
-### to enable HTTPS redirection #######
-### and require HTTPS only ############
+### with #'s below to enable HTTPS  ###
+### redirection & require HTTPS only ##
 #######################################
 <VirtualHost *:80>
         #RewriteEngine On
@@ -69,13 +62,9 @@ CustomLog ${APACHE_LOG_DIR}/access.log combined
 
 
 <VirtualHost _default_:443>
-        #   SSL Engine Switch:
-        #   Enable/Disable SSL for this virtual host.
         SSLEngine on
-
-        SSLCipherSuite "EECDH+ECDSA+AESGCM EECDH+aRSA+AESGCM EECDH+ECDSA+SHA384 \
-                       EECDH+ECDSA+SHA256 EECDH+aRSA+SHA384 EECDH+aRSA+SHA256 EECDH+aRSA+RC4 \
-                       EECDH EDH+aRSA RC4 !aNULL !eNULL !LOW !3DES !MD5 !EXP !PSK !SRP !DSS"
+        SSLHonorCipherOrder on
+        SSLCipherSuite EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH
         SSLProtocol -ALL +TLSv1.2
         SSLCertificateFile    /etc/ssl/certs/webserver.cert.pem
         SSLCertificateKeyFile /etc/ssl/private/webserver.key.pem


### PR DESCRIPTION
GH-185

Need to test.

Removed `allowsymlinks` for now...maybe can be replaced by `allowsymlinksifownersmatch` but not sure. See this pretty shocking post: https://blog.sucuri.net/2013/05/from-a-site-compromise-to-full-root-access-symlinks-to-root-part-i.html

Only `html2pdf` uses `symlink` php function...once, will try to find a way to refactor this out and then restrict in `php.ini`.

Added:
HTTPProtocolOptions Strict
SSLHonorCipherOrder
Refactored SSLCipherSuite