### PR TITLE
Fixes #370, Put launch in non-interactive mode.

### DIFF
--- a/packages/lightsail/launch.sh
+++ b/packages/lightsail/launch.sh
@@ -61,6 +61,9 @@ f () {
   else
     echo Skipping swap allocation...
   fi
+  
+  # Make sure we don't fail out if there is an interactive prompt... go with defaults
+  export DEBIAN_FRONTEND=noninteractive
 
   apt-get update -y
   apt-get dist-upgrade -y


### PR DESCRIPTION
Fixes #370 by exporting the noninteractive shell environment var.  Tested this by executing a lightsail installation and it is now running.
