### PR TITLE
ci: test that builds work

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,39 @@
+# OpenEMR Docker Testing
+
+This directory contains a GitHub Actions workflow to test the OpenEMR 7.0.4 Docker image.
+
+## Workflow: OpenEMR Docker Test
+
+The `build-test.yml` workflow verifies that the OpenEMR Docker image can be built correctly and functions with a database connection. It performs the following steps:
+
+1. Builds the OpenEMR 7.0.4 Docker image
+2. Sets up a test environment using Docker Compose with:
+   - MariaDB 11.4 database
+   - OpenEMR container connected to the database
+3. Verifies that the web server is responding correctly
+
+### Triggers
+
+The workflow runs automatically when:
+- Files in the `docker/openemr/7.0.4/` directory are changed on the main branch
+- A pull request targeting the main branch changes files in the `docker/openemr/7.0.4/` directory
+
+It can also be run manually through the GitHub Actions tab using workflow_dispatch.
+
+## Running the Test Manually
+
+To run the test manually:
+1. Go to the GitHub Actions tab in the repository
+2. Select "OpenEMR Docker Test" from the workflows list
+3. Click "Run workflow"
+4. Choose the branch to run the test on
+5. Click "Run workflow"
+
+For debugging purposes, you can enable the tmate debugging option when running the workflow manually. This will provide an SSH connection to the GitHub Actions runner for interactive debugging.
+
+## Adding Tests for Other OpenEMR Versions
+
+To add tests for other OpenEMR versions:
+1. Copy the existing workflow and update the version number
+2. Update the paths in the workflow triggers
+3. Update the image tags and other version-specific information

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,105 @@
+name: OpenEMR Docker Build Test
+
+on:
+  push:
+    branches:
+    - master
+    paths:
+    - '.github/workflows/test.yml'
+    - 'docker/openemr/**'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - '.github/workflows/test.yml'
+    - 'docker/openemr/**'
+
+jobs:
+  build-and-test:
+    name: Test OpenEMR Image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-dir:
+        - 6.1.0
+        - 7.0.0
+        - 7.0.1
+        - 7.0.2
+        - 7.0.3
+        - 7.0.4
+    defaults:
+      run:
+        working-directory: docker/openemr
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build the Docker image
+      env:
+        COMPOSE_BAKE: "1"
+        DOCKER_BUILDKIT: "1"
+        DOCKER_CONTEXT_PATH: "${{matrix.docker-dir}}"
+      run: docker compose build
+
+    - name: Run the containers
+      run: docker compose up --detach --wait --wait-timeout 180
+
+    - name: Check container status
+      run: |
+        docker compose ps
+        docker compose logs openemr
+
+    - name: Test web connectivity
+      run: |
+        # Test that OpenEMR web server is responding
+        HTTP_CODE=$(curl -f -s -o /dev/null -w "%{http_code}" http://localhost:8080/)
+        echo "OpenEMR HTTP status code: $HTTP_CODE"
+        if (( HTTP_CODE == 200 || HTTP_CODE == 302 )); then
+          echo "OpenEMR web server is responding correctly!"
+          exit 0
+        fi
+        echo "OpenEMR web server is not responding correctly!"
+        exit 1
+
+    - name: Install and configure
+      run: |
+        docker compose exec --workdir /var/www/localhost/htdocs/openemr/contrib/util/installScripts \
+          openemr sh -c 'sed -e "s@^exit;@ @" InstallerAuto.php |
+                         php -- rootpass=root server=mysql loginhost=%'
+        docker compose exec openemr mysql -u openemr --password="openemr" -h mysql -e 'INSERT INTO product_registration (opt_out) VALUES (1);
+                                                                                       UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_api";
+                                                                                       UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_fhir_api";
+                                                                                       UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_portal_api";
+                                                                                       UPDATE globals SET gl_value = 3 WHERE gl_name = "oauth_password_grant";
+                                                                                       UPDATE globals SET gl_value = 1 WHERE gl_name = "rest_system_scopes_api";' openemr
+        docker compose exec openemr composer install --dev --no-interaction --optimize-autoloader
+
+    - name: Unit Test
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite unit
+
+    - name: Fixtures testing
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite fixtures
+
+    - name: Services testing
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite services
+
+    - name: Validators testing
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite validators
+
+    - name: Controllers testing
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite controllers
+
+    - name: Common testing
+      run: |
+        docker compose exec openemr php -d memory_limit=8G ./vendor/bin/phpunit --colors=always --testdox --stop-on-failure --testsuite common
+
+    - name: Cleanup
+      if: always()
+      run: docker compose down --remove-orphans --volumes

--- a/docker/openemr/compose.yml
+++ b/docker/openemr/compose.yml
@@ -1,0 +1,47 @@
+services:
+  mysql:
+    image: mariadb:11.4
+    command:
+    - mariadbd
+    - --character-set-server=utf8mb4
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+    healthcheck:
+      test:
+      - CMD
+      - /usr/local/bin/healthcheck.sh
+      - --su-mysql
+      - --connect
+      - --innodb_initialized
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3
+  openemr:
+    build:
+      context: ${DOCKER_CONTEXT_PATH}
+    ports:
+    - 8080:80
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MANUAL_SETUP: 'yes'
+      MYSQL_HOST: mysql
+      MYSQL_PASS: openemr
+      MYSQL_ROOT_PASS: root
+      MYSQL_USER: openemr
+      OE_PASS: pass
+      OE_USER: admin
+    healthcheck:
+      test:
+      - CMD
+      - curl
+      - -fsSLo/dev/null
+      - http://localhost/
+      start_period: 1m
+      start_interval: 10s
+      interval: 1m
+      timeout: 5s
+      retries: 3


### PR DESCRIPTION
Fixes #430

#### Short description of what this resolves:

Add testing action around the prod builds, so we know if we break them.


#### Changes proposed in this pull request:

Add a Github Action workflow for testing 6.1.0 and 7.0.0 and up.

