### PR TITLE
wait for device (volume) to be ready | random webserverinstance creation failure

### DIFF
--- a/packages/standard/ami/ami-configure.sh
+++ b/packages/standard/ami/ami-configure.sh
@@ -5,8 +5,16 @@ exec > /var/log/openemr-configure.log 2>&1
 cd /root/openemr-devops/packages/standard
 
 # prepare the encrypted volume CFN just added
-COUNTER=0
-until mkfs -t ext4 /dev/xvdd || [ $COUNTER -gt 5 ]; do echo 'mkfs on /dev/xvdd failed, trying again in 5 seconds.'; sleep 5; let COUNTER=COUNTER+1; done
+MKFSCOUNTER=0
+until mkfs -t ext4 /dev/xvdd; do 
+  if [ $MKFSCOUNTER == 6 ]; then
+  echo 'mkfs on /dev/xvdd failure, aborting.'
+  exit 1
+  fi
+  echo 'mkfs on /dev/xvdd failed, trying again in 5 seconds...'
+  sleep 5
+  let MKFSCOUNTER=MKFSCOUNTER+1
+done
 mkdir /mnt/docker
 chown 711 /mnt/docker
 cat snippets/fstab.append >> /etc/fstab

--- a/packages/standard/ami/ami-configure.sh
+++ b/packages/standard/ami/ami-configure.sh
@@ -5,7 +5,8 @@ exec > /var/log/openemr-configure.log 2>&1
 cd /root/openemr-devops/packages/standard
 
 # prepare the encrypted volume CFN just added
-until mkfs -t ext4 /dev/xvdd; do echo 'mkfs on /dev/xvdd failed, trying again in 5 seconds.'; sleep 5; done
+COUNTER=0
+until mkfs -t ext4 /dev/xvdd || [ $COUNTER -gt 5 ]; do echo 'mkfs on /dev/xvdd failed, trying again in 5 seconds.'; sleep 5; let COUNTER=COUNTER+1; done
 mkdir /mnt/docker
 chown 711 /mnt/docker
 cat snippets/fstab.append >> /etc/fstab

--- a/packages/standard/ami/ami-configure.sh
+++ b/packages/standard/ami/ami-configure.sh
@@ -5,7 +5,7 @@ exec > /var/log/openemr-configure.log 2>&1
 cd /root/openemr-devops/packages/standard
 
 # prepare the encrypted volume CFN just added
-mkfs -t ext4 /dev/xvdd
+until mkfs -t ext4 /dev/xvdd; do echo 'mkfs on /dev/xvdd failed, trying again in 5 seconds.'; sleep 5; done
 mkdir /mnt/docker
 chown 711 /mnt/docker
 cat snippets/fstab.append >> /etc/fstab


### PR DESCRIPTION
# EC2 Bootstrap Error

Summary:
Randomly receive error on CloudFormation launch of standard package:

- CREATE_FAILED	 AWS::CloudFormation::Stack  The following resource(s) failed to create: [WebserverInstance].
- CREATE_FAILED	 AWS::EC2::Instance	WebserverInstance  Received FAILURE signal with UniqueId i-xxxx

Output of `/var/log/openemr-configure.log`:

    + cd /root/openemr-devops/packages/standard
    + mkfs -t ext4 /dev/xvdd
    mke2fs 1.42.13 (17-May-2015)
    The file /dev/xvdd does not exist and no size was specified.

Component name:

    openemr-devops/packages/standard/ami/ami-configure.sh

Resolution:  
    Replace line 8 with the following:  

    until mkfs -t ext4 /dev/xvdd; do echo 'mkfs failed trying again in 5 seconds.'; sleep 5; done