### PR TITLE
add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true


### PR DESCRIPTION
.editorconfig was added to openemr/openemr@7b7c76602a around openemr/openemr#151. This is the same.

#### Short description of what this resolves:

There are a lot of different whitespace styles in this repo. I hope editorconfig helps move things toward consistency.


#### Changes proposed in this pull request:

- add the same .editorconfig to this repo as is in openemr/openemr
