### PR TITLE
Specify current docker image

### DIFF
--- a/packages/lightsail/launch.sh
+++ b/packages/lightsail/launch.sh
@@ -13,7 +13,7 @@ exec > /var/log/lightsail-launch.log 2>&1
 SWAPAMT=1
 SWAPPATHNAME=/mnt/auto.swap
 
-CURRENTDOCKER=openemr:latest
+CURRENTDOCKER=openemr:7.0.2
 OVERRIDEDOCKER=$CURRENTDOCKER
 
 DEVELOPERMODE=0


### PR DESCRIPTION
Specify current docker image used so it can be overridden.

<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-