### PR TITLE
more granular docker tags

### DIFF
--- a/.github/workflows/build-703.yml
+++ b/.github/workflows/build-703.yml
@@ -18,11 +18,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get build date
+        id: build_date
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
       - name: Build and push 7.0.3 docker
         uses: docker/build-push-action@v5
         with:
           context: "{{defaultContext}}:docker/openemr/7.0.3"
-          tags: openemr/openemr:7.0.3, openemr/openemr:latest
+          tags: openemr/openemr:7.0.3, openemr/openemr:7.0.3.4, openemr/openemr:7.0.3.4-${{ steps.build_date.outputs.date }}, openemr/openemr:latest
           platforms: linux/amd64,linux/arm64
           push: true
           no-cache: true


### PR DESCRIPTION
Adding a tag with patch and also adding a tag with patch-date to the production docker releases.
This is so that orchestrations that need to ensure never change images on the fly (ie. they can pin to the patch-date tag)