### PR TITLE
fix: increase active dockers php memory_limit to 512M

### DIFF
--- a/docker/openemr/7.0.3/php.ini
+++ b/docker/openemr/7.0.3/php.ini
@@ -442,7 +442,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/docker/openemr/7.0.4/php.ini
+++ b/docker/openemr/7.0.4/php.ini
@@ -432,7 +432,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/docker/openemr/flex-3.18/php.ini
+++ b/docker/openemr/flex-3.18/php.ini
@@ -427,7 +427,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/docker/openemr/flex-3.20/php.ini
+++ b/docker/openemr/flex-3.20/php.ini
@@ -442,7 +442,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/docker/openemr/flex-3.21/php.ini
+++ b/docker/openemr/flex-3.21/php.ini
@@ -432,7 +432,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;

--- a/docker/openemr/flex-edge/php.ini
+++ b/docker/openemr/flex-edge/php.ini
@@ -432,7 +432,7 @@ max_input_vars = 3000
 
 ; Maximum amount of memory a script may consume
 ; https://php.net/memory-limit
-memory_limit = 256M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
fixes #418 

Will not rebuild production docker 7.0.3 (instead will do a rebuild after release patch 5 in future).
Will rebuild the other dockers.
