### PR TITLE
easy development docker environment fix

### DIFF
--- a/docker/openemr/flex-3.10/autoconfig.sh
+++ b/docker/openemr/flex-3.10/autoconfig.sh
@@ -12,7 +12,8 @@
 #    - Setting db parameters MYSQL_USER, MYSQL_PASS, MYSQL_DATABASE
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
-#       and does not download code from github (uses local repo).
+#    - EAST_DEV_MODE_NEW with value of 'yes' expands EASY_DEV_MODE by not requiring downloading
+#      code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -121,7 +122,7 @@ if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ "$EMPTY" != "yes" ] &&
-       [ "$EASY_DEV_MODE" != "yes" ]; then
+       [ "$EASY_DEV_MODE_NEW" != "yes" ]; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."
@@ -152,6 +153,11 @@ if [ -f /etc/docker-leader ] ||
         rsync --ignore-existing --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
         rm -fr openemr
         cd /var/www/localhost/htdocs/
+    fi
+
+    if [ "$EASY_DEV_MODE_NEW" == "yes" ]; then
+        # trickery for the easy dev environment
+        rsync --ignore-existing --recursive --links --exclude .git /openemr /var/www/localhost/htdocs/
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&

--- a/docker/openemr/flex-3.10/autoconfig.sh
+++ b/docker/openemr/flex-3.10/autoconfig.sh
@@ -12,6 +12,7 @@
 #    - Setting db parameters MYSQL_USER, MYSQL_PASS, MYSQL_DATABASE
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
+#       and does not download code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -119,7 +120,8 @@ fi
 if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
-       [ "$EMPTY" != "yes" ] ; then
+       [ "$EMPTY" != "yes" ] &&
+       [ "$EASY_DEV_MODE" != "yes" ]; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."

--- a/docker/openemr/flex-3.11/autoconfig.sh
+++ b/docker/openemr/flex-3.11/autoconfig.sh
@@ -12,6 +12,7 @@
 #    - Setting db parameters MYSQL_USER, MYSQL_PASS, MYSQL_DATABASE
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
+#       and does not download code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -119,7 +120,8 @@ fi
 if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
-       [ "$EMPTY" != "yes" ] ; then
+       [ "$EMPTY" != "yes" ] &&
+       [ "$EASY_DEV_MODE" != "yes" ]; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."

--- a/docker/openemr/flex-3.11/autoconfig.sh
+++ b/docker/openemr/flex-3.11/autoconfig.sh
@@ -13,6 +13,8 @@
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
 #       and does not download code from github (uses local repo).
+#    - EAST_DEV_MODE_NEW with value of 'yes' expands EASY_DEV_MODE by not requiring downloading
+#      code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -121,7 +123,7 @@ if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ "$EMPTY" != "yes" ] &&
-       [ "$EASY_DEV_MODE" != "yes" ]; then
+       [ "$EAST_DEV_MODE_NEW" != "yes" ]; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."
@@ -152,6 +154,11 @@ if [ -f /etc/docker-leader ] ||
         rsync --ignore-existing --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
         rm -fr openemr
         cd /var/www/localhost/htdocs/
+    fi
+
+    if [ "$EASY_DEV_MODE_NEW" == "yes" ]; then
+        # trickery for the easy dev environment
+        rsync --ignore-existing --recursive --links --exclude .git /openemr /var/www/localhost/htdocs/
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -13,6 +13,8 @@
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
 #       and does not download code from github (uses local repo).
+#    - EAST_DEV_MODE_NEW with value of 'yes' expands EASY_DEV_MODE by not requiring downloading
+#      code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -121,7 +123,7 @@ if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
        [ "$EMPTY" != "yes" ] &&
-       [ "$EASY_DEV_MODE" != "yes" ] ; then
+       [ "$EAST_DEV_MODE_NEW" != "yes" ] ; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."
@@ -152,6 +154,11 @@ if [ -f /etc/docker-leader ] ||
         rsync --ignore-existing --recursive --links --exclude .git openemr /var/www/localhost/htdocs/
         rm -fr openemr
         cd /var/www/localhost/htdocs/
+    fi
+
+    if [ "$EASY_DEV_MODE_NEW" == "yes" ]; then
+        # trickery for the easy dev environment
+        rsync --ignore-existing --recursive --links --exclude .git /openemr /var/www/localhost/htdocs/
     fi
 
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -12,6 +12,7 @@
 #    - Setting db parameters MYSQL_USER, MYSQL_PASS, MYSQL_DATABASE
 #    - Setting openemr parameters OE_USER, OE_PASS
 #    - EASY_DEV_MODE with value of 'yes' prevents issues with permissions when mounting volumes
+#       and does not download code from github (uses local repo).
 set -e
 
 swarm_wait() {
@@ -119,7 +120,8 @@ fi
 if [ -f /etc/docker-leader ] ||
    [ "$SWARM_MODE" != "yes" ]; then
     if [ -f /var/www/localhost/htdocs/auto_configure.php ] &&
-       [ "$EMPTY" != "yes" ] ; then
+       [ "$EMPTY" != "yes" ] &&
+       [ "$EASY_DEV_MODE" != "yes" ] ; then
         echo "Configuring a new flex openemr docker"
         if [ "$FLEX_REPOSITORY" == "" ]; then
             echo "Exiting from OpenEMR flex docker since missing required FLEX_REPOSITORY environment setting."


### PR DESCRIPTION
It seem like the easy development docker should use the local repo code rather than grabbing code from a online repository. Changed it to do that. Still need to build and test this before bringing in.