### PR TITLE
Enable opcache for latest flex and 7.0.1 dockers.

### DIFF
--- a/docker/openemr/7.0.1/Dockerfile
+++ b/docker/openemr/7.0.1/Dockerfile
@@ -58,9 +58,9 @@ ENV APACHE_LOG_DIR=/var/log/apache2
 COPY php.ini /etc/php81/php.ini
 COPY openemr.conf /etc/apache2/conf.d/
 #add runner and auto_configure and prevent auto_configure from being run w/o being enabled
-COPY openemr.sh ssl.sh xdebug.sh auto_configure.php /var/www/localhost/htdocs/openemr/
+COPY openemr.sh ssl.sh xdebug.sh opcache.sh auto_configure.php /var/www/localhost/htdocs/openemr/
 COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
-RUN chmod 500 openemr.sh ssl.sh xdebug.sh /root/unlock_admin.sh \
+RUN chmod 500 openemr.sh ssl.sh xdebug.sh opcache.sh /root/unlock_admin.sh \
     && chmod 000 auto_configure.php /root/unlock_admin.php
 #bring in pieces used for automatic upgrade process
 COPY upgrade/docker-version \

--- a/docker/openemr/flex-3.17/Dockerfile
+++ b/docker/openemr/flex-3.17/Dockerfile
@@ -45,9 +45,9 @@ ENV APACHE_LOG_DIR=/var/log/apache2
 COPY php.ini /etc/php81/php.ini
 COPY openemr.conf /etc/apache2/conf.d/
 #add runner and auto_configure and prevent auto_configure from being run w/o being enabled
-COPY openemr.sh ssl.sh xdebug.sh auto_configure.php /var/www/localhost/htdocs/
+COPY openemr.sh ssl.sh xdebug.sh opcache.sh auto_configure.php /var/www/localhost/htdocs/
 COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
-RUN chmod 500 openemr.sh ssl.sh xdebug.sh /root/unlock_admin.sh \
+RUN chmod 500 openemr.sh ssl.sh xdebug.sh opcache.sh /root/unlock_admin.sh \
     && chmod 000 auto_configure.php /root/unlock_admin.php
 #fix issue with apache2 dying prematurely
 RUN mkdir -p /run/apache2

--- a/docker/openemr/flex-3.17/opcache.sh
+++ b/docker/openemr/flex-3.17/opcache.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+set -e
+
+if [ ! "$OPCACHE_ON" == 1 ]; then
+   echo bad context for opcache.sh launch
+   exit 1
+fi
+
+if [ ! -f /etc/php-opcache-configured ]; then
+    # install opcache library
+    apk update
+    apk add --no-cache php81-opcache 
+
+    # set up xdebug in php.ini
+    echo "; start opcache configuration" >> /etc/php81/php.ini
+    echo "zend_extension=opcache" >> /etc/php81/php.ini
+    echo "opcache.enable=1" >> /etc/php81/php.ini
+    echo "opcache.enable_cli=0" >> /etc/php81/php.ini
+    echo "opcache.memory_consumption=128" >> /etc/php81/php.ini
+    echo "opcache.max_accelerated_files=100000" >> /etc/php81/php.ini
+    echo "opcache.max_wasted_percentage=5" >> /etc/php81/php.ini
+    echo "opcache.save_comments=1" >> /etc/php81/php.ini
+    if [ ! "$OPCACHE_ON" == 1 ]; then
+	   echo bad context for opcache.sh launch
+	   exit 1
+	fi
+    if [ ! "$XDEBUG_IDE_KEY" != "" ] &&
+	   [ ! "$XDEBUG_ON" == 1 ]; then
+    	   echo "opcache.jit_buffer_size=100M" >> /etc/php81/php.ini
+           echo "opcache.jit=tracing" >> /etc/php81/php.ini
+    fi
+
+    # Ensure only configure this one time
+    touch /etc/php-opcache-configured
+fi

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -45,9 +45,9 @@ ENV APACHE_LOG_DIR=/var/log/apache2
 COPY php.ini /etc/php82/php.ini
 COPY openemr.conf /etc/apache2/conf.d/
 #add runner and auto_configure and prevent auto_configure from being run w/o being enabled
-COPY openemr.sh ssl.sh xdebug.sh auto_configure.php /var/www/localhost/htdocs/
+COPY openemr.sh ssl.sh xdebug.sh opcache.sh auto_configure.php /var/www/localhost/htdocs/
 COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
-RUN chmod 500 openemr.sh ssl.sh xdebug.sh /root/unlock_admin.sh \
+RUN chmod 500 openemr.sh ssl.sh xdebug.sh opcache.sh /root/unlock_admin.sh \
     && chmod 000 auto_configure.php /root/unlock_admin.php
 #fix issue with apache2 dying prematurely
 RUN mkdir -p /run/apache2

--- a/docker/openemr/flex-edge/opcache.sh
+++ b/docker/openemr/flex-edge/opcache.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+if [ ! "$OPCACHE_ON" == 1 ]; then
+   echo bad context for opcache.sh launch
+   exit 1
+fi
+
+if [ ! -f /etc/php-opcache-configured ]; then
+    # install opcache library
+    apk update
+    apk add --no-cache php82-opcache 
+
+    # set up xdebug in php.ini
+    echo "; start opcache configuration" >> /etc/php82/php.ini
+    echo "zend_extension=opcache" >> /etc/php82/php.ini
+    echo "opcache.enable=1" >> /etc/php82/php.ini
+    echo "opcache.enable_cli=0" >> /etc/php82/php.ini
+    echo "opcache.memory_consumption=128" >> /etc/php82/php.ini
+    echo "opcache.max_accelerated_files=100000" >> /etc/php82/php.ini
+    echo "opcache.max_wasted_percentage=5" >> /etc/php82/php.ini
+    echo "opcache.save_comments=1" >> /etc/php82/php.ini
+    echo "opcache.jit_buffer_size=100M" >> /etc/php82/php.ini
+    echo "opcache.jit=tracing" >> /etc/php82/php.ini
+
+    # Ensure only configure this one time
+    touch /etc/php-opcache-configured
+fi


### PR DESCRIPTION
Enable the opcache module and turn on JIT if xdebug is not enabled.  We benchmarked 50% response time improvements in the API and much faster UX interactions in the regular openemr interface just by having the opcache enabled.  Turning on JIT with xdebug disabled saw another 25% improvement.

So I took a stab at this.  I'm not as familiar with building the docker images but I followed the pattern that we used with the xdebug (Thanks @stephenwaite).

I'd love pointers on what else I should change / update here to make sure I got all of the moving pieces.