### PR TITLE
fix(flex-edge/auto_configure.php): wordsplit -f argument

### DIFF
--- a/docker/openemr/flex-edge/auto_configure.php
+++ b/docker/openemr/flex-edge/auto_configure.php
@@ -26,10 +26,25 @@ $installSettings['no_root_db_access']        = 'BLANK';
 $installSettings['development_translations'] = 'BLANK';
 // Collect parameters(if exist) for installation configuration settings
 for ($i=1; $i < count($argv); $i++) {
-    $indexandvalue = explode("=", $argv[$i]);
-    $index = $indexandvalue[0];
-    $value = $indexandvalue[1] ?? '';
-    $installSettings[$index] = $value;
+    if ($argv[$i] == '-f' && isset($argv[$i+1])) {
+        // Handle case where a single string contains all parameters
+        $configString = $argv[$i+1];
+        $configPairs = preg_split('/\s+/', trim($configString));
+        foreach ($configPairs as $pair) {
+            if (strpos($pair, '=') !== false) {
+                list($index, $value) = explode('=', $pair, 2);
+                $installSettings[$index] = $value;
+            }
+        }
+        // Skip the next argument since we already processed it
+        $i++;
+    } else {
+        // Handle standard key=value parameters
+        $indexandvalue = explode("=", $argv[$i]);
+        $index = $indexandvalue[0];
+        $value = $indexandvalue[1] ?? '';
+        $installSettings[$index] = $value;
+    }
 }
 // Convert BLANK settings to empty
 $tempInstallSettings = array();


### PR DESCRIPTION
Fixes #441

#### Short description of what this resolves:

Make `auto_configure.php` handle splitting the mysql connection string,
since we don't want to rely on the shell to do it.


#### Changes proposed in this pull request:

Make `auto_configure.php` handle splitting the mysql connection string,
since we don't want to rely on the shell to do it.
