### PR TITLE
Adds php82-pecl-apcu to Dockerfile, adds APCu optimizations to autolo…

### DIFF
--- a/docker/openemr/7.0.2/Dockerfile
+++ b/docker/openemr/7.0.2/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
-    && composer install --no-dev --optimize-autoloader --apcu-autoloader \
+    && composer install --no-dev \
     && npm install --unsafe-perm \
     && npm run build \
     && cd ccdaservice \

--- a/docker/openemr/7.0.2/Dockerfile
+++ b/docker/openemr/7.0.2/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     php82-json php82-pdo php82-pdo_mysql php82-curl php82-ldap php82-openssl php82-iconv \
     php82-xml php82-xsl php82-gd php82-zip php82-soap php82-mbstring php82-zlib \
     php82-mysqli php82-sockets php82-xmlreader php82-redis php82-simplexml php82-xmlwriter php82-phar php82-fileinfo \
-    php82-sodium php82-calendar php82-intl php82-opcache \
+    php82-sodium php82-calendar php82-intl php82-opcache php82-pecl-apcu \
     perl mysql-client tar curl imagemagick nodejs npm \
     python3 openssl py-pip openssl-dev dcron \
     rsync shadow ncurses \
@@ -24,7 +24,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && git clone https://github.com/openemr/openemr.git --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
-    && composer install --no-dev \
+    && composer install --no-dev --optimize-autoloader --apcu-autoloader \
     && npm install --unsafe-perm \
     && npm run build \
     && cd ccdaservice \
@@ -34,7 +34,7 @@ RUN apk add --no-cache git build-base libffi-dev python3-dev cargo \
     && /root/.composer/vendor/bin/phing vendor-clean \
     && /root/.composer/vendor/bin/phing assets-clean \
     && composer global remove phing/phing \
-    && composer dump-autoload -o \
+    && composer dump-autoload --optimize --apcu \
     && composer clearcache \
     && npm cache clear --force \
     && rm -fr node_modules \

--- a/docker/openemr/7.0.2/openemr.sh
+++ b/docker/openemr/7.0.2/openemr.sh
@@ -24,6 +24,8 @@ swarm_wait() {
 auto_setup() {
     prepareVariables
 
+    chmod -R 600 .
+
     #create temporary file cache directory for auto_configure.php to use
     TMP_FILE_CACHE_LOCATION="/tmp/php-file-cache"
     mkdir $TMP_FILE_CACHE_LOCATION

--- a/docker/openemr/7.0.2/openemr.sh
+++ b/docker/openemr/7.0.2/openemr.sh
@@ -24,8 +24,26 @@ swarm_wait() {
 auto_setup() {
     prepareVariables
 
-    chmod -R 600 .
-    php auto_configure.php -f ${CONFIGURATION} || return 1
+    #create temporary file cache directory for auto_configure.php to use
+    TMP_FILE_CACHE_LOCATION="/tmp/php-file-cache"
+    mkdir $TMP_FILE_CACHE_LOCATION
+
+    #create auto_configure.ini to be able to leverage opcache for operations
+    touch auto_configure.ini
+    echo "opcache.enable=1" >> auto_configure.ini
+    echo "opcache.enable_cli=1" >> auto_configure.ini
+    echo "opcache.file_cache=$TMP_FILE_CACHE_LOCATION" >> auto_configure.ini
+    echo "opcache.file_cache_only=1" >> auto_configure.ini
+    echo "opcache.file_cache_consistency_checks=1" >> auto_configure.ini
+    echo "opcache.enable_file_override=1" >> auto_configure.ini
+    echo "opcache.max_accelerated_files=1000000" >> auto_configure.ini
+
+    #run auto_configure
+    php auto_configure.php -c auto_configure.ini -f ${CONFIGURATION} || return 1
+
+    #remove temporary file cache directory and auto_configure.ini
+    rm -r $TMP_FILE_CACHE_LOCATION
+    rm auto_configure.ini
 
     echo "OpenEMR configured."
     CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")
@@ -261,7 +279,7 @@ if [ "$REDIS_SERVER" != "" ] &&
       phpize82
       # note for php 8.2, needed to change from './configure --enable-redis-igbinary' to:
       ./configure --with-php-config=/usr/bin/php-config82 --enable-redis-igbinary
-      make
+      make -j $(nproc --all)
       make install
       echo "extension=redis" > /etc/php82/conf.d/20_redis.ini
       rm -fr /tmpredis/phpredis
@@ -322,10 +340,14 @@ if
             # This section only runs once after per docker since auto_configure.php gets removed after this script
 
             echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
+
+            #return number from nproc to have value for -P flag in xargs
+            N_PROC=$(nproc --all)
+
             #set all directories to 500 (note that sites/default/documents is dealt with below which need to skip here to prevent breakage in swarm mode)
-            find . -type d -not -path "./sites/default/documents/*" -print0 | xargs -0 chmod 500
+            find . -type d -not -path "./sites/default/documents/*" -print0 | xargs -0 -P $N_PROC chmod 500
             #set all file access to 400 (note that sites/default/documents is dealt with below which need to skip here to prevent breakage in swarm mode)
-            find . -type f -not -path "./sites/default/documents/*" -print0 | xargs -0 chmod 400
+            find . -type f -not -path "./sites/default/documents/*" -print0 | xargs -0 -P $N_PROC chmod 400
 
             echo "Default file permissions and ownership set, allowing writing to specific directories"
             chmod 700 openemr.sh
@@ -336,8 +358,8 @@ if
                [ "$SWARM_MODE" != "yes" ] ||
                [ ! -f /var/www/localhost/htdocs/openemr/sites/docker-completed ]; then
                 echo "Setting sites/default/documents permissions to 700"
-                find sites/default/documents -type d -print0 | xargs -0 chmod 700
-                find sites/default/documents -type f -print0 | xargs -0 chmod 700
+                find sites/default/documents -type d -print0 | xargs -0 -P $N_PROC chmod 700
+                find sites/default/documents -type f -print0 | xargs -0 -P $N_PROC chmod 700
             fi
 
             echo "Removing remaining setup scripts"

--- a/docker/openemr/flex-3.18/Dockerfile
+++ b/docker/openemr/flex-3.18/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     php82-json php82-pdo php82-pdo_mysql php82-curl php82-ldap php82-openssl php82-iconv \
     php82-xml php82-xsl php82-gd php82-zip php82-soap php82-mbstring php82-zlib \
     php82-mysqli php82-sockets php82-xmlreader php82-redis perl php82-simplexml php82-xmlwriter php82-phar php82-fileinfo \
-    php82-sodium php82-calendar php82-intl php82-opcache \
+    php82-sodium php82-calendar php82-intl php82-opcache php82-pecl-apcu \
     mysql-client tar curl imagemagick nodejs npm \
     python3 openssl git py-pip openssl-dev dcron \
     rsync shadow jq ncurses \

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     php82-json php82-pdo php82-pdo_mysql php82-curl php82-ldap php82-openssl php82-iconv \
     php82-xml php82-xsl php82-gd php82-zip php82-soap php82-mbstring php82-zlib \
     php82-mysqli php82-sockets php82-xmlreader php82-redis perl php82-simplexml php82-xmlwriter php82-phar php82-fileinfo \
-    php82-sodium php82-calendar php82-intl php82-opcache \
+    php82-sodium php82-calendar php82-intl php82-opcache php82-pecl-apcu \
     mysql-client tar curl imagemagick nodejs npm \
     python3 openssl git py-pip openssl-dev dcron \
     rsync shadow jq ncurses \


### PR DESCRIPTION
…ader, uses OPcache for auto_configure.php and uses multiple processes for make and find.

#### Changes proposed in this pull request:

- Adds php82-pecl-apcu package which allows us to do level 2/B optimizations with the autoloader as described here: https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-b-apcu-cache
- Leverages the OPcache file cache to run auto_configure.php faster. 
- Uses multiple processes for Make and find which was found to reduce runtime there as well.

Tested for 7.0.2! 