### PR TITLE
support for new writable requirements in flex docker

### DIFF
--- a/docker/openemr/flex-3.9/autoconfig.sh
+++ b/docker/openemr/flex-3.9/autoconfig.sh
@@ -189,7 +189,6 @@ if [ -f /etc/docker-leader ] ||
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ "$EASY_DEV_MODE" != "yes" ]; then
         chmod 666 /var/www/localhost/htdocs/openemr/sites/default/sqlconf.php
-        chmod 666 /var/www/localhost/htdocs/openemr/interface/modules/zend_modules/config/application.config.php
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
@@ -231,14 +230,7 @@ if [ -f /etc/docker-leader ] ||
             echo "Default file permissions and ownership set, allowing writing to specific directories"
             chmod 700 /var/www/localhost/htdocs/run_openemr.sh
             # Set file and directory permissions
-            chmod 600 interface/modules/zend_modules/config/application.config.php
             find sites/default/documents -type d -print0 | xargs -0 chmod 700
-            find sites/default/edi -type d -print0 | xargs -0 chmod 700
-            find sites/default/era -type d -print0 | xargs -0 chmod 700
-            find sites/default/letter_templates -type d -print0 | xargs -0 chmod 700
-            find interface/main/calendar/modules/PostCalendar/pntemplates/cache -type d -print0 | xargs -0 chmod 700
-            find interface/main/calendar/modules/PostCalendar/pntemplates/compiled -type d -print0 | xargs -0 chmod 700
-            find gacl/admin/templates_c -type d -print0 | xargs -0 chmod 700
 
             echo "Removing remaining setup scripts"
             #remove all setup scripts


### PR DESCRIPTION
Plan to bring in this PR and rebuild `flex` docker after 5.0.2 release in the future.