### PR TITLE
add shellcheck action to validate shell scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,140 @@
+name: ShellCheck
+on:
+  push:
+    branches:
+      - master
+    # GitHub Actions do not support YAML anchors
+    # There are four places in here we must keep
+    # the paths in sync.
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+      - 'docker/openemr/flex-*/utilities/devtools'
+      - 'kubernetes/kub-down'
+      - 'kubernetes/kub-up'
+      - 'packages/standard/cfn/buildstacks.bat'  # ¯\_(ツ)_/¯
+      - 'utilities/openemr-cmd/openemr-cmd'
+      - 'utilities/openemr-cmd/openemr-cmd-h'
+      - 'utilities/openemr-env-installer/openemr-env-installer'
+      - 'utilities/openemr-env-migrator/openemr-env-migrator'
+      - 'utilities/openemr-monitor/monitor-installer'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+      - 'docker/openemr/flex-*/utilities/devtools'
+      - 'kubernetes/kub-down'
+      - 'kubernetes/kub-up'
+      - 'packages/standard/cfn/buildstacks.bat'  # ¯\_(ツ)_/¯
+      - 'utilities/openemr-cmd/openemr-cmd'
+      - 'utilities/openemr-cmd/openemr-cmd-h'
+      - 'utilities/openemr-env-installer/openemr-env-installer'
+      - 'utilities/openemr-env-migrator/openemr-env-migrator'
+      - 'utilities/openemr-monitor/monitor-installer'
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup PHP with cs2pr
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          # cs2pr enables us to convert checkstyle output to github annotations
+          tools: cs2pr
+      - name: Get changed shell files
+        id: changed-files
+        # We run shellcheck on all unique shell files in the repo
+        # if only the workflow file itself is changed in a PR.
+        # Thus we validate changes to the workflow file.
+        continue-on-error: true
+        uses: tj-actions/changed-files@v46
+        with:
+          # Keep the paths in sync with the paths in the on.push and on.pull_request sections
+          # See https://github.com/tj-actions/changed-files/blob/v46/README.md#inputs-%EF%B8%8F
+          # for tj-actions/changed-files specific syntax
+          files: |
+            **.sh
+            docker/openemr/flex-*/utilities/devtools
+            kubernetes/kub-down
+            kubernetes/kub-up
+            packages/standard/cfn/buildstacks.bat
+            utilities/openemr-cmd/openemr-cmd
+            utilities/openemr-cmd/openemr-cmd-h
+            utilities/openemr-env-installer/openemr-env-installer
+            utilities/openemr-env-migrator/openemr-env-migrator
+            utilities/openemr-monitor/monitor-installer
+      - name: Create unique files list
+        id: unique-files
+        run: |
+          set -x
+          # Create a temp directory to store file hashes
+          mkdir -p /tmp/shellcheck-hashes
+
+          # Initialize variable to hold unique files
+          unique_files=''
+
+          # If the changed-files step failed or returned empty,
+          # use git to find all shell files in the repo.
+          if [[ "${{ steps.changed-files.outcome }}" = success && "${{ steps.changed-files.outputs.any_changed }}" = true ]]; then
+            echo 'Changed files found, checking only those.'
+            set -f  # disable glob expansion
+            files_to_check=( ${{ steps.changed-files.outputs.all_changed_files }} )
+            set +f  # re-enable glob expansion
+          else
+            echo 'No changed files found, checking all shell files in the repo.'
+            # Use the same paths as in the on.push and on.pull_request sections
+            # to ensure we only check shell files.
+            # Use globstar to find shell files in subdirectories.
+            shopt -s globstar
+            files_to_check=(
+              **/*.sh
+              docker/openemr/flex-*/utilities/devtools
+              kubernetes/kub-down
+              kubernetes/kub-up
+              packages/standard/cfn/buildstacks.bat
+              utilities/openemr-cmd/openemr-cmd
+              utilities/openemr-cmd/openemr-cmd-h
+              utilities/openemr-env-installer/openemr-env-installer
+              utilities/openemr-env-migrator/openemr-env-migrator
+              utilities/openemr-monitor/monitor-installer
+            )
+          fi
+
+          unique_files=()
+          # Process each changed file
+          for file in "${files_to_check[@]}"; do
+            [[ -f "$file" ]] || continue
+            # Get hash of file content
+            hash=$(sha256sum "$file" | cut -d ' ' -f 1)
+            # Check if we've seen this hash before
+            [[ -f "/tmp/shellcheck-hashes/$hash" ]] && continue
+            # New unique file
+            > "/tmp/shellcheck-hashes/$hash"
+            unique_files+=( "$file" )
+          done
+
+          # This relies on one space between each path name.
+          echo "files=${unique_files[*]}" >> "$GITHUB_OUTPUT"
+      - name: Run shellcheck on unique files
+        run: |
+          if [[ -z "${{ steps.unique-files.outputs.files }}" ]]; then
+            echo "No shell files to check."
+            exit 0
+          fi
+          shellcheck --check-sourced --external-sources --format=checkstyle ${{ steps.unique-files.outputs.files }} | tee checkstyle-shellcheck.xml
+      - uses: staabm/annotate-pull-request-from-checkstyle-action@v1
+        if: always()
+        with:
+          files: checkstyle-shellcheck.xml
+          notices-as-warnings: true
+      - name: Upload shellcheck results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: shellcheck-results
+          path: checkstyle-shellcheck.xml
+          if-no-files-found: error

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,4 @@
+# https://www.shellcheck.net/wiki/Directive
+# Enable all optional shellcheck checks
+enable=all
+external-sources=true


### PR DESCRIPTION
#### Short description of what this resolves:

Uses [shellcheck](https://www.shellcheck.net/) to analyze and debug shell scripts.


#### Changes proposed in this pull request:

Add an action for shellcheck. It only runs when either a shell file is changed, or when the workflow itself is changed. So, while there will be lots of things flagged in this PR, once merged there would only be flags if a shell file were changed. Also, it only runs on the first of each set of identical files.

If this PR is accepted, I intend to follow it with PRs fixing the found issues over time.