### PR TITLE
temporarily point 7.0.2 docker to v7_0_2_1 tag instead of rel-702 branch

### DIFF
--- a/docker/openemr/7.0.2/Dockerfile
+++ b/docker/openemr/7.0.2/Dockerfile
@@ -21,7 +21,7 @@ RUN cp /usr/bin/php82 /usr/bin/php
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 RUN apk add --no-cache git build-base \
-    && git clone https://github.com/openemr/openemr.git --branch rel-702 --depth 1 \
+    && git clone https://github.com/openemr/openemr.git --branch v_7_0_2_1 --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
     && composer install --no-dev \


### PR DESCRIPTION
saw that @bradymiller did this back in v7.0.0 when we last had a patch and looks like that this will build the docker based on latest patch code instead of rel-702 which could diverge when new commits are added for patch 2