### PR TITLE
suppresses error, not sure why alpine has this prob

### DIFF
--- a/docker/openemr/flex-3.13/autoconfig.sh
+++ b/docker/openemr/flex-3.13/autoconfig.sh
@@ -374,5 +374,10 @@ if [ "$XDEBUG_IDE_KEY" != "" ] ||
 
         # Ensure only configure this one time
         touch /etc/php-xdebug-configured
+        # fix for Xdebug: [Log Files] File '/tmp/xdebug.log' could not be opened.
+        touch /tmp/xdebug.log
+        chown root:apache /tmp/xdebug.log
+        chmod 664 /tmp/xdebug.log
+
     fi
 fi


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:
suppresses `Xdebug: [Log Files] File '/tmp/xdebug.log' could not be opened.`

php runs as root so why it can't open the file inside of /tmp is confusing

if this looks ok @bradymiller will add to other scripts too