### PR TITLE
speed up chmod

### DIFF
--- a/docker/openemr/7.0.3/openemr.sh
+++ b/docker/openemr/7.0.3/openemr.sh
@@ -24,7 +24,7 @@ swarm_wait() {
 auto_setup() {
     prepareVariables
 
-    chmod -R 600 .
+    find . -not -perm 600 -exec chmod 600 {} \+
 
     #create temporary file cache directory for auto_configure.php to use
     TMP_FILE_CACHE_LOCATION="/tmp/php-file-cache"

--- a/docker/openemr/7.0.3/openemr.sh
+++ b/docker/openemr/7.0.3/openemr.sh
@@ -343,13 +343,10 @@ if
 
             echo "Setting user 'www' as owner of openemr/ and setting file/dir permissions to 400/500"
 
-            #return number from nproc to have value for -P flag in xargs
-            N_PROC=$(nproc --all)
-
             #set all directories to 500 (note that sites/default/documents is dealt with below which need to skip here to prevent breakage in swarm mode)
-            find . -type d -not -path "./sites/default/documents/*" -print0 | xargs -0 -P $N_PROC chmod 500
+            find . -type d -not -path "./sites/default/documents/*" -not -perm 500 -exec chmod 500 {} \+
             #set all file access to 400 (note that sites/default/documents is dealt with below which need to skip here to prevent breakage in swarm mode)
-            find . -type f -not -path "./sites/default/documents/*" -print0 | xargs -0 -P $N_PROC chmod 400
+            find . -type f -not -path "./sites/default/documents/*" -not -path './openemr.sh' -not -perm 400 -exec chmod 400 {} \+
 
             echo "Default file permissions and ownership set, allowing writing to specific directories"
             chmod 700 openemr.sh
@@ -360,8 +357,7 @@ if
                [ "$SWARM_MODE" != "yes" ] ||
                [ ! -f /var/www/localhost/htdocs/openemr/sites/docker-completed ]; then
                 echo "Setting sites/default/documents permissions to 700"
-                find sites/default/documents -type d -print0 | xargs -0 -P $N_PROC chmod 700
-                find sites/default/documents -type f -print0 | xargs -0 -P $N_PROC chmod 700
+                find sites/default/documents -not -path "sites/default/documents/smarty/main/*" -not -perm 700 -exec chmod 700 {} \+
             fi
 
             echo "Removing remaining setup scripts"

--- a/docker/openemr/7.0.3/openemr.sh
+++ b/docker/openemr/7.0.3/openemr.sh
@@ -357,7 +357,7 @@ if
                [ "$SWARM_MODE" != "yes" ] ||
                [ ! -f /var/www/localhost/htdocs/openemr/sites/docker-completed ]; then
                 echo "Setting sites/default/documents permissions to 700"
-                find sites/default/documents -not -path "sites/default/documents/smarty/main/*" -not -perm 700 -exec chmod 700 {} \+
+                find sites/default/documents -not -perm 700 -exec chmod 700 {} \+
             fi
 
             echo "Removing remaining setup scripts"

--- a/docker/openemr/flex-3.19/openemr.sh
+++ b/docker/openemr/flex-3.19/openemr.sh
@@ -35,7 +35,7 @@ auto_setup() {
     prepareVariables
 
     if [ "$EASY_DEV_MODE" != "yes" ]; then
-        chmod -R 600 /var/www/localhost/htdocs/openemr
+        find /var/www/localhost/htdocs/openemr -not -perm 600 -exec chmod 600 {} \+
     fi
 
     #create temporary file cache directory for auto_configure.php to use
@@ -397,15 +397,14 @@ if
         N_PROC=$(nproc --all)
 
         #set all directories to 500
-        find . -type d -print0 | xargs -0 -P $N_PROC chmod 500
+        find . -type d -not -path "./sites/default/documents/*" -not -perm 500 -exec chmod 500 {} \+
         #set all file access to 400
-        find . -type f -print0 | xargs -0 -P $N_PROC chmod 400
+        find . -type f -not -path "./sites/default/documents/*" -not -path './openemr.sh' -not -perm 400 -exec chmod 400 {} \+
 
         echo "Default file permissions and ownership set, allowing writing to specific directories"
         chmod 700 /var/www/localhost/htdocs/openemr.sh
         # Set file and directory permissions
-        find sites/default/documents -type d -print0 | xargs -0 -P $N_PROC chmod 700
-        find sites/default/documents -type f -print0 | xargs -0 -P $N_PROC chmod 700
+        find sites/default/documents -not -perm 700 -exec chmod 700 {} \+
 
         echo "Removing remaining setup scripts"
         #remove all setup scripts


### PR DESCRIPTION
This will speed up chmod by only executing chmod on non conforming items This reduces disk iops, and improves start times.

#### Short description of what this resolves
- slow startup/scaleup/redeploy while waiting for chmod

#### Changes proposed in this pull request
- only chmod files and dirs that need changing


#### Extra notes
I excluded `'./openemr.sh'` to prevent it being changed to 400

I excluded `"sites/default/documents/smarty/main/*"` because I'm not sure if the chmod is needed here as thought this might fill up with a lot of generated files and folders which might slow the process down.

#### Questions
- The files and folders in path `sites/default/documents` are set to `700` was this intentional?