### PR TITLE
Support setting openemr globals

### DIFF
--- a/docker/openemr/5.0.3/autoconfig.sh
+++ b/docker/openemr/5.0.3/autoconfig.sh
@@ -60,15 +60,18 @@ auto_setup() {
     fi
 
     # Set requested openemr settings
-    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
-    while IFS= read -r line; do
-        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
-        # note am omitting the letter O on purpose
-        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
-        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
-        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
-    done
+    OPENEMR_SETTINGS=`printenv | grep '^OPENEMR_SETTING_'`
+    if [ -n "$OPENEMR_SETTINGS" ]; then
+        echo "$OPENEMR_SETTINGS" |
+        while IFS= read -r line; do
+            SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+            # note am omitting the letter O on purpose
+            CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+            VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+            echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+            mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+        done
+    fi
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then

--- a/docker/openemr/5.0.3/autoconfig.sh
+++ b/docker/openemr/5.0.3/autoconfig.sh
@@ -33,13 +33,13 @@ auto_setup() {
     if [ "$MYSQL_PASS" != "" ]; then
         CONFIGURATION="${CONFIGURATION} pass=${MYSQL_PASS}"
         CUSTOM_PASSWORD="$MYSQL_PASS"
-    else 
+    else
         CUSTOM_PASSWORD="openemr"
     fi
     if [ "$MYSQL_DATABASE" != "" ]; then
         CONFIGURATION="${CONFIGURATION} dbname=${MYSQL_DATABASE}"
         CUSTOM_DATABASE="$MYSQL_DATABASE"
-    else 
+    else
         CUSTOM_DATABASE="openemr"
     fi
     if [ "$OE_USER" != "" ]; then
@@ -48,7 +48,7 @@ auto_setup() {
     if [ "$OE_PASS" != "" ]; then
         CONFIGURATION="${CONFIGURATION} iuserpass=${OE_PASS}"
     fi
-    
+
     chmod -R 600 .
     php auto_configure.php -f ${CONFIGURATION} || return 1
 
@@ -59,10 +59,16 @@ auto_setup() {
         exit 2
     fi
 
-    #Turn on API from docker
-    if [ "$ACTIVATE_API" == "yes" ]; then
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" "$CUSTOM_DATABASE"
-    fi
+    # Set requested openemr settings
+    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
+    while IFS= read -r line; do
+        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+        # note am omitting the letter O on purpose
+        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+    done
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then

--- a/docker/openemr/flex-3.11/autoconfig.sh
+++ b/docker/openemr/flex-3.11/autoconfig.sh
@@ -41,13 +41,13 @@ auto_setup() {
     if [ "$MYSQL_PASS" != "" ]; then
         CONFIGURATION="${CONFIGURATION} pass=${MYSQL_PASS}"
         CUSTOM_PASSWORD="$MYSQL_PASS"
-    else 
+    else
         CUSTOM_PASSWORD="openemr"
     fi
     if [ "$MYSQL_DATABASE" != "" ]; then
         CONFIGURATION="${CONFIGURATION} dbname=${MYSQL_DATABASE}"
         CUSTOM_DATABASE="$MYSQL_DATABASE"
-    else 
+    else
         CUSTOM_DATABASE="openemr"
     fi
     if [ "$OE_USER" != "" ]; then
@@ -60,7 +60,7 @@ auto_setup() {
     if [ "$EASY_DEV_MODE" != "yes" ]; then
         chmod -R 600 /var/www/localhost/htdocs/openemr
     fi
-    
+
     php /var/www/localhost/htdocs/auto_configure.php -f ${CONFIGURATION} || return 1
 
     echo "OpenEMR configured."
@@ -70,10 +70,16 @@ auto_setup() {
         exit 2
     fi
 
-    #Turn on API from docker
-    if [ "$ACTIVATE_API" == "yes" ]; then
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" "$CUSTOM_DATABASE"
-    fi
+    # Set requested openemr settings
+    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
+    while IFS= read -r line; do
+        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+        # note am omitting the letter O on purpose
+        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+    done
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then

--- a/docker/openemr/flex-3.11/autoconfig.sh
+++ b/docker/openemr/flex-3.11/autoconfig.sh
@@ -71,15 +71,18 @@ auto_setup() {
     fi
 
     # Set requested openemr settings
-    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
-    while IFS= read -r line; do
-        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
-        # note am omitting the letter O on purpose
-        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
-        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
-        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
-    done
+    OPENEMR_SETTINGS=`printenv | grep '^OPENEMR_SETTING_'`
+    if [ -n "$OPENEMR_SETTINGS" ]; then
+        echo "$OPENEMR_SETTINGS" |
+        while IFS= read -r line; do
+            SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+            # note am omitting the letter O on purpose
+            CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+            VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+            echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+            mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+        done
+    fi
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -41,13 +41,13 @@ auto_setup() {
     if [ "$MYSQL_PASS" != "" ]; then
         CONFIGURATION="${CONFIGURATION} pass=${MYSQL_PASS}"
         CUSTOM_PASSWORD="$MYSQL_PASS"
-    else 
+    else
         CUSTOM_PASSWORD="openemr"
     fi
     if [ "$MYSQL_DATABASE" != "" ]; then
         CONFIGURATION="${CONFIGURATION} dbname=${MYSQL_DATABASE}"
         CUSTOM_DATABASE="$MYSQL_DATABASE"
-    else 
+    else
         CUSTOM_DATABASE="openemr"
     fi
     if [ "$OE_USER" != "" ]; then
@@ -60,7 +60,7 @@ auto_setup() {
     if [ "$EASY_DEV_MODE" != "yes" ]; then
         chmod -R 600 /var/www/localhost/htdocs/openemr
     fi
-    
+
     php /var/www/localhost/htdocs/auto_configure.php -f ${CONFIGURATION} || return 1
 
     echo "OpenEMR configured."
@@ -70,10 +70,16 @@ auto_setup() {
         exit 2
     fi
 
-    #Turn on API from docker
-    if [ "$ACTIVATE_API" == "yes" ]; then
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = 1 WHERE gl_name = \"rest_api\"" "$CUSTOM_DATABASE"
-    fi
+    # Set requested openemr settings
+    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
+    while IFS= read -r line; do
+        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+        # note am omitting the letter O on purpose
+        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+    done
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -71,15 +71,18 @@ auto_setup() {
     fi
 
     # Set requested openemr settings
-    echo "`printenv | grep '^OPENEMR_SETTING_'`" |
-    while IFS= read -r line; do
-        SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
-        # note am omitting the letter O on purpose
-        CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
-        VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
-        echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
-        mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
-    done
+    OPENEMR_SETTINGS=`printenv | grep '^OPENEMR_SETTING_'`
+    if [ -n "$OPENEMR_SETTINGS" ]; then
+        echo "$OPENEMR_SETTINGS" |
+        while IFS= read -r line; do
+            SETTING_TEMP=`echo "$line" | cut -d "=" -f 1`
+            # note am omitting the letter O on purpose
+            CORRECT_SETTING_TEMP=`echo "$SETTING_TEMP" | awk -F 'PENEMR_SETTING_' '{print $2}'`
+            VALUE_TEMP=`echo "$line" | cut -d "=" -f 2`
+            echo "Set ${CORRECT_SETTING_TEMP} to ${VALUE_TEMP}"
+            mysql -u "$CUSTOM_USER"  --password="$CUSTOM_PASSWORD" -h "$MYSQL_HOST" -e "UPDATE globals SET gl_value = '${VALUE_TEMP}' WHERE gl_name = '${CORRECT_SETTING_TEMP}'" "$CUSTOM_DATABASE"
+        done
+    fi
 }
 
 if [ "$SWARM_MODE" == "yes" ]; then


### PR DESCRIPTION
fixes #240 

This allows setting any openemr global from the docker-compose.yml . For example, plan to place following environment setting in the easy dev docker environment docker-compose.yml:
```
OPENEMR_SETTING_rest_api: 1
OPENEMR_SETTING_rest_fhir_api: 1
OPENEMR_SETTING_rest_portal_api: 1
OPENEMR_SETTING_rest_portal_fhir_api: 1
OPENEMR_SETTING_portal_onsite_two_enable: 1
```