### PR TITLE
Implements PHP-FPM/FCGI for Apache for 7.0.3, Flex 3.19, and Flex Edge

### DIFF
--- a/docker/openemr/7.0.3/Dockerfile
+++ b/docker/openemr/7.0.3/Dockerfile
@@ -3,11 +3,11 @@ FROM alpine:3.19
 #Install dependencies and fix issue in apache
 RUN apk --no-cache upgrade
 RUN apk add --no-cache \
-    apache2 apache2-ssl apache2-utils git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
+    apache2 apache2-ssl apache2-utils apache2-proxy git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
     php83-json php83-pdo php83-pdo_mysql php83-curl php83-ldap php83-openssl php83-iconv \
     php83-xml php83-xsl php83-gd php83-zip php83-soap php83-mbstring php83-zlib \
     php83-mysqli php83-sockets php83-xmlreader php83-redis php83-simplexml php83-xmlwriter php83-phar php83-fileinfo \
-    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu \
+    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu php83-fpm \
     perl mysql-client tar curl imagemagick nodejs npm \
     certbot openssl openssl-dev dcron \
     rsync shadow ncurses \

--- a/docker/openemr/7.0.3/openemr.conf
+++ b/docker/openemr/7.0.3/openemr.conf
@@ -65,3 +65,8 @@ CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combin
     SSLCertificateFile    /etc/ssl/certs/webserver.cert.pem
     SSLCertificateKeyFile /etc/ssl/private/webserver.key.pem
 </VirtualHost>
+
+#Add FPM FCGI configuration
+<FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+</FilesMatch>

--- a/docker/openemr/flex-3.19/Dockerfile
+++ b/docker/openemr/flex-3.19/Dockerfile
@@ -3,11 +3,11 @@ FROM alpine:3.19
 #Install dependencies and fix issue in apache
 RUN apk --no-cache upgrade
 RUN apk add --no-cache \
-    apache2 apache2-ssl apache2-utils git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
+    apache2 apache2-ssl apache2-utils apache2-proxy git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
     php83-json php83-pdo php83-pdo_mysql php83-curl php83-ldap php83-openssl php83-iconv \
     php83-xml php83-xsl php83-gd php83-zip php83-soap php83-mbstring php83-zlib \
     php83-mysqli php83-sockets php83-xmlreader php83-redis perl php83-simplexml php83-xmlwriter php83-phar php83-fileinfo \
-    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu \
+    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu php83-fpm \
     mysql-client tar curl imagemagick nodejs npm \
     certbot openssl git openssl-dev dcron \
     rsync shadow jq ncurses \

--- a/docker/openemr/flex-3.19/openemr.conf
+++ b/docker/openemr/flex-3.19/openemr.conf
@@ -71,3 +71,8 @@ CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combin
     #   Used for client based certificates
     #SSLCACertificateFile /etc/ssl/certs/CAcustomclientbasedwebserver.cert.pem
 </VirtualHost>
+
+#Add FPM FCGI configuration
+<FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+</FilesMatch>

--- a/docker/openemr/flex-edge/Dockerfile
+++ b/docker/openemr/flex-edge/Dockerfile
@@ -3,11 +3,11 @@ FROM alpine:edge
 #Install dependencies and fix issue in apache
 RUN apk --no-cache upgrade
 RUN apk add --no-cache \
-    apache2 apache2-ssl apache2-utils git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
+    apache2 apache2-ssl apache2-utils apache2-proxy git php83 php83-tokenizer php83-ctype php83-session php83-apache2 \
     php83-json php83-pdo php83-pdo_mysql php83-curl php83-ldap php83-openssl php83-iconv \
     php83-xml php83-xsl php83-gd php83-zip php83-soap php83-mbstring php83-zlib \
     php83-mysqli php83-sockets php83-xmlreader php83-redis perl php83-simplexml php83-xmlwriter php83-phar php83-fileinfo \
-    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu \
+    php83-sodium php83-calendar php83-intl php83-opcache php83-pecl-apcu php83-fpm \
     mysql-client tar curl imagemagick nodejs npm \
     certbot openssl git openssl-dev dcron \
     rsync shadow jq ncurses \

--- a/docker/openemr/flex-edge/openemr.conf
+++ b/docker/openemr/flex-edge/openemr.conf
@@ -71,3 +71,8 @@ CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combin
     #   Used for client based certificates
     #SSLCACertificateFile /etc/ssl/certs/CAcustomclientbasedwebserver.cert.pem
 </VirtualHost>
+
+#Add FPM FCGI configuration
+<FilesMatch \.php$>
+    SetHandler "proxy:fcgi://127.0.0.1:9000"
+</FilesMatch>


### PR DESCRIPTION
Implements PHP-FPM/FCGI for Apache. More information about PHP-FPM/FCGI for Apache on Alpine can be found here (https://wiki.alpinelinux.org/wiki/Apache_with_php-fpm). Tested for 7.0.3.