### PR TITLE
Rsync fails without openemr naming convention

### DIFF
--- a/docker/openemr/flex-3.7/autoconfig.sh
+++ b/docker/openemr/flex-3.7/autoconfig.sh
@@ -135,10 +135,10 @@ if [ -f /etc/docker-leader ] ||
 
         if [ "$FLEX_REPOSITORY_BRANCH" != "" ]; then
             echo "Collecting $FLEX_REPOSITORY_BRANCH branch from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1
+            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1 openemr
         else
             echo "Collecting $FLEX_REPOSITORY_TAG tag from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY"
+            git clone "$FLEX_REPOSITORY" openemr
             cd openemr
             git checkout "$FLEX_REPOSITORY_TAG"
             cd ../

--- a/docker/openemr/flex-3.8/autoconfig.sh
+++ b/docker/openemr/flex-3.8/autoconfig.sh
@@ -135,10 +135,10 @@ if [ -f /etc/docker-leader ] ||
 
         if [ "$FLEX_REPOSITORY_BRANCH" != "" ]; then
             echo "Collecting $FLEX_REPOSITORY_BRANCH branch from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1
+            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1 openemr
         else
             echo "Collecting $FLEX_REPOSITORY_TAG tag from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY"
+            git clone "$FLEX_REPOSITORY" openemr
             cd openemr
             git checkout "$FLEX_REPOSITORY_TAG"
             cd ../

--- a/docker/openemr/flex-3.9/autoconfig.sh
+++ b/docker/openemr/flex-3.9/autoconfig.sh
@@ -135,10 +135,10 @@ if [ -f /etc/docker-leader ] ||
 
         if [ "$FLEX_REPOSITORY_BRANCH" != "" ]; then
             echo "Collecting $FLEX_REPOSITORY_BRANCH branch from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1
+            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1 openemr
         else
             echo "Collecting $FLEX_REPOSITORY_TAG tag from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY"
+            git clone "$FLEX_REPOSITORY" openemr
             cd openemr
             git checkout "$FLEX_REPOSITORY_TAG"
             cd ../

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -135,10 +135,10 @@ if [ -f /etc/docker-leader ] ||
 
         if [ "$FLEX_REPOSITORY_BRANCH" != "" ]; then
             echo "Collecting $FLEX_REPOSITORY_BRANCH branch from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1
+            git clone "$FLEX_REPOSITORY" --branch "$FLEX_REPOSITORY_BRANCH" --depth 1 openemr
         else
             echo "Collecting $FLEX_REPOSITORY_TAG tag from $FLEX_REPOSITORY repository"
-            git clone "$FLEX_REPOSITORY"
+            git clone "$FLEX_REPOSITORY" openemr
             cd openemr
             git checkout "$FLEX_REPOSITORY_TAG"
             cd ../


### PR DESCRIPTION
In order for openemr to work with nonstandard names it requires that the cloned repo have the name requested in the rsync statement or the image fails

https://github.com/openemr/openemr-devops/blob/master/docker/openemr/flex-3.10/autoconfig.sh#L150