### PR TITLE
fix the other status docker names

### DIFF
--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -53,8 +53,9 @@ check_docker_names() {
 	if [ $# -eq 1 ]
 	then
 		# ARGS: couchdb php fhir mariadb mysql nginx openemr openldap orthanc redis.
-		echo '=======Running Docker Names======='
-		docker ps | awk '{print $NF}'|grep -v NAMES|sort -n | grep $CHECK_NAME
+		echo '===Check the single Docker Name==='
+		echo '  STATUS        NAME'
+		docker ps -a --format "{{.Status}}\t{{.Names}}"| grep $CHECK_NAME
 
 	else
 		# Show all the docker names.
@@ -65,6 +66,8 @@ check_docker_names() {
 		echo '***************************************************************'
 		echo '=======Running Docker Names======='
 		docker ps | awk '{print $NF}'|grep -v NAMES|sort -n
+		echo '====Other Docker Status Names====='
+		docker ps -a --format "table{{.Status}}\t{{.Names}}"| grep -v Up
 	fi
 }
 
@@ -238,11 +241,11 @@ then
   echo "  stop                               Execute: docker-compose stop"
   echo "  s, shell                           Open a docker shell quickly"
   echo "  e, exec                            Execute commands outside docker"
+	echo "  dl, docker-log                     To check docker log"
+	echo "  dn, docker-names                   To check docker the running docker names"
   echo 'php-management:'
   echo "  bt, build-themes                   Make changes to any files on your local file system"
 	echo "  pl, php-log                        To check PHP error logs"
-	echo "  dl, docker-log                     To check docker log"
-	echo "  dn, docker-names                   To check docker the running docker names"
 	echo "  pr, psr12-report                   To create a report of PSR12 code styling issues"
 	echo "  pf, psr12-fix                      To fix PSR12 code styling issues"
 	echo "  ltr, lint-themes-report            To create a report of theme styling issues"


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
--> 1. There are different status(exit, created....) for the docker, so try to add the different status docker names in case the related docker is not running success, it will help to check:
```
 ./openemr-cmd dn
***************************************************************
Show all the docker names by default.
Please provide the keyword if you want to check the single one.
e.g openemr-cmd [docker-names|dn] php
***************************************************************
=======Running Docker Names=======
cadvisor
openemr_couchdb_1
openemr_mysql_1
openemr_openemr_1
openemr_phpmyadmin_1
====Other Docker Status Names=====
STATUS              NAMES
Created             interesting_moser
[root@easy-env openemr-cmd]# ./openemr-cmd dn php
===Check the single Docker Name===
  STATUS        NAME
Up 4 days	openemr_phpmyadmin_1

```

2. Correct the classify of the help
```
docker-management:
  up                                 Execute: docker-compose up -d
  down                               Execute: docker-compose down -v
  start                              Execute: docker-compose start
  stop                               Execute: docker-compose stop
  s, shell                           Open a docker shell quickly
  e, exec                            Execute commands outside docker
  dl, docker-log                     To check docker log          <<<
  dn, docker-names                   To check docker the running docker names   <<<
```

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-