### PR TITLE
chore: address shellcheck findings in `xrecovery-final.sh`

### DIFF
--- a/docker/mysql-xtrabackup-final/xrecovery-final.sh
+++ b/docker/mysql-xtrabackup-final/xrecovery-final.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
+set -euo pipefail
+
 WORKDIR=/mnt/backups/recovery
 
 if service mysql status; then
-  echo xrecovery-final: mysql must not be running, yet it is; aborting
+  echo 'xrecovery-final: mysql must not be running, yet it is; aborting'
   exit 1
 fi
 
 # Even though MySQL isn't running, I can't just make off with /var/lib/mysql,
 # since the container mounts it.
 
-chown -R mysql:mysql $WORKDIR
+chown -R mysql:mysql "${WORKDIR}"
 rm -rf /mnt/backups/prerecovery-mysql-datadir
-echo Copying prerecovery state...
+echo 'Copying prerecovery state...'
 mkdir /mnt/backups/prerecovery-mysql-datadir
 mv /var/lib/mysql/* /mnt/backups/prerecovery-mysql-datadir
-echo Moving restored database into position...
-mv -v $WORKDIR/* /var/lib/mysql
-echo Done, continuing...
+echo 'Moving restored database into position...'
+mv -v "${WORKDIR}"/* /var/lib/mysql
+echo 'Done, continuing...'
 rm -f /root/pending-restore
-touch /root/force-full-backup
-touch /root/restore-process-complete
-exit 0
+touch /root/force-full-backup /root/restore-process-complete

--- a/docker/mysql-xtrabackup/xrecovery-final.sh
+++ b/docker/mysql-xtrabackup/xrecovery-final.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
+set -euo pipefail
+
 WORKDIR=/mnt/backups/recovery
 
 if service mysql status; then
-  echo xrecovery-final: mysql must not be running, yet it is; aborting
+  echo 'xrecovery-final: mysql must not be running, yet it is; aborting'
   exit 1
 fi
 
 # Even though MySQL isn't running, I can't just make off with /var/lib/mysql,
 # since the container mounts it.
 
-chown -R mysql:mysql $WORKDIR
+chown -R mysql:mysql "${WORKDIR}"
 rm -rf /mnt/backups/prerecovery-mysql-datadir
-echo Copying prerecovery state...
+echo 'Copying prerecovery state...'
 mkdir /mnt/backups/prerecovery-mysql-datadir
 mv /var/lib/mysql/* /mnt/backups/prerecovery-mysql-datadir
-echo Moving restored database into position...
-mv -v $WORKDIR/* /var/lib/mysql
-echo Done, continuing...
+echo 'Moving restored database into position...'
+mv -v "${WORKDIR}"/* /var/lib/mysql
+echo 'Done, continuing...'
 rm -f /root/pending-restore
-touch /root/force-full-backup
-touch /root/restore-process-complete
-exit 0
+touch /root/force-full-backup /root/restore-process-complete


### PR DESCRIPTION
#### Short description of what this resolves:

Address the issues uncovered by shellcheck in one set of (identical) files.


#### Changes proposed in this pull request:

- Add quotes around variables to avoid accidental wordsplitting and glob expansion.
- Add curly braces around variables for consistency and readability.
- Combine `touch` to create two files.
- Remove `exit 0` to exit with the correct exit code
- Use `set -euo pipefail` to catch errors earlier. 
