### PR TITLE
Update openemr-cmd container name

### DIFF
--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -14,19 +14,24 @@ VERSION="1.0.12"
 
 # Set the default container name/id to look for
 INSANE_DEV_DOCKER="_openemr-8-1_1"
-# To determine a snap or a non-snap docker
-# Function to determine EASY_DEV_DOCKER
-get_easy_dev_docker() {
+# If the docker is snap or non-snap docker
+# Setting the container names accordingly
+get_container_names() {
 	snap_docker=$(which docker)
 	if [ $snap_docker == '/snap/bin/docker' ]
 	then
-   		echo "openemr-1"
-	else
-		echo "_openemr_1"
-	fi
+		INSANE_DEV_DOCKER="openemr-8-1"
+		EASY_DEV_DOCKER="openemr-1"
+        COUCHDB_DOCKER="couchdb-1"
+    else
+		INSANE_DEV_DOCKER="_openemr-8-1_1"
+		EASY_DEV_DOCKER="_openemr_1"
+        COUCHDB_DOCKER="_couchdb_1" 
+	fi	
 }
-EASY_DEV_DOCKER=$(get_easy_dev_docker)
-COUCHDB_DOCKER="_couchdb_1"
+
+# Set the container names
+get_container_names
 
 # Set some constants
 DOCKER_EXEC_CMD='docker exec -i'                                 # docker exec command

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -14,7 +14,18 @@ VERSION="1.0.12"
 
 # Set the default container name/id to look for
 INSANE_DEV_DOCKER="_openemr-8-1_1"
-EASY_DEV_DOCKER="openemr-1"
+# To determine a snap or a non-snap docker
+# Function to determine EASY_DEV_DOCKER
+get_easy_dev_docker() {
+	snap_docker=$(which docker)
+	if [ $snap_docker == '/snap/bin/docker' ]
+	then
+   		echo "openemr-1"
+	else
+		echo "_openemr_1"
+	fi
+}
+EASY_DEV_DOCKER=$(get_easy_dev_docker)
 COUCHDB_DOCKER="_couchdb_1"
 
 # Set some constants

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -20,7 +20,7 @@ get_container_names() {
 	snap_docker=$(which docker)
 	if [ $snap_docker == '/snap/bin/docker' ]
 	then
-		INSANE_DEV_DOCKER="openemr-8-1"
+		INSANE_DEV_DOCKER="openemr-8-1-1"
 		EASY_DEV_DOCKER="openemr-1"
         COUCHDB_DOCKER="couchdb-1"
     else

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -14,7 +14,7 @@ VERSION="1.0.12"
 
 # Set the default container name/id to look for
 INSANE_DEV_DOCKER="_openemr-8-1_1"
-EASY_DEV_DOCKER="_openemr_1"
+EASY_DEV_DOCKER="openemr-1"
 COUCHDB_DOCKER="_couchdb_1"
 
 # Set some constants


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #364

#### Short description of what this resolves:
Allows the openemr-cmd to run all of its commands. Besides the docker commands, other commands were not running. 

This was the issue: 
![image](https://github.com/openemr/openemr-devops/assets/48083186/f63d3713-fa31-4d08-b3a0-197ee716c4ae)


#### Changes proposed in this pull request:

- In openemr-cmd, in line 17, by removing the leading "_" to a hyphen
- Basically, 
`EASY_DEV_DOCKER="_openemr_1"` to
`EASY_DEV_DOCKER="openemr-1"`


This fixed the issue and I was able to run the other commands as well. I had struggled with this issue and after this fix, it finally works. 