### PR TITLE
fix crypto in flex 3.13 series

### DIFF
--- a/docker/openemr/6.1.0/Dockerfile
+++ b/docker/openemr/6.1.0/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     perl mysql-client tar curl imagemagick npm \
-    python2 python3 openssl py-pip openssl-dev dcron \
+    python2 python3 openssl py-pip openssl-dev dcron cargo \
     rsync shadow \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
@@ -17,7 +17,7 @@ RUN usermod -u 1000 apache
 # Install composer for openemr package building
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #clone openemr
-RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
+RUN apk add --no-cache git build-base libffi-dev python3-dev \
     && git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
@@ -40,7 +40,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
-    && apk del --no-cache git build-base libffi-dev python3-dev cargo
+    && apk del --no-cache git build-base libffi-dev python3-dev
 WORKDIR /var/www/localhost/htdocs/openemr
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/6.1.0/Dockerfile
+++ b/docker/openemr/6.1.0/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     perl mysql-client tar curl imagemagick npm \
-    python2 python3 openssl py-pip openssl-dev dcron cargo \
+    python2 python3 openssl py-pip openssl-dev dcron \
     rsync shadow \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
@@ -17,7 +17,7 @@ RUN usermod -u 1000 apache
 # Install composer for openemr package building
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #clone openemr
-RUN apk add --no-cache git build-base libffi-dev python3-dev \
+RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
@@ -40,7 +40,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
-    && apk del --no-cache git build-base libffi-dev python3-dev
+    && apk del --no-cache git build-base libffi-dev python3-dev cargo
 WORKDIR /var/www/localhost/htdocs/openemr
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/6.1.0/Dockerfile
+++ b/docker/openemr/6.1.0/Dockerfile
@@ -17,7 +17,7 @@ RUN usermod -u 1000 apache
 # Install composer for openemr package building
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 #clone openemr
-RUN apk add --no-cache git build-base libffi-dev python3-dev \
+RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
@@ -40,7 +40,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
     && mkdir -p /etc/ssl/certs /etc/ssl/private \
-    && apk del --no-cache git build-base libffi-dev python3-dev
+    && apk del --no-cache git build-base libffi-dev python3-dev cargo
 WORKDIR /var/www/localhost/htdocs/openemr
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/flex-3.13-8/Dockerfile
+++ b/docker/openemr/flex-3.13-8/Dockerfile
@@ -9,15 +9,15 @@ RUN apk add --no-cache \
     php8-mysqli php8-sockets php8-xmlreader php8-redis perl php8-simplexml php8-xmlwriter php8-phar php8-fileinfo \
     php8-sodium php8-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron \
+    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
     RUN usermod -u 1000 apache
-
 #Stuff for developers since this predominantly a developer/tester docker
 RUN apk add --no-cache \
     unzip vim nano bash bash-doc bash-completion tree
+
 #BELOW LINE NEEDED TO SUPPORT PHP8 ON ALPINE 3.13; SHOULD BE ABLE TO REMOVE THIS IN FUTURE ALPINE VERSIONS
 RUN cp /usr/bin/php8 /usr/bin/php
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer

--- a/docker/openemr/flex-3.13-8/Dockerfile
+++ b/docker/openemr/flex-3.13-8/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php8-mysqli php8-sockets php8-xmlreader php8-redis perl php8-simplexml php8-xmlwriter php8-phar php8-fileinfo \
     php8-sodium php8-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
+    python2 python3 openssl git py-pip openssl-dev dcron \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
@@ -22,14 +22,18 @@ RUN apk add --no-cache \
 RUN cp /usr/bin/php8 /usr/bin/php
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
-#some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
-# is predominantly a developer/tester docker)
-RUN mkdir -p /var/www/localhost/htdocs/openemr/sites \
+# TODO: Note that flex series 3.13+ needs to keep build-base package in (ie. not apk del it after done) for now
+#  since npm package libxmljs needs to be built during openemr build; this is part of the ccda npm build and
+#  can place build-base in below apk del line when this issue is fixed)
+#  btw, when this is fixed and we apk del build-base, this will decrease size of docker by 190MB :)
+RUN apk add --no-cache build-base libffi-dev python3-dev cargo \
+    && mkdir -p /var/www/localhost/htdocs/openemr/sites \
     && chown -R apache /var/www/localhost/htdocs/openemr \
     && git clone https://github.com/letsencrypt/letsencrypt --depth 1 /opt/certbot \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
-    && mkdir -p /etc/ssl/certs /etc/ssl/private
+    && mkdir -p /etc/ssl/certs /etc/ssl/private \
+    && apk del --no-cache libffi-dev python3-dev cargo
 WORKDIR /var/www/localhost/htdocs
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/flex-3.13-8/autoconfig.sh
+++ b/docker/openemr/flex-3.13-8/autoconfig.sh
@@ -342,7 +342,7 @@ if [ "$XDEBUG_IDE_KEY" != "" ] &&
 
     # set up xdebug in php.ini
     echo "; start xdebug configuration" >> /etc/php8/php.ini
-    echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php8/php.ini
+    echo "zend_extension=/usr/lib/php8/modules/xdebug.so" >> /etc/php8/php.ini
     echo "xdebug.output_dir=/tmp" >> /etc/php8/php.ini
     echo "xdebug.start_with_request=trigger" >> /etc/php8/php.ini
     if [ "$XDEBUG_PROFILER_ON" == 1 ]; then

--- a/docker/openemr/flex-3.13-8/autoconfig.sh
+++ b/docker/openemr/flex-3.13-8/autoconfig.sh
@@ -328,8 +328,8 @@ rm -f /var/www/localhost/htdocs/auto_configure.php
 if [ "$REDIS_SERVER" != "" ] &&
    [ ! -f /etc/php-redis-configured ]; then
     # Variable for $REDIS_SERVER is usually going to be something like 'redis'
-    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php7/php.ini
-    sed -i "s@;session.save_path = \"/tmp\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php7/php.ini
+    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php8/php.ini
+    sed -i "s@;session.save_path = \"/tmp\"@session.save_path = \"tcp://$REDIS_SERVER:6379\"@" /etc/php8/php.ini
     # Ensure only configure this one time
     touch /etc/php-redis-configured
 fi
@@ -338,25 +338,26 @@ if [ "$XDEBUG_IDE_KEY" != "" ] &&
    [ ! -f /etc/php-xdebug-configured ]; then
     # install xdebug library
     apk update
-    apk add --no-cache php7-pecl-xdebug
+    apk add --no-cache php8-pecl-xdebug
 
     # set up xdebug in php.ini
-    echo "; start xdebug configuration" >> /etc/php7/php.ini
-    echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
-    echo "xdebug.remote_enable=1" >> /etc/php7/php.ini
-    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
-    echo "xdebug.remote_port=9000" >> /etc/php7/php.ini
-    echo "xdebug.remote_connect_back=1" >> /etc/php7/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
-    echo "xdebug.remote_log=/tmp/xdebug.log" >> /etc/php7/php.ini
+    echo "; start xdebug configuration" >> /etc/php8/php.ini
+    echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php8/php.ini
+    echo "xdebug.output_dir=/tmp" >> /etc/php8/php.ini
+    echo "xdebug.start_with_request=trigger" >> /etc/php8/php.ini
     if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
         # set up xdebug profiler
-        echo "xdebug.profiler_enable=0" >> /etc/php7/php.ini
-        echo "xdebug.profiler_enable_trigger=1" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_dir=/tmp" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
+        echo "xdebug.mode=debug,profile" >> /etc/php8/php.ini
+        echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php8/php.ini
+    else
+        echo "xdebug.mode=debug" >> /etc/php8/php.ini
     fi
-    echo "; end xdebug configuration" >> /etc/php7/php.ini
+    echo "xdebug.remote_handler=dbgp" >> /etc/php8/php.ini
+    echo "xdebug.client_port=9000" >> /etc/php8/php.ini
+    echo "xdebug.discover_client_host=1" >> /etc/php8/php.ini
+    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php8/php.ini
+    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php8/php.ini
+    echo "; end xdebug configuration" >> /etc/php8/php.ini
 
     # Ensure only configure this one time
     touch /etc/php-xdebug-configured

--- a/docker/openemr/flex-3.13/Dockerfile
+++ b/docker/openemr/flex-3.13/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis perl php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron \
+    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers

--- a/docker/openemr/flex-3.13/Dockerfile
+++ b/docker/openemr/flex-3.13/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis perl php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
+    python2 python3 openssl git py-pip openssl-dev dcron \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
@@ -18,14 +18,18 @@ RUN apk add --no-cache \
 RUN apk add --no-cache \
     unzip vim nano bash bash-doc bash-completion tree
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-#some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
-# is predominantly a developer/tester docker)
-RUN mkdir -p /var/www/localhost/htdocs/openemr/sites \
+# TODO: Note that flex series 3.13+ needs to keep build-base package in (ie. not apk del it after done) for now
+#  since npm package libxmljs needs to be built during openemr build; this is part of the ccda npm build and
+#  can place build-base in below apk del line when this issue is fixed)
+#  btw, when this is fixed and we apk del build-base, this will decrease size of docker by 190MB :)
+RUN apk add --no-cache build-base libffi-dev python3-dev cargo \
+    && mkdir -p /var/www/localhost/htdocs/openemr/sites \
     && chown -R apache /var/www/localhost/htdocs/openemr \
     && git clone https://github.com/letsencrypt/letsencrypt --depth 1 /opt/certbot \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
-    && mkdir -p /etc/ssl/certs /etc/ssl/private
+    && mkdir -p /etc/ssl/certs /etc/ssl/private \
+    && apk del --no-cache libffi-dev python3-dev cargo
 WORKDIR /var/www/localhost/htdocs
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/flex-3.13/autoconfig.sh
+++ b/docker/openemr/flex-3.13/autoconfig.sh
@@ -343,19 +343,20 @@ if [ "$XDEBUG_IDE_KEY" != "" ] &&
     # set up xdebug in php.ini
     echo "; start xdebug configuration" >> /etc/php7/php.ini
     echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
-    echo "xdebug.remote_enable=1" >> /etc/php7/php.ini
-    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
-    echo "xdebug.remote_port=9000" >> /etc/php7/php.ini
-    echo "xdebug.remote_connect_back=1" >> /etc/php7/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
-    echo "xdebug.remote_log=/tmp/xdebug.log" >> /etc/php7/php.ini
+    echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
+    echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
     if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
         # set up xdebug profiler
-        echo "xdebug.profiler_enable=0" >> /etc/php7/php.ini
-        echo "xdebug.profiler_enable_trigger=1" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_dir=/tmp" >> /etc/php7/php.ini
+        echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
         echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
+    else
+        echo "xdebug.mode=debug" >> /etc/php7/php.ini
     fi
+    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
+    echo "xdebug.client_port=9000" >> /etc/php7/php.ini
+    echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
+    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
+    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
     echo "; end xdebug configuration" >> /etc/php7/php.ini
 
     # Ensure only configure this one time

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis perl php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron \
+    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     php7-mysqli php7-sockets php7-xmlreader php7-redis perl php7-simplexml php7-xmlwriter php7-phar php7-fileinfo \
     php7-sodium php7-calendar \
     mysql-client tar curl imagemagick npm \
-    python2 python3 openssl git libffi-dev py-pip python3-dev build-base openssl-dev dcron cargo \
+    python2 python3 openssl git py-pip openssl-dev dcron \
     rsync shadow jq \
     && sed -i 's/^Listen 80$/Listen 0.0.0.0:80/' /etc/apache2/httpd.conf
 # Needed to ensure permissions work across shared volumes with openemr, nginx, and php-fpm dockers
@@ -18,14 +18,18 @@ RUN usermod -u 1000 apache
 RUN apk add --no-cache \
     unzip vim nano bash bash-doc bash-completion tree
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-#some other stuff (note not deleting build-base, libffi-dev, and python-dev since this
-# is predominantly a developer/tester docker)
-RUN mkdir -p /var/www/localhost/htdocs/openemr/sites \
+# TODO: Note that flex series 3.13+ needs to keep build-base package in (ie. not apk del it after done) for now
+#  since npm package libxmljs needs to be built during openemr build; this is part of the ccda npm build and
+#  can place build-base in below apk del line when this issue is fixed)
+#  btw, when this is fixed and we apk del build-base, this will decrease size of docker by 190MB :)
+RUN apk add --no-cache build-base libffi-dev python3-dev cargo \
+    && mkdir -p /var/www/localhost/htdocs/openemr/sites \
     && chown -R apache /var/www/localhost/htdocs/openemr \
     && git clone https://github.com/letsencrypt/letsencrypt --depth 1 /opt/certbot \
     && pip install --upgrade pip \
     && pip install -e /opt/certbot/acme -e /opt/certbot/certbot \
-    && mkdir -p /etc/ssl/certs /etc/ssl/private
+    && mkdir -p /etc/ssl/certs /etc/ssl/private \
+    && apk del --no-cache libffi-dev python3-dev cargo
 WORKDIR /var/www/localhost/htdocs
 VOLUME [ "/etc/letsencrypt/", "/etc/ssl" ]
 #configure apache & php properly

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -343,19 +343,20 @@ if [ "$XDEBUG_IDE_KEY" != "" ] &&
     # set up xdebug in php.ini
     echo "; start xdebug configuration" >> /etc/php7/php.ini
     echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
-    echo "xdebug.remote_enable=1" >> /etc/php7/php.ini
-    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
-    echo "xdebug.remote_port=9000" >> /etc/php7/php.ini
-    echo "xdebug.remote_connect_back=1" >> /etc/php7/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
-    echo "xdebug.remote_log=/tmp/xdebug.log" >> /etc/php7/php.ini
+    echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
+    echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
     if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
         # set up xdebug profiler
-        echo "xdebug.profiler_enable=0" >> /etc/php7/php.ini
-        echo "xdebug.profiler_enable_trigger=1" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_dir=/tmp" >> /etc/php7/php.ini
+        echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
         echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
+    else
+        echo "xdebug.mode=debug" >> /etc/php7/php.ini
     fi
+    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
+    echo "xdebug.client_port=9000" >> /etc/php7/php.ini
+    echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
+    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
+    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
     echo "; end xdebug configuration" >> /etc/php7/php.ini
 
     # Ensure only configure this one time


### PR DESCRIPTION
fix crypto in flex 3.13 series

The crypto thing was also breaking in 3.13 series, which is fixed by adding the rust package manager (cargo)

However, this shoots the docker size through the roof! It increases it by 500 MB (goes from 750MB to 1.25GB)
@jesdynf , any thoughts on why the size went crazy (maybe a cache or something). I'm still trying to figure out this Rust stuff (i also read that ticket which was pretty crazy stuff to consider the billions of things around the world that were instantly broken with the change :) ).

It also adds a lot more time to the build, but can live with that.