### PR TITLE
xdebug updates

### DIFF
--- a/docker/openemr/flex-3.13-8/autoconfig.sh
+++ b/docker/openemr/flex-3.13-8/autoconfig.sh
@@ -334,31 +334,45 @@ if [ "$REDIS_SERVER" != "" ] &&
     touch /etc/php-redis-configured
 fi
 
-if [ "$XDEBUG_IDE_KEY" != "" ] &&
-   [ ! -f /etc/php-xdebug-configured ]; then
-    # install xdebug library
-    apk update
-    apk add --no-cache php8-pecl-xdebug
+if [ "$XDEBUG_IDE_KEY" != "" ] ||
+   [ "$XDEBUG_ON" == 1 ]; then
+    if [ ! -f /etc/php-xdebug-configured ]; then
+        # install xdebug library
+        apk update
+        apk add --no-cache php8-pecl-xdebug
 
-    # set up xdebug in php.ini
-    echo "; start xdebug configuration" >> /etc/php8/php.ini
-    echo "zend_extension=/usr/lib/php8/modules/xdebug.so" >> /etc/php8/php.ini
-    echo "xdebug.output_dir=/tmp" >> /etc/php8/php.ini
-    echo "xdebug.start_with_request=trigger" >> /etc/php8/php.ini
-    if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
-        # set up xdebug profiler
-        echo "xdebug.mode=debug,profile" >> /etc/php8/php.ini
-        echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php8/php.ini
-    else
-        echo "xdebug.mode=debug" >> /etc/php8/php.ini
+        # set up xdebug in php.ini
+        echo "; start xdebug configuration" >> /etc/php8/php.ini
+        echo "zend_extension=/usr/lib/php8/modules/xdebug.so" >> /etc/php8/php.ini
+        echo "xdebug.output_dir=/tmp" >> /etc/php8/php.ini
+        echo "xdebug.start_with_request=trigger" >> /etc/php8/php.ini
+        echo "xdebug.remote_handler=dbgp" >> /etc/php8/php.ini
+        echo "xdebug.log=/tmp/xdebug.log" >> /etc/php8/php.ini
+        echo "xdebug.discover_client_host=1" >> /etc/php8/php.ini
+        if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
+            # set up xdebug profiler
+            echo "xdebug.mode=debug,profile" >> /etc/php8/php.ini
+            echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php8/php.ini
+        else
+            echo "xdebug.mode=debug" >> /etc/php8/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_PORT" != "" ]; then
+            # manually set up host port, if set
+            echo "xdebug.client_port=${XDEBUG_CLIENT_PORT}" >> /etc/php8/php.ini
+        else
+            echo "xdebug.client_port=9003" >> /etc/php8/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_HOST" != "" ]; then
+            # manually set up host, if set
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}" >> /etc/php8/php.ini
+        fi
+        if [ "$XDEBUG_IDE_KEY" != "" ]; then
+          # set up ide key, if set
+          echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php8/php.ini
+        fi
+        echo "; end xdebug configuration" >> /etc/php8/php.ini
+
+        # Ensure only configure this one time
+        touch /etc/php-xdebug-configured
     fi
-    echo "xdebug.remote_handler=dbgp" >> /etc/php8/php.ini
-    echo "xdebug.client_port=9000" >> /etc/php8/php.ini
-    echo "xdebug.discover_client_host=1" >> /etc/php8/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php8/php.ini
-    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php8/php.ini
-    echo "; end xdebug configuration" >> /etc/php8/php.ini
-
-    # Ensure only configure this one time
-    touch /etc/php-xdebug-configured
 fi

--- a/docker/openemr/flex-3.13/autoconfig.sh
+++ b/docker/openemr/flex-3.13/autoconfig.sh
@@ -334,31 +334,45 @@ if [ "$REDIS_SERVER" != "" ] &&
     touch /etc/php-redis-configured
 fi
 
-if [ "$XDEBUG_IDE_KEY" != "" ] &&
-   [ ! -f /etc/php-xdebug-configured ]; then
-    # install xdebug library
-    apk update
-    apk add --no-cache php7-pecl-xdebug
+if [ "$XDEBUG_IDE_KEY" != "" ] ||
+   [ "$XDEBUG_ON" == 1 ]; then
+    if [ ! -f /etc/php-xdebug-configured ]; then
+        # install xdebug library
+        apk update
+        apk add --no-cache php7-pecl-xdebug
 
-    # set up xdebug in php.ini
-    echo "; start xdebug configuration" >> /etc/php7/php.ini
-    echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
-    echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
-    echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
-    if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
-        # set up xdebug profiler
-        echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
-    else
-        echo "xdebug.mode=debug" >> /etc/php7/php.ini
+        # set up xdebug in php.ini
+        echo "; start xdebug configuration" >> /etc/php7/php.ini
+        echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
+        echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
+        echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
+        echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
+        echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
+        echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
+        if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
+            # set up xdebug profiler
+            echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
+            echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
+        else
+            echo "xdebug.mode=debug" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_PORT" != "" ]; then
+            # manually set up host port, if set
+            echo "xdebug.client_port=${XDEBUG_CLIENT_PORT}" >> /etc/php7/php.ini
+        else
+            echo "xdebug.client_port=9003" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_HOST" != "" ]; then
+            # manually set up host, if set
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_IDE_KEY" != "" ]; then
+          # set up ide key, if set
+          echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
+        fi
+        echo "; end xdebug configuration" >> /etc/php7/php.ini
+
+        # Ensure only configure this one time
+        touch /etc/php-xdebug-configured
     fi
-    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
-    echo "xdebug.client_port=9000" >> /etc/php7/php.ini
-    echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
-    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
-    echo "; end xdebug configuration" >> /etc/php7/php.ini
-
-    # Ensure only configure this one time
-    touch /etc/php-xdebug-configured
 fi

--- a/docker/openemr/flex-edge/autoconfig.sh
+++ b/docker/openemr/flex-edge/autoconfig.sh
@@ -334,31 +334,45 @@ if [ "$REDIS_SERVER" != "" ] &&
     touch /etc/php-redis-configured
 fi
 
-if [ "$XDEBUG_IDE_KEY" != "" ] &&
-   [ ! -f /etc/php-xdebug-configured ]; then
-    # install xdebug library
-    apk update
-    apk add --no-cache php7-pecl-xdebug
+if [ "$XDEBUG_IDE_KEY" != "" ] ||
+   [ "$XDEBUG_ON" == 1 ]; then
+    if [ ! -f /etc/php-xdebug-configured ]; then
+        # install xdebug library
+        apk update
+        apk add --no-cache php7-pecl-xdebug
 
-    # set up xdebug in php.ini
-    echo "; start xdebug configuration" >> /etc/php7/php.ini
-    echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
-    echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
-    echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
-    if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
-        # set up xdebug profiler
-        echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
-        echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
-    else
-        echo "xdebug.mode=debug" >> /etc/php7/php.ini
+        # set up xdebug in php.ini
+        echo "; start xdebug configuration" >> /etc/php7/php.ini
+        echo "zend_extension=/usr/lib/php7/modules/xdebug.so" >> /etc/php7/php.ini
+        echo "xdebug.output_dir=/tmp" >> /etc/php7/php.ini
+        echo "xdebug.start_with_request=trigger" >> /etc/php7/php.ini
+        echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
+        echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
+        echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
+        if [ "$XDEBUG_PROFILER_ON" == 1 ]; then
+            # set up xdebug profiler
+            echo "xdebug.mode=debug,profile" >> /etc/php7/php.ini
+            echo "xdebug.profiler_output_name=cachegrind.out.%s" >> /etc/php7/php.ini
+        else
+            echo "xdebug.mode=debug" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_PORT" != "" ]; then
+            # manually set up host port, if set
+            echo "xdebug.client_port=${XDEBUG_CLIENT_PORT}" >> /etc/php7/php.ini
+        else
+            echo "xdebug.client_port=9003" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_CLIENT_HOST" != "" ]; then
+            # manually set up host, if set
+            echo "xdebug.client_host=${XDEBUG_CLIENT_HOST}" >> /etc/php7/php.ini
+        fi
+        if [ "$XDEBUG_IDE_KEY" != "" ]; then
+          # set up ide key, if set
+          echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
+        fi
+        echo "; end xdebug configuration" >> /etc/php7/php.ini
+
+        # Ensure only configure this one time
+        touch /etc/php-xdebug-configured
     fi
-    echo "xdebug.remote_handler=dbgp" >> /etc/php7/php.ini
-    echo "xdebug.client_port=9000" >> /etc/php7/php.ini
-    echo "xdebug.discover_client_host=1" >> /etc/php7/php.ini
-    echo "xdebug.idekey=${XDEBUG_IDE_KEY}" >> /etc/php7/php.ini
-    echo "xdebug.log=/tmp/xdebug.log" >> /etc/php7/php.ini
-    echo "; end xdebug configuration" >> /etc/php7/php.ini
-
-    # Ensure only configure this one time
-    touch /etc/php-xdebug-configured
 fi


### PR DESCRIPTION
fixes: #285

Changed default client port to 9003

Changed the setting to turn on Xdebug to: `XDEBUG_ON` (setting it to 1 turns it on)

Have the following optional settings:
`XDEBUG_IDE_KEY` (not needed in phpstorm or vscode, but maybe another ide will need it)
`XDEBUG_CLIENT_HOST` (should never need, but just in case the xdebug.discover_client_host does not work)
`XDEBUG_CLIENT_PORT` (give flexibility if wish to not use default port 9003)

Testing well in main flex docker on both PHPStorm and VSCode (see this PR in openemr repo for settings that are using to work with this in development environment: https://github.com/openemr/openemr/pull/4248 ) . Profiling is also working.

Gotta bring these changes into 3.13-8 and edge also. And then update the official dockers on dockerhub.