### PR TITLE
add check docker names

### DIFF
--- a/utilities/chkdocker-names/chkdocker-names
+++ b/utilities/chkdocker-names/chkdocker-names
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This is a scipt to check the running docker names.
+# 1. mkdir ~/bin  
+# 2. copy the script to ~/bin/chkdocker-names
+# 3. chmod +x ~/bin/chkdocker-names
+
+CHECK_NAME=$1     # specify the checking name
+
+# Script usage
+EXIT_CODE=11
+FINAL_CODE=0
+if [ $# -eq 0 ]
+then
+	echo "Check the docker names."
+	echo "Usage: `basename $0` {all|couchdb|php|fhir|mariadb|mysql|nginx|openemr|openldap|orthanc|redis}"
+	exit $EXIT_CODE
+fi
+
+# Show all docker names.
+if [ "$CHECK_NAME" == 'all' ]
+then
+ 	echo '=======Running Docker Names======='
+	docker ps | awk '{print $NF}'|grep -v NAMES|sort -n
+else
+	# ARGS: couchdb php fhir mariadb mysql nginx openemr openldap orthanc redis.
+ 	echo '=======Running Docker Names======='
+	docker ps | awk '{print $NF}'|grep -v NAMES|sort -n | grep $CHECK_NAME
+fi
+exit $FINAL_CODE


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes # In the  Insane Development Docker Environment, there is a lot of running dockers, this script is to help check the docker names:
```
Note the NAMES column is extremely important and how you run docker commands on specific containers. For example, to go into a shell script in the openemr_openemr-7-2_1 container, would use
```
https://github.com/openemr/openemr/blob/master/contrib/util/docker/README.md#easy-development-docker-environment
e.g.
```
# chkdocker-names mysql
=======Running Docker Names=======
docker_mysql_1
docker_mysql-old_1
docker_mysql-very-old_1

# chkdocker-names nginx
=======Running Docker Names=======
docker_nginx_1
```

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-