### PR TITLE
fix(shell): SC2230/avoid nonstandard `which` command

### DIFF
--- a/docker/mysql-xtrabackup/xbackup.sh
+++ b/docker/mysql-xtrabackup/xbackup.sh
@@ -442,8 +442,9 @@ _s_inf "INFO: Backup job started: ${_start_backup_date}"
 DEFAULTS_FILE_FLAG=
 [ -n "${DEFAULTS_FILE}" ] && DEFAULTS_FILE_FLAG="--defaults-file=${DEFAULTS_FILE}"
 # Check for innobackupex
-_ibx=$(which innobackupex)
-if [ "$?" -gt 0 ]; then _d_inf "ERROR: Could not find innobackupex binary!"; fi
+if ! _ibx=$(command -v innobackupex); then
+    _d_inf 'ERROR: Could not find innobackupex binary!'
+fi
 if [ -n ${DEFAULTS_FILE} ]; then _ibx="${_ibx} ${DEFAULTS_FILE_FLAG}"; fi
 if [ "x${GALERA_INFO}" = "x1" ]; then _ibx="${_ibx} --galera-info"; fi
 

--- a/docker/mysql-xtrabackup/xbackup.sh
+++ b/docker/mysql-xtrabackup/xbackup.sh
@@ -464,12 +464,9 @@ fi
 #
 # Determine what will be our --incremental-basedir
 #
-if [ "${BKP_TYPE}" = "incr" ];
-then
-   if [ -n "${INC_BSEDIR}" ];
-   then
-      if [ ! -d ${WORK_DIR}/bkps/${INC_BSEDIR} ];
-      then
+if [ "${BKP_TYPE}" = "incr" ]; then
+   if [ -n "${INC_BSEDIR}" ]; then
+      if [ ! -d ${WORK_DIR}/bkps/${INC_BSEDIR} ]; then
          _d_inf "ERROR: Specified incremental basedir ${WORK_DIR}/bkps/${_inc_basedir} does not exist.";
       fi
 
@@ -478,8 +475,7 @@ then
       _inc_basedir=${_last_bkp}
    fi
 
-   if [ ! -n "${_inc_basedir}" ];
-   then
+   if [ ! -n "${_inc_basedir}" ]; then
       _d_inf "ERROR: No valid incremental basedir found!";
    fi
 
@@ -487,8 +483,7 @@ then
       _inc_basedir_path="${WORK_DIR}/bkps/${_inc_basedir}" || \
       _inc_basedir_path="${STOR_DIR}/bkps/${_inc_basedir}"
 
-   if [ ! -d "${_inc_basedir_path}" ];
-   then
+   if [ ! -d "${_inc_basedir_path}" ]; then
       _d_inf "ERROR: Incremental basedir ${_inc_basedir_path} does not exist.";
    fi
 
@@ -663,17 +658,14 @@ if [ "${status}" != 1 ]; then
    _start_prepare_date=$(date)
    _s_inf "INFO: Apply log started: ${_start_prepare_date}"
 
-   if [ "${BKP_TYPE}" = "incr" ];
-   then
-      if [ ! -n "${_incr_base}" ];
-      then
+   if [ "${BKP_TYPE}" = "incr" ]; then
+      if [ ! -n "${_incr_base}" ]; then
          _d_inf "ERROR: No valid base backup found!";
       fi
 
       _incr_base=P_${_incr_base}
 
-      if [ ! -d "${WORK_DIR}/bkps/${_incr_base}" ];
-      then
+      if [ ! -d "${WORK_DIR}/bkps/${_incr_base}" ]; then
          _d_inf "ERROR: Base backup ${WORK_DIR}/bkps/${_incr_base} does not exist.";
       fi
       _ibx_prep="${_ibx_prep} --apply-log --redo-only ${WORK_DIR}/bkps/${_incr_base} --incremental-dir ${_this_bkp}"

--- a/docker/openemr/7.0.3/openemr.sh
+++ b/docker/openemr/7.0.3/openemr.sh
@@ -437,16 +437,16 @@ fi
 
 if [ "${SWARM_MODE}" = "yes" ]; then
     # Set flag that the instance is ready when in swarm mode
-    echo ""
+    echo
     echo "swarm mode on: this instance is ready"
-    echo ""
+    echo
     touch /root/instance-swarm-ready
 fi
 
-echo ""
+echo
 echo "Love OpenEMR? You can now support the project via the open collective:"
 echo " > https://opencollective.com/openemr/donate"
-echo ""
+echo
 
 if [ "${OPERATOR}" = yes ]; then
     echo 'Starting apache!'

--- a/docker/openemr/7.0.4/openemr.sh
+++ b/docker/openemr/7.0.4/openemr.sh
@@ -437,16 +437,16 @@ fi
 
 if [ "${SWARM_MODE}" = "yes" ]; then
     # Set flag that the instance is ready when in swarm mode
-    echo ""
+    echo
     echo "swarm mode on: this instance is ready"
-    echo ""
+    echo
     touch /root/instance-swarm-ready
 fi
 
-echo ""
+echo
 echo "Love OpenEMR? You can now support the project via the open collective:"
 echo " > https://opencollective.com/openemr/donate"
-echo ""
+echo
 
 if [ "${OPERATOR}" = yes ]; then
     echo 'Starting apache!'

--- a/docker/openemr/flex-3.20/openemr.sh
+++ b/docker/openemr/flex-3.20/openemr.sh
@@ -505,10 +505,10 @@ else
    fi
 fi
 
-echo ""
+echo
 echo "Love OpenEMR? You can now support the project via the open collective:"
 echo " > https://opencollective.com/openemr/donate"
-echo ""
+echo
 
 if [ "${OPERATOR}" = yes ]; then
     echo 'Starting apache!'

--- a/docker/openemr/flex-3.21/openemr.sh
+++ b/docker/openemr/flex-3.21/openemr.sh
@@ -505,10 +505,10 @@ else
    fi
 fi
 
-echo ""
+echo
 echo "Love OpenEMR? You can now support the project via the open collective:"
 echo " > https://opencollective.com/openemr/donate"
-echo ""
+echo
 
 if [ "${OPERATOR}" = yes ]; then
     echo 'Starting apache!'

--- a/docker/openemr/flex-edge/openemr.sh
+++ b/docker/openemr/flex-edge/openemr.sh
@@ -515,10 +515,10 @@ else
    fi
 fi
 
-echo ""
+echo
 echo "Love OpenEMR? You can now support the project via the open collective:"
 echo " > https://opencollective.com/openemr/donate"
-echo ""
+echo
 
 if [ "${OPERATOR}" = yes ]; then
     echo 'Starting apache!'

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -353,7 +353,7 @@ fi
 
 # Script usage.
 if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
-    echo ""
+    echo
     echo "Usage: ${0##*/} COMMAND [ARGS]"
     echo "Usage: ${0##*/} -d <docker name> COMMAND [ARGS]"
     echo "Options:"

--- a/utilities/openemr-cmd/openemr-cmd-h
+++ b/utilities/openemr-cmd/openemr-cmd-h
@@ -12,8 +12,7 @@ filter_help_output(){
 }
 
 # Use (( )) for numeric comparisons
-if (( $# == 0 ))
-then
+if (( $# == 0 )); then
     echo "To search the keyword from openemr-cmd -h output quickly
     Usage: openemr-cmd-h keyword
     e.g.   openemr-cmd-h ssl

--- a/utilities/openemr-env-installer/openemr-env-installer
+++ b/utilities/openemr-env-installer/openemr-env-installer
@@ -26,11 +26,11 @@ install_git() {
     os_distribution=$(grep ^HOME_URL /etc/os-release| awk -F'[/.]' '{print $(NF-2)}')
     if command -v git &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mGit is already installed. \033[0m"
-        echo ''
+        echo
         return
     fi
     echo -e "\033[30m===>\033[0m \033[32mInstalling git... \033[0m"
-    echo ''
+    echo
     case "${os_distribution}" in
         ubuntu|debian)
             sudo apt-get update -y
@@ -44,17 +44,17 @@ install_git() {
             dnf install git -y
             ;;
     esac
-    [ $? -ne 0 ] && echo '' && echo -e "\e[31mInstalled failed, please check the repo list and the network.\e[0m" && exit
-    echo ''
+    [ $? -ne 0 ] && echo && echo -e "\e[31mInstalled failed, please check the repo list and the network.\e[0m" && exit
+    echo
 }
 
 # The script usage
 installer_script_usage() {
     echo "Usage: bash $(basename $0) <code location> <github account>"
-    echo ''
+    echo
     echo "  e.g. bash $(basename $0) /home/test/code testuser"
     echo "    or bash $(basename $0) /Users/test/code testuser"
-    echo ''
+    echo
     echo -e "\033[33mNOTE1: Please make sure you have created your own fork of OpenEMR and OpenEMR-devops at first.\033[0m"
     echo -e "\033[33mNOTE2: Please make sure you have the necessary environment if use minikube:\033[0m"
     echo -e "\033[33m       * 2 CPUs or more\033[0m"
@@ -72,31 +72,31 @@ git_clone_function(){
     github_account=$2
     cd ${code_location} && [ $(pwd) != "${code_location}" ] && cd ${code_location}
     echo -e "\033[30m===>\033[0m \033[32mDownloading OpenEMR repository... \033[0m"
-    echo ''
+    echo
     # For openemr repos
     git clone https://github.com/${github_account}/openemr.git
     cd ${code_location}/openemr && [ $(pwd) != "${code_location}/openemr" ] && cd ${code_location}/openemr
     git remote add upstream https://github.com/openemr/openemr.git
     git fetch upstream
-    echo ''
+    echo
     echo -e "\033[30m===>\033[0m \033[32mPulling the latest data... \033[0m"
-    echo ''
+    echo
     git pull upstream master
-    echo ''
+    echo
 
     # For openemr-devops repos
     cd ${code_location} && [ $(pwd) != "${code_location}" ] && cd ${code_location}
     echo -e "\033[30m===>\033[0m \033[32mDownloading OpenEMR-devops repository... \033[0m"
-    echo ''
+    echo
     git clone https://github.com/${github_account}/openemr-devops.git
     cd ${code_location}/openemr-devops && [ $(pwd) != "${code_location}/openemr-devops" ] && cd ${code_location}/openemr-devops
     git remote add upstream https://github.com/openemr/openemr-devops.git
     git fetch upstream
-    echo ''
+    echo
     echo -e "\033[30m===>\033[0m \033[32mPulling the latest data... \033[0m"
-    echo ''
+    echo
     git pull upstream master
-    echo ''
+    echo
 }
 
 # Check the code clone or not
@@ -114,7 +114,7 @@ code_dir_exist_or_not() {
         git_clone_function $1 $2
     else
         echo -e "\033[30m===>\033[0m \033[32mOpenEMR repos are already downloaded. \033[0m"
-        echo ''
+        echo
     fi
 }
 
@@ -151,7 +151,7 @@ rhel_register_check_and_enable_repo() {
     # Attach the necessary repo
     if [ ! -f ${repo_lock} ]; then
         echo -e "\033[30m===>\033[0m \033[32mEnabling base and extras repo... \033[0m"
-        echo ''
+        echo
         subscription-manager repos --enable rhel-7-server-rpms &>/dev/null
         [ $? -eq 0 ] && echo 1 >  ${repo_lock}
         subscription-manager repos --enable rhel-7-server-extras-rpms &>/dev/null
@@ -159,7 +159,7 @@ rhel_register_check_and_enable_repo() {
     elif [ -f ${repo_lock} ]; then
         if [ "$(cat /tmp/openemr-repo-lock|wc -l)" = "2" ]; then
             echo -e "\033[30m===>\033[0m \033[32mBoth of base and extras repo are already enabled. \033[0m"
-            echo ''
+            echo
         fi
     fi
 }
@@ -179,60 +179,60 @@ install_docker() {
         case "${os_distribution}" in
             ubuntu|debian)
                 echo -e "\033[30m===>\033[0m \033[32mUpdate the apt package index and install packages to allow apt to use a repository over HTTPS... \033[0m"
-                echo ''
+                echo
                 sudo apt-get update -y
                 sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
-                echo ''
+                echo
                 echo -e "\033[30m===>\033[0m \033[32mAdding the Docker official GPG key... \033[0m"
                 sudo curl -fsSL https://download.docker.com/linux/${os_distribution}/gpg | sudo apt-key add -
-                echo ''
+                echo
                 echo -e "\033[30m===>\033[0m \033[32mSetting up the stable repository... \033[0m"
                 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/${os_distribution} $(lsb_release -cs) stable"
-                echo ''
+                echo
                 echo -e "\033[30m===>\033[0m \033[32mInstalling docker engine... \033[0m"
-                echo ''
+                echo
                 sudo apt-get update -y
                 sudo apt-get install docker-ce docker-ce-cli containerd.io -y
                 echo -e "\033[30m===>\033[0m \033[32mAdding your username to the docker group to avoid typing sudo whenever you run the docker command... \033[0m"
-                echo ''
+                echo
                 sudo usermod -aG docker ${USER}
                 sudo systemctl start docker
                 sudo systemctl enable docker
-                echo ''
+                echo
                 ;;
             redhat)
                 echo -e "\033[30m===>\033[0m \033[32mInstalling docker device-mapper-libs device-mapper-event-libs... \033[0m"
-                echo ''
+                echo
                 yum install docker device-mapper-libs device-mapper-event-libs -y
                 start_enable_docker
-                echo ''
+                echo
                 ;;
             centos)
                 echo -e "\033[30m===>\033[0m \033[32mDownloading docker-ce repo... \033[0m"
-                echo ''
+                echo
                 curl -o /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/centos/docker-ce.repo &>/dev/null
                 echo -e "\033[30m===>\033[0m \033[32mInstalling docker-ce docker-ce-cli containerd.io... \033[0m"
-                echo ''
+                echo
                 yum install docker-ce docker-ce-cli containerd.io -y
                 start_enable_docker
-                echo ''
+                echo
                 ;;
             fedoraproject)
                 echo -e "\033[30m===>\033[0m \033[32mDownloading docker-ce repo... \033[0m"
-                echo ''
+                echo
                 curl -o /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/fedora/docker-ce.repo &>/dev/null
                 echo -e "\033[30m===>\033[0m \033[32mInstalling docker-ce docker-ce-cli containerd.io... \033[0m"
-                echo ''
+                echo
                 dnf update -y
                 dnf install docker-ce docker-ce-cli containerd.io -y
                 start_enable_docker
-                echo ''
+                echo
                 ;;
         esac
     else
         echo -e "\033[30m===>\033[0m \033[32mDocker is already installed. \033[0m"
         start_enable_docker
-        echo ''
+        echo
     fi
 }
 
@@ -240,15 +240,15 @@ install_docker() {
 install_docker_compose() {
     if command -v docker-compose &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mDocker-compose is already installed. \033[0m"
-        echo ''
+        echo
         return
     fi
     echo -e "\033[30m===>\033[0m \033[32mInstalling docker-compose... \033[0m"
-    echo ''
+    echo
     # Run sudo under root mode that is also fine e.g. rhel/fedora/centos
     sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
     sudo chmod +x /usr/local/bin/docker-compose
-    echo ''
+    echo
 }
 
 # Install openemr-cmd tool
@@ -262,25 +262,25 @@ install_openemr_cmd() {
 
     if command -v openemr-cmd &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mOpenEMR-cmd is already installed. \033[0m"
-        echo ''
+        echo
         return
     fi
     echo -e "\033[30m===>\033[0m \033[32mInstalling openemr-cmd... \033[0m"
-    echo ''
+    echo
     case "${os_distribution}" in
         ubuntu|debian)
             sudo curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
             sudo chmod +x /usr/local/bin/openemr-cmd
-            echo ''
+            echo
             ;;
         *)
             # It requests a password if run sudo in macOS, so try without sudo
             curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
             chmod +x /usr/local/bin/openemr-cmd
-            echo ''
+            echo
             ;;
     esac
-    echo ''
+    echo
 }
 
 # Install command check
@@ -304,16 +304,16 @@ install_conntrack() {
     case "${os_distribution}" in
         ubuntu|debian)
             echo -e "\033[30m===>\033[0m \033[32mInatalling conntrack package... \033[0m"
-            echo ''
+            echo
             sudo apt-get update -y
             sudo apt-get install conntrack -y
-            echo ''
+            echo
             ;;
         redhat|centos|fedoraproject)
             echo -e "\033[30m===>\033[0m \033[32mInatalling conntrack package... \033[0m"
-            echo ''
+            echo
             yum install conntrack -y
-            echo ''
+            echo
             ;;
     esac
 }
@@ -329,31 +329,31 @@ install_minikube_kubectl(){
     # Install minikube
     if command -v minikube &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mMinikube is already installed. \033[0m"
-        echo ''
+        echo
         run_cluster_tip
-        echo ''
+        echo
     else
         echo -e "\033[30m===>\033[0m \033[32mInstalling minikube... \033[0m"
-        echo ''
+        echo
         sudo curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-${minikube_os}-amd64
-        echo ''
+        echo
         install_cmd_chk
         sudo install minikube-${minikube_os}-amd64 /usr/local/bin/minikube
         sudo rm -f minikube-${minikube_os}-amd64
-        echo ''
+        echo
         run_cluster_tip
-        echo ''
+        echo
     fi
     # Install kubectl
     if command -v kubectl &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mKubectl is already installed. \033[0m"
-        echo ''
+        echo
     else
         echo -e "\033[30m===>\033[0m \033[32mInstalling kubectl... \033[0m"
-        echo ''
+        echo
         sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/${minikube_os}/amd64/kubectl -o /usr/local/bin/kubectl
         sudo chmod +x /usr/local/bin/kubectl
-        echo ''
+        echo
     fi
 }
 
@@ -378,7 +378,7 @@ quick_check_result() {
     echo -e "\033[36mThe docker status: \033[0m\033[32m${docker_status} \033[0m"
     echo -e "\033[33mNOTE: Please run 'dnf update' for fedora if docker-compose check failed.\033[0m"
     echo '*********************************************'
-    echo ''
+    echo
 }
 
 # Show the startup commands
@@ -479,22 +479,22 @@ elif [ "${os_type}" = "Darwin" ]; then
         # Homebrew info: https://brew.sh
         if command -v brew &>/dev/null; then
             echo -e "\033[30m===>\033[0m \033[32mHomebrew is already installed. \033[0m"
-            echo ''
+            echo
         else
             echo -e "\033[30m===>\033[0m \033[32mInstalling Homebrew... \033[0m"
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
-            echo ''
+            echo
         fi
 
         # Install git
         if command -v git &>/dev/null; then
             echo -e "\033[30m===>\033[0m \033[32mGit is already installed. \033[0m"
-            echo ''
+            echo
         else
             echo -e "\033[30m===>\033[0m \033[32mInstalling git... \033[0m"
             brew install git
-            [ $? -ne 0 ] && echo '' && echo -e "\e[31mInstalled failed, please check the network.\e[0m" && exit
-            echo ''
+            [ $? -ne 0 ] && echo && echo -e "\e[31mInstalled failed, please check the network.\e[0m" && exit
+            echo
         fi
 
         # Check the code dir and git clone
@@ -503,12 +503,12 @@ elif [ "${os_type}" = "Darwin" ]; then
         # Install docker
         if command -v docker &>/dev/null; then
             echo -e "\033[30m===>\033[0m \033[32mDocker is already installed. \033[0m"
-            echo ''
+            echo
         else
             echo -e "\033[30m===>\033[0m \033[32mInstalling docker... \033[0m"
-            echo ''
+            echo
             brew cask install docker
-            echo ''
+            echo
             open /Applications/Docker.app
             echo -e "\033[30m===>\033[0m \033[33mPlease click open for docker prompt window. \033[0m"
             echo -e "\033[30m===>\033[0m \033[33mPlease click ok and provide your login password for docker privileged access prompt window. \033[0m"
@@ -519,12 +519,12 @@ elif [ "${os_type}" = "Darwin" ]; then
                     break
                 fi
             done
-            echo ''
+            echo
         fi
 
         # Install docker-compose
         echo -e "\033[30m===>\033[0m \033[32mDocker Compose is installed as part of Docker for Mac. \033[0m"
-        echo ''
+        echo
 
         # Install openemr-cmd
         install_openemr_cmd
@@ -535,11 +535,11 @@ elif [ "${os_type}" = "Darwin" ]; then
         # Check the installation result
         echo '****************************Quick Check****************************'
         quick_check_command
-        echo ''
+        echo
         echo -e "\033[36mThe docker status: \033[0m"
         echo -e "\033[33mPlease check the docker icon on the top right of the desktop.\033[0m"
         echo '********************************************************************'
-        echo ''
+        echo
 
         # Startup env
         startup_the_env $1

--- a/utilities/openemr-env-installer/openemr-env-installer
+++ b/utilities/openemr-env-installer/openemr-env-installer
@@ -14,8 +14,7 @@ github_account=$2       # github account
 # Installation: git --> docker --> docker-compose --> openemr-cmd --> minikube
 # Run as root for centos/rhel/fedora
 script_run_as_root(){
-    if [ "${UID}" -ne 0 ]
-    then
+    if [ "${UID}" -ne 0 ]; then
         echo 'Please run with the root user.'
         exit
     fi
@@ -25,30 +24,28 @@ script_run_as_root(){
 install_git() {
     # Check the os distribution ubuntu/debian/rhel/fedora/centos
     os_distribution=$(grep ^HOME_URL /etc/os-release| awk -F'[/.]' '{print $(NF-2)}')
-    which git &>/dev/null
-    if [ $? -ne 0 ]
-    then
-        echo -e "\033[30m===>\033[0m \033[32mInstalling git... \033[0m"
-        echo ''
-        case "${os_distribution}" in
-            ubuntu|debian)
-                sudo apt-get update -y
-                sudo apt-get install git -y
-                ;;
-            redhat|centos)
-                yum install git -y
-                ;;
-            fedoraproject)
-                dnf update -y
-                dnf install git -y
-                ;;
-        esac
-        [ $? -ne 0 ] && echo '' && echo -e "\e[31mInstalled failed, please check the repo list and the network.\e[0m" && exit
-        echo ''
-    else
+    if command -v git &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mGit is already installed. \033[0m"
         echo ''
+        return
     fi
+    echo -e "\033[30m===>\033[0m \033[32mInstalling git... \033[0m"
+    echo ''
+    case "${os_distribution}" in
+        ubuntu|debian)
+            sudo apt-get update -y
+            sudo apt-get install git -y
+            ;;
+        redhat|centos)
+            yum install git -y
+            ;;
+        fedoraproject)
+            dnf update -y
+            dnf install git -y
+            ;;
+    esac
+    [ $? -ne 0 ] && echo '' && echo -e "\e[31mInstalled failed, please check the repo list and the network.\e[0m" && exit
+    echo ''
 }
 
 # The script usage
@@ -107,16 +104,13 @@ code_dir_exist_or_not() {
     code_location=$1
     github_account=$2
     # Create the code location if not exist
-    if [ ! -d ${code_location} ]
-    then
+    if [ ! -d ${code_location} ]; then
         mkdir -p ${code_location}
         git_clone_function $1 $2
         # It already downloaded if openemr dir exsit
-    elif [ ! -d ${code_location}/openemr ]
-    then
+    elif [ ! -d ${code_location}/openemr ]; then
         git_clone_function $1 $2
-    elif [ ! -d ${code_location}/openemr-devops ]
-    then
+    elif [ ! -d ${code_location}/openemr-devops ]; then
         git_clone_function $1 $2
     else
         echo -e "\033[30m===>\033[0m \033[32mOpenEMR repos are already downloaded. \033[0m"
@@ -140,37 +134,30 @@ rhel_register_check_and_enable_repo() {
     register_lock=/tmp/openemr-register-lock
     repo_lock=/tmp/openemr-repo-lock
     # Due to subscription-manager check very slow, so add a lock file to check
-    if [ ! -f ${register_lock} ]
-    then
+    if [ ! -f ${register_lock} ]; then
         subscription-manager status | grep Current &>/dev/null
-        if [ $? -eq 0 ]
-        then
+        if [ $? -eq 0 ]; then
             echo 0 > ${register_lock}
         else
             echo 1 > ${register_lock}
             register_note
         fi
-    elif [ -f ${register_lock} ]
-    then
-        if [ "$(cat /tmp/openemr-register-lock)" = "1" ]
-        then
+    elif [ -f ${register_lock} ]; then
+        if [ "$(cat /tmp/openemr-register-lock)" = "1" ]; then
             register_note
         fi
     fi
 
     # Attach the necessary repo
-    if [ ! -f ${repo_lock} ]
-    then
+    if [ ! -f ${repo_lock} ]; then
         echo -e "\033[30m===>\033[0m \033[32mEnabling base and extras repo... \033[0m"
         echo ''
         subscription-manager repos --enable rhel-7-server-rpms &>/dev/null
         [ $? -eq 0 ] && echo 1 >  ${repo_lock}
         subscription-manager repos --enable rhel-7-server-extras-rpms &>/dev/null
         [ $? -eq 0 ] && echo 2 >> ${repo_lock}
-    elif [ -f ${repo_lock} ]
-    then
-        if [ "$(cat /tmp/openemr-repo-lock|wc -l)" = "2" ]
-        then
+    elif [ -f ${repo_lock} ]; then
+        if [ "$(cat /tmp/openemr-repo-lock|wc -l)" = "2" ]; then
             echo -e "\033[30m===>\033[0m \033[32mBoth of base and extras repo are already enabled. \033[0m"
             echo ''
         fi
@@ -188,8 +175,7 @@ install_docker() {
     os_distribution=$(grep ^HOME_URL /etc/os-release| awk -F'[/.]' '{print $(NF-2)}')
     # Check docker service status if do not install or not startup
     sudo systemctl start docker &>/dev/null
-    if [ $? -ne 0 ]
-    then
+    if [ $? -ne 0 ]; then
         case "${os_distribution}" in
             ubuntu|debian)
                 echo -e "\033[30m===>\033[0m \033[32mUpdate the apt package index and install packages to allow apt to use a repository over HTTPS... \033[0m"
@@ -252,64 +238,56 @@ install_docker() {
 
 # install docker-compose tool
 install_docker_compose() {
-    which docker-compose &>/dev/null
-    if [ $? -ne 0 ]
-    then
-        echo -e "\033[30m===>\033[0m \033[32mInstalling docker-compose... \033[0m"
-        echo ''
-        # Run sudo under root mode that is also fine e.g. rhel/fedora/centos
-        sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-        sudo chmod +x /usr/local/bin/docker-compose
-        echo ''
-    else
+    if command -v docker-compose &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mDocker-compose is already installed. \033[0m"
         echo ''
+        return
     fi
+    echo -e "\033[30m===>\033[0m \033[32mInstalling docker-compose... \033[0m"
+    echo ''
+    # Run sudo under root mode that is also fine e.g. rhel/fedora/centos
+    sudo curl -L "https://github.com/docker/compose/releases/download/1.26.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    sudo chmod +x /usr/local/bin/docker-compose
+    echo ''
 }
 
 # Install openemr-cmd tool
 install_openemr_cmd() {
     os_type=$(uname)
-    if [ "${os_type}" = "Linux" ]
-    then
+    if [ "${os_type}" = "Linux" ]; then
         os_distribution=$(grep ^HOME_URL /etc/os-release| awk -F'[/.]' '{print $(NF-2)}')
     else
         os_distribution=$(uname)
     fi
 
-    which openemr-cmd &>/dev/null
-    if [ $? -ne 0 ]
-    then
-        echo -e "\033[30m===>\033[0m \033[32mInstalling openemr-cmd... \033[0m"
-        echo ''
-        case "${os_distribution}" in
-            ubuntu|debian)
-                sudo curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
-                sudo chmod +x /usr/local/bin/openemr-cmd
-                echo ''
-                ;;
-            *)
-                # It requests a password if run sudo in macOS, so try without sudo
-                curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
-                chmod +x /usr/local/bin/openemr-cmd
-                echo ''
-                ;;
-        esac
-        echo ''
-    else
+    if command -v openemr-cmd &>/dev/null; then
         echo -e "\033[30m===>\033[0m \033[32mOpenEMR-cmd is already installed. \033[0m"
         echo ''
+        return
     fi
+    echo -e "\033[30m===>\033[0m \033[32mInstalling openemr-cmd... \033[0m"
+    echo ''
+    case "${os_distribution}" in
+        ubuntu|debian)
+            sudo curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
+            sudo chmod +x /usr/local/bin/openemr-cmd
+            echo ''
+            ;;
+        *)
+            # It requests a password if run sudo in macOS, so try without sudo
+            curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-cmd/openemr-cmd -o /usr/local/bin/openemr-cmd
+            chmod +x /usr/local/bin/openemr-cmd
+            echo ''
+            ;;
+    esac
+    echo ''
 }
 
 # Install command check
 install_cmd_chk(){
-    which install &>/dev/null
-    if [ $? -ne 0 ]
-    then
-        echo -e "\033[33mNOTE: Please make sure you have installed coreutils package at first.\033[0m"
-        exit
-    fi
+    command -v install &>/dev/null && return
+    echo -e "\033[33mNOTE: Please make sure you have installed coreutils package at first.\033[0m"
+    exit
 }
 
 # Run minikube cmd to startup cluster tip
@@ -343,17 +321,18 @@ install_conntrack() {
 # Install minikube and kubectl
 install_minikube_kubectl(){
     # Judge the os type e.g. Linux or MacOS
-    if [ "${os_type}" = "Linux" ]
-    then
+    if [ "${os_type}" = "Linux" ]; then
         minikube_os=linux
-    elif [ "${os_type}" = "Darwin" ]
-    then
+    elif [ "${os_type}" = "Darwin" ]; then
         minikube_os=darwin
     fi
     # Install minikube
-    which minikube &>/dev/null
-    if [ $? -ne 0 ]
-    then
+    if command -v minikube &>/dev/null; then
+        echo -e "\033[30m===>\033[0m \033[32mMinikube is already installed. \033[0m"
+        echo ''
+        run_cluster_tip
+        echo ''
+    else
         echo -e "\033[30m===>\033[0m \033[32mInstalling minikube... \033[0m"
         echo ''
         sudo curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-${minikube_os}-amd64
@@ -364,23 +343,16 @@ install_minikube_kubectl(){
         echo ''
         run_cluster_tip
         echo ''
-    else
-        echo -e "\033[30m===>\033[0m \033[32mMinikube is already installed. \033[0m"
-        echo ''
-        run_cluster_tip
-        echo ''
     fi
     # Install kubectl
-    which kubectl &>/dev/null
-    if [ $? -ne 0 ]
-    then
+    if command -v kubectl &>/dev/null; then
+        echo -e "\033[30m===>\033[0m \033[32mKubectl is already installed. \033[0m"
+        echo ''
+    else
         echo -e "\033[30m===>\033[0m \033[32mInstalling kubectl... \033[0m"
         echo ''
         sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/${minikube_os}/amd64/kubectl -o /usr/local/bin/kubectl
         sudo chmod +x /usr/local/bin/kubectl
-        echo ''
-    else
-        echo -e "\033[30m===>\033[0m \033[32mKubectl is already installed. \033[0m"
         echo ''
     fi
 }
@@ -428,22 +400,19 @@ startup_the_env() {
 
 # The main logic
 # Judge the os type e.g. Linux or MacOS
-if [ "${os_type}" = "Linux" ]
-then
+if [ "${os_type}" = "Linux" ]; then
     major_release=$(grep VERSION_ID /etc/os-release | awk -F'[.]' '{print $1}' | awk -F'["]' '{print $2}')
     os_distribution=$(grep ^HOME_URL /etc/os-release| awk -F'[/.]' '{print $(NF-2)}')
     case "${os_distribution}" in
         ubuntu)
-            if [ "${major_release}" -lt  "16" ]
-            then
+            if [ "${major_release}" -lt  "16" ]; then
                 echo 'The script only supports ubuntu 16.04 or later.'
                 exit
             fi
             [ $# -ne 2 ] && installer_script_usage
             ;;
         debian)
-            if [ "${major_release}" -lt  "9" ] || [ "${major_release}" -gt  "10" ]
-            then
+            if [ "${major_release}" -lt  "9" ] || [ "${major_release}" -gt  "10" ]; then
                 echo 'The script only supports debian 9 or debian 10.'
                 exit
             fi
@@ -452,8 +421,7 @@ then
         fedoraproject)
             # Due to the different format, so get the keyword again in fedora
             major_release=$(grep VERSION_ID /etc/os-release| awk -F'=' '{print $2}')
-            if [ "${major_release}" -lt "30" ] || [ "${major_release}" -gt "31" ]
-            then
+            if [ "${major_release}" -lt "30" ] || [ "${major_release}" -gt "31" ]; then
                 echo 'The script only supports fedora30 and fedora31.'
                 exit
             fi
@@ -461,8 +429,7 @@ then
             [ $# -ne 2 ] && installer_script_usage
             ;;
         redhat)
-            if [ "${major_release}" != "7" ]
-            then
+            if [ "${major_release}" != "7" ]; then
                 echo 'The script only supports rhel7.'
                 exit
             fi
@@ -471,8 +438,7 @@ then
             rhel_register_check_and_enable_repo
             ;;
         centos)
-            if [ "${major_release}" != "7" ]
-            then
+            if [ "${major_release}" != "7" ]; then
                 echo 'The script only supports centos7.'
                 exit
             fi
@@ -489,21 +455,17 @@ then
     install_minikube_kubectl
     quick_check_result
     startup_the_env $1
-elif [ "${os_type}" = "Darwin" ]
-then
+elif [ "${os_type}" = "Darwin" ]; then
     # For MacOS
     # Check the macOS version
     major_release=$(sw_vers -productVersion| awk -F'.' '{print $1}')
 
-    if [ "${major_release}" -lt "10" ]
-    then
+    if [ "${major_release}" -lt "10" ]; then
         echo 'The script only supports macOS10.13 and later.'
         exit
-    elif [ "${major_release}" -eq "10" ]
-    then
+    elif [ "${major_release}" -eq "10" ]; then
         minor_release=$(sw_vers -productVersion| awk -F'.' '{print $2}')
-        if [ "${minor_release}" -lt "13" ]
-        then
+        if [ "${minor_release}" -lt "13" ]; then
             echo 'The script only supports macOS10.13 and later.'
             exit
         fi
@@ -515,27 +477,23 @@ then
 
         # Install brew
         # Homebrew info: https://brew.sh
-        which brew &>/dev/null
-        if [ $? -ne 0 ]
-        then
-            echo -e "\033[30m===>\033[0m \033[32mInstalling Homebrew... \033[0m"
-            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+        if command -v brew &>/dev/null; then
+            echo -e "\033[30m===>\033[0m \033[32mHomebrew is already installed. \033[0m"
             echo ''
         else
-            echo -e "\033[30m===>\033[0m \033[32mHomebrew is already installed. \033[0m"
+            echo -e "\033[30m===>\033[0m \033[32mInstalling Homebrew... \033[0m"
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
             echo ''
         fi
 
         # Install git
-        which git &>/dev/null
-        if [ $? -ne 0 ]
-        then
+        if command -v git &>/dev/null; then
+            echo -e "\033[30m===>\033[0m \033[32mGit is already installed. \033[0m"
+            echo ''
+        else
             echo -e "\033[30m===>\033[0m \033[32mInstalling git... \033[0m"
             brew install git
             [ $? -ne 0 ] && echo '' && echo -e "\e[31mInstalled failed, please check the network.\e[0m" && exit
-            echo ''
-        else
-            echo -e "\033[30m===>\033[0m \033[32mGit is already installed. \033[0m"
             echo ''
         fi
 
@@ -543,9 +501,10 @@ then
         code_dir_exist_or_not $1 $2
 
         # Install docker
-        which docker &>/dev/null
-        if [ $? -ne 0 ]
-        then
+        if command -v docker &>/dev/null; then
+            echo -e "\033[30m===>\033[0m \033[32mDocker is already installed. \033[0m"
+            echo ''
+        else
             echo -e "\033[30m===>\033[0m \033[32mInstalling docker... \033[0m"
             echo ''
             brew cask install docker
@@ -556,14 +515,10 @@ then
             while true
             do
                 read -p "Please enter [yes|y] to continue if you already permitted the docker access: " CONFIRM_PERMIT
-                if [ "${CONFIRM_PERMIT}" = "yes" ] || [ "${CONFIRM_PERMIT}" = "y" ]
-                then
+                if [ "${CONFIRM_PERMIT}" = "yes" ] || [ "${CONFIRM_PERMIT}" = "y" ]; then
                     break
                 fi
             done
-            echo ''
-        else
-            echo -e "\033[30m===>\033[0m \033[32mDocker is already installed. \033[0m"
             echo ''
         fi
 

--- a/utilities/openemr-env-migrator/openemr-env-migrator
+++ b/utilities/openemr-env-migrator/openemr-env-migrator
@@ -68,8 +68,7 @@ set_daemon_json_file() {
     migrate_target_dir=$1
     echo -e "\033[30m===>\033[0m \033[32mSetting daemon.json file... \033[0m"
     echo
-    if [ ! -f /etc/docker/daemon.json ]
-    then
+    if [ ! -f /etc/docker/daemon.json ]; then
         cat << EOF > /etc/docker/daemon.json
 {
     "data-root": "${migrate_target_dir}"
@@ -77,8 +76,7 @@ set_daemon_json_file() {
 EOF
 else
     grep data-root /etc/docker/daemon.json &>/dev/null
-    if [ $? -ne 0 ]
-    then
+    if [ $? -ne 0 ]; then
         sed -i '$d' /etc/docker/daemon.json
         echo '    "data-root": "migrate"' >> /etc/docker/daemon.json
         sed -i "s#\"data-root\"\:\ \"migrate\"#\"data-root\"\: \"${migrate_target_dir}\"#g" /etc/docker/daemon.json
@@ -158,8 +156,7 @@ script_usage() {
     exit
 }
 
-if [ "${first_arg}" != "-t" ]
-then
+if [ "${first_arg}" != "-t" ]; then
     script_usage
 fi
 
@@ -207,27 +204,23 @@ done
 
 # Main logic
 # Migrate from one data dir to another dir in local
-if [ "${migrate_type}" = 'local' ]
-then
+if [ "${migrate_type}" = 'local' ]; then
     target_dir_local_check ${migrate_target_dir}
     stop_all_containers
     sync_data_dir_in_local ${migrate_source_dir} ${migrate_target_dir}
     set_daemon_json_file ${migrate_target_dir}
     start_all_containers
     # Migrate data dir from one host to remote host(first step)
-elif [ "${migrate_type}" = 'remote' ]
-then
+elif [ "${migrate_type}" = 'remote' ]; then
     target_dir_remote_check ${target_ssh_user} ${target_ip} ${migrate_target_dir}
     stop_all_containers
     sync_data_dir_to_remote ${migrate_source_dir} ${target_ssh_user} ${target_ip} ${migrate_target_dir}
     # Second step
-elif [ "${migrate_type}" = 'set' ]
-then
+elif [ "${migrate_type}" = 'set' ]; then
     set_daemon_json_file ${migrate_target_dir}
     start_all_containers
     # Migrate the single container
-elif [ "${migrate_type}" = 'single' ]
-then
+elif [ "${migrate_type}" = 'single' ]; then
     commit_and_save_container ${migrate_container_name} ${container_name} ${target_ssh_user} ${target_ip}
 else
     echo -e "\033[0m\033[31mInvalid migrate type, e.g. local, remote, set, single. \033[0m"

--- a/utilities/openemr-env-migrator/openemr-env-migrator
+++ b/utilities/openemr-env-migrator/openemr-env-migrator
@@ -8,7 +8,7 @@ target_dir_local_check() {
     migrate_target_dir=$1
     echo -e "\033[30m===>\033[0m \033[32mChecking the target dir... \033[0m"
     [ ! -d "${migrate_target_dir}" ] && mkdir ${migrate_target_dir} -p
-    echo ''
+    echo
 }
 
 # For the remote host env
@@ -17,9 +17,9 @@ target_dir_remote_check() {
     target_ip=$2
     migrate_target_dir=$3
     echo -e "\033[30m===>\033[0m \033[32mChecking the target dir... \033[0m"
-    echo ''
+    echo
     ssh ${target_ssh_user}@${target_ip} "mkdir ${migrate_target_dir} -p"
-    echo ''
+    echo
 }
 
 # Stop the container at first
@@ -30,13 +30,13 @@ stop_all_containers() {
     do
         docker stop ${cn}
     done
-    echo ''
+    echo
 }
 
 # Confirm rsync whether exist
 rsync_check() {
     echo -e "\033[30m===>\033[0m \033[32mSyncing data to target dir... \033[0m"
-    echo ''
+    echo
     command -v rsync &>/dev/null && return
     echo 'Please install rsync first.'
     exit
@@ -49,7 +49,7 @@ sync_data_dir_in_local() {
     migrate_source_dir=$1
     migrate_target_dir=$2
     rsync -avz ${migrate_source_dir} ${migrate_target_dir}
-    echo ''
+    echo
 }
 
 # Sync the data to remote
@@ -60,14 +60,14 @@ sync_data_dir_to_remote() {
     target_ip=$3
     migrate_target_dir=$4
     rsync -avz ${migrate_source_dir} ${target_ssh_user}@${target_ip}:${migrate_target_dir}
-    echo ''
+    echo
 }
 
 # Set the daemon.json file for the data location
 set_daemon_json_file() {
     migrate_target_dir=$1
     echo -e "\033[30m===>\033[0m \033[32mSetting daemon.json file... \033[0m"
-    echo ''
+    echo
     if [ ! -f /etc/docker/daemon.json ]
     then
         cat << EOF > /etc/docker/daemon.json
@@ -94,12 +94,12 @@ start_all_containers() {
     sudo systemctl restart docker
     container_name=$(docker ps -a | awk '{print $NF}'|grep -v NAMES)
     echo -e "\033[30m===>\033[0m \033[32mStarting the container... \033[0m"
-    echo ''
+    echo
     for cn in "${container_name}"
     do
         docker start ${cn}
     done
-    echo ''
+    echo
 }
 
 # Migrate single container
@@ -112,21 +112,21 @@ commit_and_save_container(){
     echo -e "\033[30m===>\033[0m \033[32mCommit and save the image... \033[0m"
     docker commit ${migrate_container_name} ${container_name}  &>/dev/null
     docker save -o /tmp/${container_name}.tar ${container_name}
-    echo ''
+    echo
     echo -e "\033[30m===>\033[0m \033[32mMoving to the target host... \033[0m"
-    echo ''
+    echo
     # Move the tar file to remote host
     if ! command -v scp &>/dev/null; then
         echo 'Please check openssh-clients install or not.'
         exit 1
     fi
     scp /tmp/${container_name}.tar ${ssh_user}@${target_host}:/tmp
-    echo ''
+    echo
     # Load an image from a tar archive in the remote host
     echo -e "\033[30m===>\033[0m \033[32mLoaing the image... \033[0m"
-    echo ''
+    echo
     ssh ${ssh_user}@${target_host} "docker load -i /tmp/${container_name}.tar"
-    echo ''
+    echo
     echo "Please try to run the image in target host."
     # Clean the tar file after scp
     rm -f /tmp/${container_name}.tar
@@ -142,7 +142,7 @@ script_usage() {
     echo "    -h,      Specify the target host ip."
     echo "    -m,      Specify the migration source container."
     echo "    -n,      Specify the migration new container name."
-    echo ''
+    echo
     echo -e "\033[0m\033[36mMigrate all the containers: \033[0m"
     echo -e " \033[0m\033[33m Scenario one: Migrate in local.\033[0m"
     echo "   e.g. $(basename $0) -t local -s /var/lib/docker/ -d /data/docker/"
@@ -151,10 +151,10 @@ script_usage() {
     echo -e "   \033[0m\033[32mSecond step in remote:\033[0m  $(basename $0) -t set -d /data/docker/"
     echo -e "\033[0m\033[35m  **NOTE-1**: Do not forget the last slash of source dir, e.g. /var/lib/docker/ \033[0m"
     echo -e "\033[0m\033[35m  **NOTE-2**: Please make sure there is the same source code dir in the remote host for easy or insane env and setup the base container services. \033[0m"
-    echo ''
+    echo
     echo -e "\033[0m\033[36mMigrate the single container: \033[0m"
     echo "   e.g. $(basename $0) -t single -m  brave_snyder -n http -u testuser -h 192.168.117.117"
-    echo ''
+    echo
     exit
 }
 
@@ -198,7 +198,7 @@ do
         \?)
             opt=${OPTARG}
             echo -e "\033[0m\033[31mInvalid option: -${opt}.\033[0m"
-            echo ''
+            echo
             script_usage
             exit
             ;;
@@ -231,7 +231,7 @@ then
     commit_and_save_container ${migrate_container_name} ${container_name} ${target_ssh_user} ${target_ip}
 else
     echo -e "\033[0m\033[31mInvalid migrate type, e.g. local, remote, set, single. \033[0m"
-    echo ''
+    echo
     script_usage
     exit
 fi

--- a/utilities/openemr-env-migrator/openemr-env-migrator
+++ b/utilities/openemr-env-migrator/openemr-env-migrator
@@ -37,8 +37,9 @@ stop_all_containers() {
 rsync_check() {
     echo -e "\033[30m===>\033[0m \033[32mSyncing data to target dir... \033[0m"
     echo ''
-    which rsync &>/dev/null
-    [ $? -ne 0 ] && echo "Please install rsync first." && exit
+    command -v rsync &>/dev/null && return
+    echo 'Please install rsync first.'
+    exit
 }
 
 # Sync the data local
@@ -115,8 +116,10 @@ commit_and_save_container(){
     echo -e "\033[30m===>\033[0m \033[32mMoving to the target host... \033[0m"
     echo ''
     # Move the tar file to remote host
-    which scp &>/dev/null
-    [ $? -ne 0 ] && echo "Please check openssh-clients install or not." && exit
+    if ! command -v scp &>/dev/null; then
+        echo 'Please check openssh-clients install or not.'
+        exit 1
+    fi
     scp /tmp/${container_name}.tar ${ssh_user}@${target_host}:/tmp
     echo ''
     # Load an image from a tar archive in the remote host

--- a/utilities/openemr-monitor/monitor-installer
+++ b/utilities/openemr-monitor/monitor-installer
@@ -24,8 +24,7 @@ fi
 
 # Modify the ip and mail setting for the yml files
 ARG_CODE=13
-if [ $# -ne 6 ]
-then
+if [ $# -ne 6 ]; then
     echo "Usage: bash $(basename $0) <install dir> <host ip> <smtp server:port> <mail sender> <sender password> <receiver>"
     echo 'e.g.'
     echo "bash $(basename $0) /home/openemr-monitor 192.168.2.111 smtp.gmail.com:587 monitor@gmail.com pass12 test@gmail.com"

--- a/utilities/openemr-monitor/monitor-installer
+++ b/utilities/openemr-monitor/monitor-installer
@@ -35,11 +35,11 @@ fi
 # Install location
 [ ! -d "${installDir}" ] && mkdir ${installDir}/grafana/provisioning/{dashboards,datasources} -p
 mkdir ${installDir}/prometheus -p
-echo '    '
+echo
 
 # Download the yml files
 echo 'Downloading the configuration files...'
-echo '    '
+echo
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/prometheus.yml  > ${installDir}/prometheus/prometheus.yml
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/alert-rules.yml > ${installDir}/prometheus/alert-rules.yml
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/alertmanager.yml           > ${installDir}/alertmanager.yml
@@ -47,7 +47,7 @@ curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilitie
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard-193.json > ${installDir}/grafana/provisioning/dashboards/dashboard-193.json
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard.yml > ${installDir}/grafana/provisioning/dashboards/dashboard.yml
 curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/datasources/datasource.yml > ${installDir}/grafana/provisioning/datasources/datasource.yml
-echo '    '
+echo
 
 # Input Host ip
 sed -i "s/hostIp/${hostIp}/g" ${installDir}/prometheus/prometheus.yml
@@ -68,14 +68,14 @@ sed -i "s/receiverEmail/${receiverEmail}/g" ${installDir}/alertmanager.yml
 echo '******************************Check the Modification******************************'
 echo "Setting in ${installDir}/prometheus/prometheus.yml file."
 egrep "3001|3002|3003" ${installDir}/prometheus/prometheus.yml
-echo '    '
+echo
 echo "Setting in ${installDir}/grafana/provisioning/datasources/datasource.yml file."
 grep url ${installDir}/grafana/provisioning/datasources/datasource.yml
-echo '    '
+echo
 echo "Setting in ${installDir}/alertmanager.yml file."
 egrep 'smtp|to' ${installDir}/alertmanager.yml
 echo '**********************************************************************************'
-echo ''
+echo
 echo '=======================Startup========================'
 echo 'Please run below commands to startup the monitor env:'
 echo "cd ${installDir} && docker-compose up"

--- a/utilities/openemr-monitor/monitor-installer
+++ b/utilities/openemr-monitor/monitor-installer
@@ -11,16 +11,13 @@ receiverEmail=$6
 DOCKER_CODE=10
 DOCKER_START=11
 DOCKER_COMPOSE_CODE=12
-if ! which docker &>/dev/null
-then
-    echo "Please check docker and docker-compose install or not."
+if ! command -v docker &>/dev/null; then
+    echo 'Please check docker and docker-compose install or not.'
     exit ${DOCKER_CODE}
-elif ! which docker-compose &>/dev/null
-then
-    echo "Please check docker-compose install or not."
+elif ! command -v docker-compose &>/dev/null; then
+    echo 'Please check docker-compose install or not.'
     exit ${DOCKER_COMPOSE_CODE}
-elif [ $(ps aux|grep dockerd|grep -v grep|wc -l) -ne 1 ]
-then
+elif [ $(ps aux|grep dockerd|grep -v grep|wc -l) -ne 1 ]; then
     echo "Please check doceker start or not."
     exit ${DOCKER_START}
 fi


### PR DESCRIPTION
Fixes SC2230

#### Short description of what this resolves:

Prefer POSIX-standard `command -v` to tell if a command is installed and on the path, rather than `which`.


#### Changes proposed in this pull request:

- fix(SC2230): avoid `which` in shell
- fix(shell): remove empty strings after echo
- fix(shell): `then` on same line as `if`
