### PR TITLE
fix(shell): quote variables for SC2086/SC2248/SC2046

### DIFF
--- a/docker/openemr/7.0.4/openemr.sh
+++ b/docker/openemr/7.0.4/openemr.sh
@@ -29,7 +29,7 @@ auto_setup() {
 
     #create temporary file cache directory for auto_configure.php to use
     TMP_FILE_CACHE_LOCATION="/tmp/php-file-cache"
-    mkdir ${TMP_FILE_CACHE_LOCATION}
+    mkdir "${TMP_FILE_CACHE_LOCATION}"
 
     #create auto_configure.ini to be able to leverage opcache for operations
     touch auto_configure.ini
@@ -42,10 +42,11 @@ auto_setup() {
     echo "opcache.max_accelerated_files=1000000" >> auto_configure.ini
 
     #run auto_configure
+    # shellcheck disable=SC2086 # CONFIGURATION intentionally word-splits into multiple -f flags (see openemr/openemr-devops#539)
     php auto_configure.php -c auto_configure.ini -f ${CONFIGURATION} || return 1
 
     #remove temporary file cache directory and auto_configure.ini
-    rm -r ${TMP_FILE_CACHE_LOCATION}
+    rm -r "${TMP_FILE_CACHE_LOCATION}"
     rm auto_configure.ini
 
     echo "OpenEMR configured."
@@ -246,12 +247,12 @@ if
         while [ "${c}" -le "${DOCKER_VERSION_ROOT}" ]; do
             if [ "${c}" -gt "${DOCKER_VERSION_SITES}" ] ; then
                 echo "Start: Processing fsupgrade-${c}.sh upgrade script"
-                sh /root/fsupgrade-${c}.sh
+                sh /root/fsupgrade-"${c}".sh
                 echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             fi
             c=$(( c + 1 ))
         done
-        echo -n ${DOCKER_VERSION_ROOT} > /var/www/localhost/htdocs/openemr/sites/default/docker-version
+        echo -n "${DOCKER_VERSION_ROOT}" > /var/www/localhost/htdocs/openemr/sites/default/docker-version
         echo "Completed upgrade"
     fi
 fi
@@ -269,8 +270,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
     #    version 5.3.7 .
     if [ "${PHPREDIS_BUILD}" != "" ]; then
       apk update
-      apk del --no-cache php${PHP_VERSION_ABBR}-redis
-      apk add --no-cache git php${PHP_VERSION_ABBR}-dev php${PHP_VERSION_ABBR}-pecl-igbinary gcc make g++
+      apk del --no-cache php"${PHP_VERSION_ABBR}"-redis
+      apk add --no-cache git php"${PHP_VERSION_ABBR}"-dev php"${PHP_VERSION_ABBR}"-pecl-igbinary gcc make g++
       mkdir /tmpredis
       cd /tmpredis
       git clone https://github.com/phpredis/phpredis.git
@@ -282,11 +283,11 @@ if [ "${REDIS_SERVER}" != "" ] &&
       phpize83
       # note for php 8.3, needed to change from './configure --enable-redis-igbinary' to:
       ./configure --with-php-config=/usr/bin/php-config83 --enable-redis-igbinary
-      make -j $(nproc --all)
+      make -j "$(nproc --all)"
       make install
-      echo "extension=redis" > /etc/php${PHP_VERSION_ABBR}/conf.d/20_redis.ini
+      echo "extension=redis" > /etc/php"${PHP_VERSION_ABBR}"/conf.d/20_redis.ini
       rm -fr /tmpredis/phpredis
-      apk del --no-cache git php${PHP_VERSION_ABBR}-dev gcc make g++
+      apk del --no-cache git php"${PHP_VERSION_ABBR}"-dev gcc make g++
       cd /var/www/localhost/htdocs/openemr
     fi
 
@@ -436,14 +437,14 @@ if [ "${XDEBUG_IDE_KEY}" != "" ] ||
    sh xdebug.sh
    #also need to turn off opcache since it can not be turned on with xdebug
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.enable=0" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      echo "opcache.enable=0" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
       touch /etc/php-opcache-jit-configured
    fi
 else
    # Configure opcache jit if Xdebug is not being used (note opcache is already on, so just need to add setting(s) to php.ini that are different from the default setting(s))
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.jit=tracing" >> /etc/php${PHP_VERSION_ABBR}/php.ini
-      echo "opcache.jit_buffer_size=100M" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      echo "opcache.jit=tracing" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      echo "opcache.jit_buffer_size=100M" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
       touch /etc/php-opcache-jit-configured
    fi
 fi

--- a/docker/openemr/7.0.4/ssl.sh
+++ b/docker/openemr/7.0.4/ssl.sh
@@ -33,10 +33,11 @@ if [ "${DOMAIN}" != "" ]; then
     fi
     # if a domain has been set, set up LE and target those certs
 
-    if ! [ -f /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then
+    if ! [ -f /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem ]; then
         /usr/sbin/httpd -k start
         sleep 2
-        certbot certonly --webroot -n -w /var/www/localhost/htdocs/openemr/ -d ${DOMAIN} ${EMAIL} --agree-tos
+        # shellcheck disable=SC2086 # EMAIL intentionally word-splits to pass "-m address" as separate args
+        certbot certonly --webroot -n -w /var/www/localhost/htdocs/openemr/ -d "${DOMAIN}" ${EMAIL} --agree-tos
         /usr/sbin/httpd -k stop
         echo "1 23  *   *   *   certbot renew -q --post-hook \"httpd -k graceful\"" >> /etc/crontabs/root
     fi
@@ -45,8 +46,8 @@ if [ "${DOMAIN}" != "" ]; then
     if [ ! -f /etc/ssl/docker-letsencrypt-configured ]; then
         rm -f /etc/ssl/certs/webserver.cert.pem
         rm -f /etc/ssl/private/webserver.key.pem
-        ln -s /etc/letsencrypt/live/${DOMAIN}/fullchain.pem /etc/ssl/certs/webserver.cert.pem
-        ln -s /etc/letsencrypt/live/${DOMAIN}/privkey.pem /etc/ssl/private/webserver.key.pem
+        ln -s /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/ssl/certs/webserver.cert.pem
+        ln -s /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/ssl/private/webserver.key.pem
         touch /etc/ssl/docker-letsencrypt-configured
     fi
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
@@ -11,82 +11,57 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d ${dir}/era ]; then
-        if [ "$(ls ${dir}/era)" ]; then
-            mv -f ${dir}/era/* ${dir}/documents/era/
+    if [ -d "${dir}"/era ]; then
+        if [ "$(ls "${dir}"/era)" ]; then
+            mv -f "${dir}"/era/* "${dir}"/documents/era/
         fi
-        rm -rf ${dir}/era
+        rm -rf "${dir}"/era
     fi
-    if [ -d ${dir}/edi ]; then
-        if [ "$(ls ${dir}/edi)" ]; then
-            mv -f ${dir}/edi/* ${dir}/documents/edi/
+    if [ -d "${dir}"/edi ]; then
+        if [ "$(ls "${dir}"/edi)" ]; then
+            mv -f "${dir}"/edi/* "${dir}"/documents/edi/
         fi
-        rm -rf ${dir}/edi
+        rm -rf "${dir}"/edi
     fi
-    if [ -d ${dir}/letter_templates ]; then
-        if [ "$(ls ${dir}/letter_templates)" ]; then
-            if [ -f ${dir}/letter_templates/custom_pdf.php ]; then
-                mv -f ${dir}/letter_templates/custom_pdf.php ${dir}/
+    if [ -d "${dir}"/letter_templates ]; then
+        if [ "$(ls "${dir}"/letter_templates)" ]; then
+            if [ -f "${dir}"/letter_templates/custom_pdf.php ]; then
+                mv -f "${dir}"/letter_templates/custom_pdf.php "${dir}"/
             fi
-            mv -f ${dir}/letter_templates/* ${dir}/documents/letter_templates/
+            mv -f "${dir}"/letter_templates/* "${dir}"/documents/letter_templates/
         fi
-        rm -rf ${dir}/letter_templates
+        rm -rf "${dir}"/letter_templates
     fi
-    if [ -d ${dir}/procedure_results ]; then
-        if [ "$(ls ${dir}/procedure_results)" ]; then
-            mv -f ${dir}/procedure_results/* ${dir}/documents/procedure_results/
+    if [ -d "${dir}"/procedure_results ]; then
+        if [ "$(ls "${dir}"/procedure_results)" ]; then
+            mv -f "${dir}"/procedure_results/* "${dir}"/documents/procedure_results/
         fi
-        rm -rf ${dir}/procedure_results
+        rm -rf "${dir}"/procedure_results
     fi
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/openemr.sh
+++ b/docker/openemr/8.0.0/openemr.sh
@@ -29,7 +29,7 @@ auto_setup() {
 
     #create temporary file cache directory for auto_configure.php to use
     TMP_FILE_CACHE_LOCATION="/tmp/php-file-cache"
-    mkdir ${TMP_FILE_CACHE_LOCATION}
+    mkdir "${TMP_FILE_CACHE_LOCATION}"
 
     #create auto_configure.ini to be able to leverage opcache for operations
     touch auto_configure.ini
@@ -42,10 +42,11 @@ auto_setup() {
     echo "opcache.max_accelerated_files=1000000" >> auto_configure.ini
 
     #run auto_configure
+    # shellcheck disable=SC2086 # CONFIGURATION intentionally word-splits into multiple -f flags (see openemr/openemr-devops#539)
     php auto_configure.php -c auto_configure.ini -f ${CONFIGURATION} || return 1
 
     #remove temporary file cache directory and auto_configure.ini
-    rm -r ${TMP_FILE_CACHE_LOCATION}
+    rm -r "${TMP_FILE_CACHE_LOCATION}"
     rm auto_configure.ini
 
     echo "OpenEMR configured."
@@ -246,12 +247,12 @@ if
         while [ "${c}" -le "${DOCKER_VERSION_ROOT}" ]; do
             if [ "${c}" -gt "${DOCKER_VERSION_SITES}" ] ; then
                 echo "Start: Processing fsupgrade-${c}.sh upgrade script"
-                sh /root/fsupgrade-${c}.sh
+                sh /root/fsupgrade-"${c}".sh
                 echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             fi
             c=$(( c + 1 ))
         done
-        echo -n ${DOCKER_VERSION_ROOT} > /var/www/localhost/htdocs/openemr/sites/default/docker-version
+        echo -n "${DOCKER_VERSION_ROOT}" > /var/www/localhost/htdocs/openemr/sites/default/docker-version
         echo "Completed upgrade"
     fi
 fi
@@ -269,8 +270,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
     #    version 5.3.7 .
     if [ "${PHPREDIS_BUILD}" != "" ]; then
       apk update
-      apk del --no-cache php${PHP_VERSION_ABBR}-redis
-      apk add --no-cache git php${PHP_VERSION_ABBR}-dev php${PHP_VERSION_ABBR}-pecl-igbinary gcc make g++
+      apk del --no-cache php"${PHP_VERSION_ABBR}"-redis
+      apk add --no-cache git php"${PHP_VERSION_ABBR}"-dev php"${PHP_VERSION_ABBR}"-pecl-igbinary gcc make g++
       mkdir /tmpredis
       cd /tmpredis
       git clone https://github.com/phpredis/phpredis.git
@@ -282,11 +283,11 @@ if [ "${REDIS_SERVER}" != "" ] &&
       phpize83
       # note for php 8.3, needed to change from './configure --enable-redis-igbinary' to:
       ./configure --with-php-config=/usr/bin/php-config83 --enable-redis-igbinary
-      make -j $(nproc --all)
+      make -j "$(nproc --all)"
       make install
-      echo "extension=redis" > /etc/php${PHP_VERSION_ABBR}/conf.d/20_redis.ini
+      echo "extension=redis" > /etc/php"${PHP_VERSION_ABBR}"/conf.d/20_redis.ini
       rm -fr /tmpredis/phpredis
-      apk del --no-cache git php${PHP_VERSION_ABBR}-dev gcc make g++
+      apk del --no-cache git php"${PHP_VERSION_ABBR}"-dev gcc make g++
       cd /var/www/localhost/htdocs/openemr
     fi
 
@@ -436,14 +437,14 @@ if [ "${XDEBUG_IDE_KEY}" != "" ] ||
    sh xdebug.sh
    #also need to turn off opcache since it can not be turned on with xdebug
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.enable=0" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      echo "opcache.enable=0" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
       touch /etc/php-opcache-jit-configured
    fi
 else
    # Configure opcache jit if Xdebug is not being used (note opcache is already on, so just need to add setting(s) to php.ini that are different from the default setting(s))
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.jit=tracing" >> /etc/php${PHP_VERSION_ABBR}/php.ini
-      echo "opcache.jit_buffer_size=100M" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      echo "opcache.jit=tracing" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      echo "opcache.jit_buffer_size=100M" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
       touch /etc/php-opcache-jit-configured
    fi
 fi

--- a/docker/openemr/8.0.0/ssl.sh
+++ b/docker/openemr/8.0.0/ssl.sh
@@ -33,10 +33,11 @@ if [ "${DOMAIN}" != "" ]; then
     fi
     # if a domain has been set, set up LE and target those certs
 
-    if ! [ -f /etc/letsencrypt/live/${DOMAIN}/fullchain.pem ]; then
+    if ! [ -f /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem ]; then
         /usr/sbin/httpd -k start
         sleep 2
-        certbot certonly --webroot -n -w /var/www/localhost/htdocs/openemr/ -d ${DOMAIN} ${EMAIL} --agree-tos
+        # shellcheck disable=SC2086 # EMAIL intentionally word-splits to pass "-m address" as separate args
+        certbot certonly --webroot -n -w /var/www/localhost/htdocs/openemr/ -d "${DOMAIN}" ${EMAIL} --agree-tos
         /usr/sbin/httpd -k stop
         echo "1 23  *   *   *   certbot renew -q --post-hook \"httpd -k graceful\"" >> /etc/crontabs/root
     fi
@@ -45,8 +46,8 @@ if [ "${DOMAIN}" != "" ]; then
     if [ ! -f /etc/ssl/docker-letsencrypt-configured ]; then
         rm -f /etc/ssl/certs/webserver.cert.pem
         rm -f /etc/ssl/private/webserver.key.pem
-        ln -s /etc/letsencrypt/live/${DOMAIN}/fullchain.pem /etc/ssl/certs/webserver.cert.pem
-        ln -s /etc/letsencrypt/live/${DOMAIN}/privkey.pem /etc/ssl/private/webserver.key.pem
+        ln -s /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/ssl/certs/webserver.cert.pem
+        ln -s /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/ssl/private/webserver.key.pem
         touch /etc/ssl/docker-letsencrypt-configured
     fi
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
@@ -11,82 +11,57 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d ${dir}/era ]; then
-        if [ "$(ls ${dir}/era)" ]; then
-            mv -f ${dir}/era/* ${dir}/documents/era/
+    if [ -d "${dir}"/era ]; then
+        if [ "$(ls "${dir}"/era)" ]; then
+            mv -f "${dir}"/era/* "${dir}"/documents/era/
         fi
-        rm -rf ${dir}/era
+        rm -rf "${dir}"/era
     fi
-    if [ -d ${dir}/edi ]; then
-        if [ "$(ls ${dir}/edi)" ]; then
-            mv -f ${dir}/edi/* ${dir}/documents/edi/
+    if [ -d "${dir}"/edi ]; then
+        if [ "$(ls "${dir}"/edi)" ]; then
+            mv -f "${dir}"/edi/* "${dir}"/documents/edi/
         fi
-        rm -rf ${dir}/edi
+        rm -rf "${dir}"/edi
     fi
-    if [ -d ${dir}/letter_templates ]; then
-        if [ "$(ls ${dir}/letter_templates)" ]; then
-            if [ -f ${dir}/letter_templates/custom_pdf.php ]; then
-                mv -f ${dir}/letter_templates/custom_pdf.php ${dir}/
+    if [ -d "${dir}"/letter_templates ]; then
+        if [ "$(ls "${dir}"/letter_templates)" ]; then
+            if [ -f "${dir}"/letter_templates/custom_pdf.php ]; then
+                mv -f "${dir}"/letter_templates/custom_pdf.php "${dir}"/
             fi
-            mv -f ${dir}/letter_templates/* ${dir}/documents/letter_templates/
+            mv -f "${dir}"/letter_templates/* "${dir}"/documents/letter_templates/
         fi
-        rm -rf ${dir}/letter_templates
+        rm -rf "${dir}"/letter_templates
     fi
-    if [ -d ${dir}/procedure_results ]; then
-        if [ "$(ls ${dir}/procedure_results)" ]; then
-            mv -f ${dir}/procedure_results/* ${dir}/documents/procedure_results/
+    if [ -d "${dir}"/procedure_results ]; then
+        if [ "$(ls "${dir}"/procedure_results)" ]; then
+            mv -f "${dir}"/procedure_results/* "${dir}"/documents/procedure_results/
         fi
-        rm -rf ${dir}/procedure_results
+        rm -rf "${dir}"/procedure_results
     fi
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
@@ -11,51 +11,26 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
-    if [ ! -d ${dir}/documents/certificates ]; then
-        mkdir -p ${dir}/documents/certificates
-    fi
-    if [ ! -d ${dir}/documents/couchdb ]; then
-        mkdir -p ${dir}/documents/couchdb
-    fi
-    if [ ! -d ${dir}/documents/custom_menus/patient_menus ]; then
-        mkdir -p ${dir}/documents/custom_menus/patient_menus
-    fi
-    if [ ! -d ${dir}/documents/edi ]; then
-        mkdir -p ${dir}/documents/edi
-    fi
-    if [ ! -d ${dir}/documents/era ]; then
-        mkdir -p ${dir}/documents/era
-    fi
-    if [ ! -d ${dir}/documents/letter_templates ]; then
-        mkdir -p ${dir}/documents/letter_templates
-    fi
-    if [ ! -d ${dir}/documents/logs_and_misc/methods ]; then
-        mkdir -p ${dir}/documents/logs_and_misc/methods
-    fi
-    if [ ! -d ${dir}/documents/mpdf/pdf_tmp ]; then
-        mkdir -p ${dir}/documents/mpdf/pdf_tmp
-    fi
-    if [ ! -d ${dir}/documents/onsite_portal_documents/templates ]; then
-        mkdir -p ${dir}/documents/onsite_portal_documents/templates
-    fi
-    if [ ! -d ${dir}/documents/procedure_results ]; then
-        mkdir -p ${dir}/documents/procedure_results
-    fi
-    if [ ! -d ${dir}/documents/smarty/gacl ]; then
-        mkdir -p ${dir}/documents/smarty/gacl
-    fi
-    if [ ! -d ${dir}/documents/smarty/main ]; then
-        mkdir -p ${dir}/documents/smarty/main
-    fi
-    if [ ! -d ${dir}/documents/temp ]; then
-        mkdir -p ${dir}/documents/temp
-    fi
+    mkdir -p \
+        "${dir}"/documents/certificates \
+        "${dir}"/documents/couchdb \
+        "${dir}"/documents/custom_menus/patient_menus \
+        "${dir}"/documents/edi \
+        "${dir}"/documents/era \
+        "${dir}"/documents/letter_templates \
+        "${dir}"/documents/logs_and_misc/methods \
+        "${dir}"/documents/mpdf/pdf_tmp \
+        "${dir}"/documents/onsite_portal_documents/templates \
+        "${dir}"/documents/procedure_results \
+        "${dir}"/documents/smarty/gacl \
+        "${dir}"/documents/smarty/main \
+        "${dir}"/documents/temp
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr ${dir}/documents/smarty/gacl/*
-    rm -fr ${dir}/documents/smarty/main/*
+    rm -fr "${dir}"/documents/smarty/gacl/*
+    rm -fr "${dir}"/documents/smarty/main/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/packages/standard/ami/ami-build.sh
+++ b/packages/standard/ami/ami-build.sh
@@ -32,14 +32,14 @@ pip install https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-p
 ln -s /root/aws-cfn-bootstrap-latest/init/ubuntu/cfn-hup /etc/init.d/cfn-hup
 
 # grab our Docker instance
-docker pull openemr/openemr${DOCKERLABEL}
+docker pull "openemr/openemr${DOCKERLABEL}"
 
 # get the rest of the devops repo and docker-tools
 cd /root
 if [[ ${REPOBRANCH} = master ]]; then
   git clone --single-branch https://github.com/openemr/openemr-devops.git && cd openemr-devops/packages/standard
 else
-  git clone --single-branch --branch ${REPOBRANCH} https://github.com/openemr/openemr-devops.git && cd openemr-devops/packages/standard
+  git clone --single-branch --branch "${REPOBRANCH}" https://github.com/openemr/openemr-devops.git && cd openemr-devops/packages/standard
 fi
 chmod +x ami/*.sh scripts/*.sh
 

--- a/packages/standard/ami/ami-configure.sh
+++ b/packages/standard/ami/ami-configure.sh
@@ -9,10 +9,10 @@ source /root/cloud-variables
 
 # prepare the encrypted volume CFN just added
 # this used to be in a weird ready-loop but that doesn't make any sense to me
-DVOL_SERIAL=$(echo ${DVOL} | sed s/-//)
-DVOL_DEVICE=/dev/$(lsblk -no +SERIAL | grep ${DVOL_SERIAL} | awk '{print $1}')
-mkfs -t ext4 ${DVOL_DEVICE}
-echo ${DVOL_DEVICE} /mnt/docker ext4 defaults,nofail 0 0 >> /etc/fstab
+DVOL_SERIAL=$(echo "${DVOL}" | sed s/-//)
+DVOL_DEVICE=/dev/$(lsblk -no +SERIAL | grep "${DVOL_SERIAL}" | awk '{print $1}')
+mkfs -t ext4 "${DVOL_DEVICE}"
+echo "${DVOL_DEVICE}" /mnt/docker ext4 defaults,nofail 0 0 >> /etc/fstab
 mkdir /mnt/docker
 # TODO: wait, chown? what is user 711? is that supposed to be chmod?
 chown 711 /mnt/docker
@@ -29,7 +29,7 @@ service docker start
 touch /tmp/mypass
 chmod 500 /tmp/mypass
 openssl rand -base64 32 >> /tmp/mypass
-aws s3 cp /tmp/mypass s3://${S3}/Backup/passphrase.txt --sse aws:kms --sse-kms-key-id ${KMS}
+aws s3 cp /tmp/mypass "s3://${S3}/Backup/passphrase.txt" --sse aws:kms --sse-kms-key-id "${KMS}"
 rm /tmp/mypass
 ln -s /root/openemr-devops/packages/standard/scripts/restore.sh /root/restore.sh
 

--- a/packages/standard/scripts/backup.sh
+++ b/packages/standard/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 source /root/cloud-variables
-PASSPHRASE=$(aws s3 cp s3://${S3}/Backup/passphrase.txt - --sse aws:kms --sse-kms-key-id ${KMS})
+PASSPHRASE=$(aws s3 cp "s3://${S3}/Backup/passphrase.txt" - --sse aws:kms --sse-kms-key-id "${KMS}")
 export PASSPHRASE
-duplicity --full-if-older-than 7D --include $(docker volume inspect standard_sitevolume | jq -r ".[0].Mountpoint") --exclude '**' / boto3+s3://${S3}/Backup
-duplicity remove-all-but-n-full 2 --force boto3+s3://${S3}/Backup
+duplicity --full-if-older-than 7D --include "$(docker volume inspect standard_sitevolume | jq -r ".[0].Mountpoint")" --exclude '**' / "boto3+s3://${S3}/Backup"
+duplicity remove-all-but-n-full 2 --force "boto3+s3://${S3}/Backup"

--- a/packages/standard/scripts/restore.sh
+++ b/packages/standard/scripts/restore.sh
@@ -26,11 +26,11 @@ case ${RECOVERYMODE} in
     BUCKET=${RECOVERYS3}
     ;;
   \?)
-    echo "Invalid option: -r " ${RECOVERYMODE} >&2
+    echo "Invalid option: -r " "${RECOVERYMODE}" >&2
     exit 1
     ;;
 esac
 
-PASSPHRASE=$(aws s3 cp s3://${BUCKET}/Backup/passphrase.txt - --sse aws:kms --sse-kms-key-id ${KMS})
+PASSPHRASE=$(aws s3 cp "s3://${BUCKET}/Backup/passphrase.txt" - --sse aws:kms --sse-kms-key-id "${KMS}")
 export PASSPHRASE
-duplicity --force boto3+s3://${BUCKET}/Backup /
+duplicity --force "boto3+s3://${BUCKET}/Backup" /

--- a/utilities/openemr-env-installer/openemr-env-installer
+++ b/utilities/openemr-env-installer/openemr-env-installer
@@ -64,10 +64,10 @@ install_git() {
 
 # The script usage
 installer_script_usage() {
-    echo "Usage: bash $(basename $0) <code location> <github account>"
+    echo "Usage: bash $(basename "$0") <code location> <github account>"
     echo
-    echo "  e.g. bash $(basename $0) /home/test/code testuser"
-    echo "    or bash $(basename $0) /Users/test/code testuser"
+    echo "  e.g. bash $(basename "$0") /home/test/code testuser"
+    echo "    or bash $(basename "$0") /Users/test/code testuser"
     echo
     echo -e "\033[33mNOTE1: Please make sure you have created your own fork of OpenEMR and OpenEMR-devops at first.\033[0m"
     echo -e "\033[33mNOTE2: Please make sure you have the necessary environment if use minikube:\033[0m"
@@ -115,13 +115,13 @@ code_dir_exist_or_not() {
     github_account=$2
     # Create the code location if not exist
     if [[ ! -d ${code_location} ]]; then
-        mkdir -p ${code_location}
-        git_clone_function $1 $2
+        mkdir -p "${code_location}"
+        git_clone_function "$1" "$2"
         # It already downloaded if openemr dir exsit
     elif [[ ! -d ${code_location}/openemr ]]; then
-        git_clone_function $1 $2
+        git_clone_function "$1" "$2"
     elif [[ ! -d ${code_location}/openemr-devops ]]; then
-        git_clone_function $1 $2
+        git_clone_function "$1" "$2"
     else
         echo -e "\033[30m===>\033[0m \033[32mOpenEMR repos are already downloaded. \033[0m"
         echo
@@ -147,9 +147,9 @@ rhel_register_check_and_enable_repo() {
     if [[ ! -f ${register_lock} ]]; then
         subscription_status=$(subscription-manager status)
         if grep -qF Current <<< "${subscription_status}"; then
-            echo 0 > ${register_lock}
+            echo 0 > "${register_lock}"
         else
-            echo 1 > ${register_lock}
+            echo 1 > "${register_lock}"
             register_note
         fi
     elif [[ -f ${register_lock} ]]; then
@@ -196,7 +196,7 @@ install_docker() {
                 sudo apt-get install apt-transport-https ca-certificates curl gnupg-agent software-properties-common -y
                 echo
                 echo -e "\033[30m===>\033[0m \033[32mAdding the Docker official GPG key... \033[0m"
-                gpg=$(curl -fsSL https://download.docker.com/linux/${os_distribution}/gpg)
+                gpg=$(curl -fsSL "https://download.docker.com/linux/${os_distribution}/gpg")
                 sudo apt-key add - <<< "${gpg}"
                 echo
                 echo -e "\033[30m===>\033[0m \033[32mSetting up the stable repository... \033[0m"
@@ -209,7 +209,7 @@ install_docker() {
                 sudo apt-get install docker-ce docker-ce-cli containerd.io -y
                 echo -e "\033[30m===>\033[0m \033[32mAdding your username to the docker group to avoid typing sudo whenever you run the docker command... \033[0m"
                 echo
-                sudo usermod -aG docker ${USER}
+                sudo usermod -aG docker "${USER}"
                 sudo systemctl start docker
                 sudo systemctl enable docker
                 echo
@@ -359,11 +359,11 @@ install_minikube_kubectl(){
     else
         echo -e "\033[30m===>\033[0m \033[32mInstalling minikube... \033[0m"
         echo
-        sudo curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-${minikube_os}-amd64
+        sudo curl -LO "https://storage.googleapis.com/minikube/releases/latest/minikube-${minikube_os}-amd64"
         echo
         install_cmd_chk
-        sudo install minikube-${minikube_os}-amd64 /usr/local/bin/minikube
-        sudo rm -f minikube-${minikube_os}-amd64
+        sudo install "minikube-${minikube_os}-amd64" /usr/local/bin/minikube
+        sudo rm -f "minikube-${minikube_os}-amd64"
         echo
         run_cluster_tip
         echo
@@ -375,7 +375,7 @@ install_minikube_kubectl(){
     else
         echo -e "\033[30m===>\033[0m \033[32mInstalling kubectl... \033[0m"
         echo
-        sudo curl -L https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/${minikube_os}/amd64/kubectl -o /usr/local/bin/kubectl
+        sudo curl -L "https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/${minikube_os}/amd64/kubectl" -o /usr/local/bin/kubectl
         sudo chmod +x /usr/local/bin/kubectl
         echo
     fi
@@ -477,14 +477,14 @@ if [[ "${os_type}" = "Linux" ]]; then
             ;;
     esac
     install_git
-    code_dir_exist_or_not $1 $2
+    code_dir_exist_or_not "$1" "$2"
     install_docker
     install_docker_compose
     install_openemr_cmd
     install_conntrack
     install_minikube_kubectl
     quick_check_result
-    startup_the_env $1
+    startup_the_env "$1"
 elif [[ "${os_type}" = "Darwin" ]]; then
     # For MacOS
     # Check the macOS version
@@ -535,7 +535,7 @@ elif [[ "${os_type}" = "Darwin" ]]; then
         fi
 
         # Check the code dir and git clone
-        code_dir_exist_or_not $1 $2
+        code_dir_exist_or_not "$1" "$2"
 
         # Install docker
         if command -v docker &>/dev/null; then
@@ -576,7 +576,7 @@ elif [[ "${os_type}" = "Darwin" ]]; then
         echo
 
         # Startup env
-        startup_the_env $1
+        startup_the_env "$1"
     else
         echo -e "\e[31mNot supported OS. The tool only supports Linux or Darwin(macOS).\e[0m"
         exit

--- a/utilities/openemr-env-migrator/openemr-env-migrator
+++ b/utilities/openemr-env-migrator/openemr-env-migrator
@@ -7,7 +7,7 @@ first_arg=$1
 target_dir_local_check() {
     migrate_target_dir=$1
     echo -e "\033[30m===>\033[0m \033[32mChecking the target dir... \033[0m"
-    [[ ! -d "${migrate_target_dir}" ]] && mkdir ${migrate_target_dir} -p
+    [[ ! -d "${migrate_target_dir}" ]] && mkdir "${migrate_target_dir}" -p
     echo
 }
 
@@ -46,7 +46,7 @@ sync_data_dir_in_local() {
     # For the local env
     migrate_source_dir=$1
     migrate_target_dir=$2
-    rsync -avz ${migrate_source_dir} ${migrate_target_dir}
+    rsync -avz "${migrate_source_dir}" "${migrate_target_dir}"
     echo
 }
 
@@ -57,7 +57,7 @@ sync_data_dir_to_remote() {
     target_ssh_user=$2
     target_ip=$3
     migrate_target_dir=$4
-    rsync -avz ${migrate_source_dir} ${target_ssh_user}@${target_ip}:${migrate_target_dir}
+    rsync -avz "${migrate_source_dir}" "${target_ssh_user}@${target_ip}:${migrate_target_dir}"
     echo
 }
 
@@ -101,8 +101,8 @@ commit_and_save_container(){
     target_host=$4
     # Commit a container’s file changes or settings into a new image and save to tar file
     echo -e "\033[30m===>\033[0m \033[32mCommit and save the image... \033[0m"
-    docker commit ${migrate_container_name} ${container_name}  &>/dev/null
-    docker save -o /tmp/${container_name}.tar ${container_name}
+    docker commit "${migrate_container_name}" "${container_name}"  &>/dev/null
+    docker save -o "/tmp/${container_name}.tar" "${container_name}"
     echo
     echo -e "\033[30m===>\033[0m \033[32mMoving to the target host... \033[0m"
     echo
@@ -111,7 +111,7 @@ commit_and_save_container(){
         echo 'Please check openssh-clients install or not.'
         exit 1
     fi
-    scp /tmp/${container_name}.tar ${ssh_user}@${target_host}:/tmp
+    scp "/tmp/${container_name}.tar" "${ssh_user}@${target_host}:/tmp"
     echo
     # Load an image from a tar archive in the remote host
     echo -e "\033[30m===>\033[0m \033[32mLoaing the image... \033[0m"
@@ -122,7 +122,7 @@ commit_and_save_container(){
     echo
     echo "Please try to run the image in target host."
     # Clean the tar file after scp
-    rm -f /tmp/${container_name}.tar
+    rm -f "/tmp/${container_name}.tar"
 }
 
 # Script Usage
@@ -138,15 +138,15 @@ script_usage() {
     echo
     echo -e "\033[0m\033[36mMigrate all the containers: \033[0m"
     echo -e " \033[0m\033[33m Scenario one: Migrate in local.\033[0m"
-    echo "   e.g. $(basename $0) -t local -s /var/lib/docker/ -d /data/docker/"
+    echo "   e.g. $(basename "$0") -t local -s /var/lib/docker/ -d /data/docker/"
     echo -e " \033[0m\033[33m Scenario two: Migrate to remote host.\033[0m"
-    echo -e "   \033[0m\033[32mFirst step in local:\033[0m    $(basename $0) -t remote -s /var/lib/docker/ -u testuser -h 192.168.117.117 -d /data/docker/"
-    echo -e "   \033[0m\033[32mSecond step in remote:\033[0m  $(basename $0) -t set -d /data/docker/"
+    echo -e "   \033[0m\033[32mFirst step in local:\033[0m    $(basename "$0") -t remote -s /var/lib/docker/ -u testuser -h 192.168.117.117 -d /data/docker/"
+    echo -e "   \033[0m\033[32mSecond step in remote:\033[0m  $(basename "$0") -t set -d /data/docker/"
     echo -e "\033[0m\033[35m  **NOTE-1**: Do not forget the last slash of source dir, e.g. /var/lib/docker/ \033[0m"
     echo -e "\033[0m\033[35m  **NOTE-2**: Please make sure there is the same source code dir in the remote host for easy or insane env and setup the base container services. \033[0m"
     echo
     echo -e "\033[0m\033[36mMigrate the single container: \033[0m"
-    echo "   e.g. $(basename $0) -t single -m  brave_snyder -n http -u testuser -h 192.168.117.117"
+    echo "   e.g. $(basename "$0") -t single -m  brave_snyder -n http -u testuser -h 192.168.117.117"
     echo
     exit
 }
@@ -203,23 +203,23 @@ done
 # Main logic
 # Migrate from one data dir to another dir in local
 if [[ "${migrate_type}" = 'local' ]]; then
-    target_dir_local_check ${migrate_target_dir}
+    target_dir_local_check "${migrate_target_dir}"
     stop_all_containers
-    sync_data_dir_in_local ${migrate_source_dir} ${migrate_target_dir}
-    set_daemon_json_file ${migrate_target_dir}
+    sync_data_dir_in_local "${migrate_source_dir}" "${migrate_target_dir}"
+    set_daemon_json_file "${migrate_target_dir}"
     start_all_containers
     # Migrate data dir from one host to remote host(first step)
 elif [[ "${migrate_type}" = 'remote' ]]; then
-    target_dir_remote_check ${target_ssh_user} ${target_ip} ${migrate_target_dir}
+    target_dir_remote_check "${target_ssh_user}" "${target_ip}" "${migrate_target_dir}"
     stop_all_containers
-    sync_data_dir_to_remote ${migrate_source_dir} ${target_ssh_user} ${target_ip} ${migrate_target_dir}
+    sync_data_dir_to_remote "${migrate_source_dir}" "${target_ssh_user}" "${target_ip}" "${migrate_target_dir}"
     # Second step
 elif [[ "${migrate_type}" = 'set' ]]; then
-    set_daemon_json_file ${migrate_target_dir}
+    set_daemon_json_file "${migrate_target_dir}"
     start_all_containers
     # Migrate the single container
 elif [[ "${migrate_type}" = 'single' ]]; then
-    commit_and_save_container ${migrate_container_name} ${container_name} ${target_ssh_user} ${target_ip}
+    commit_and_save_container "${migrate_container_name}" "${container_name}" "${target_ssh_user}" "${target_ip}"
 else
     echo -e "\033[0m\033[31mInvalid migrate type, e.g. local, remote, set, single. \033[0m"
     echo

--- a/utilities/openemr-monitor/monitor-installer
+++ b/utilities/openemr-monitor/monitor-installer
@@ -21,51 +21,51 @@ fi
 # Modify the ip and mail setting for the yml files
 ARG_CODE=13
 if [[ $# -ne 6 ]]; then
-    echo "Usage: bash $(basename $0) <install dir> <host ip> <smtp server:port> <mail sender> <sender password> <receiver>"
+    echo "Usage: bash $(basename "$0") <install dir> <host ip> <smtp server:port> <mail sender> <sender password> <receiver>"
     echo 'e.g.'
-    echo "bash $(basename $0) /home/openemr-monitor 192.168.2.111 smtp.gmail.com:587 monitor@gmail.com pass12 test@gmail.com"
-    exit ${ARG_CODE}
+    echo "bash $(basename "$0") /home/openemr-monitor 192.168.2.111 smtp.gmail.com:587 monitor@gmail.com pass12 test@gmail.com"
+    exit "${ARG_CODE}"
 fi
 
 # Install location
-[[ ! -d "${installDir}" ]] && mkdir ${installDir}/grafana/provisioning/{dashboards,datasources} -p
-mkdir ${installDir}/prometheus -p
+[[ ! -d "${installDir}" ]] && mkdir "${installDir}"/grafana/provisioning/{dashboards,datasources} -p
+mkdir "${installDir}"/prometheus -p
 echo
 
 # Download the yml files
 echo 'Downloading the configuration files...'
 echo
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/prometheus.yml  > ${installDir}/prometheus/prometheus.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/alert-rules.yml > ${installDir}/prometheus/alert-rules.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/alertmanager.yml           > ${installDir}/alertmanager.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/docker-compose.yml         > ${installDir}/docker-compose.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard-193.json > ${installDir}/grafana/provisioning/dashboards/dashboard-193.json
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard.yml > ${installDir}/grafana/provisioning/dashboards/dashboard.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/datasources/datasource.yml > ${installDir}/grafana/provisioning/datasources/datasource.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/prometheus.yml  > "${installDir}"/prometheus/prometheus.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/alert-rules.yml > "${installDir}"/prometheus/alert-rules.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/alertmanager.yml           > "${installDir}"/alertmanager.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/docker-compose.yml         > "${installDir}"/docker-compose.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard-193.json > "${installDir}"/grafana/provisioning/dashboards/dashboard-193.json
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard.yml > "${installDir}"/grafana/provisioning/dashboards/dashboard.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/datasources/datasource.yml > "${installDir}"/grafana/provisioning/datasources/datasource.yml
 echo
 
 # Input Host ip
-sed -i "s/hostIp/${hostIp}/g" ${installDir}/prometheus/prometheus.yml
-sed -i "s/hostIp/${hostIp}/g" ${installDir}/grafana/provisioning/datasources/datasource.yml
+sed -i "s/hostIp/${hostIp}/g" "${installDir}"/prometheus/prometheus.yml
+sed -i "s/hostIp/${hostIp}/g" "${installDir}"/grafana/provisioning/datasources/datasource.yml
 
 # Input Smtp Server
-sed -i "s/smtpServer/${smtpServer}/g" ${installDir}/alertmanager.yml
+sed -i "s/smtpServer/${smtpServer}/g" "${installDir}"/alertmanager.yml
 
 # Input the sender email
-sed -i "s/senderEmail/${senderEmail}/g" ${installDir}/alertmanager.yml
-sed -i "s/senderUsername/${senderEmail}/g" ${installDir}/alertmanager.yml
+sed -i "s/senderEmail/${senderEmail}/g" "${installDir}"/alertmanager.yml
+sed -i "s/senderUsername/${senderEmail}/g" "${installDir}"/alertmanager.yml
 
 # Input the sender email password
-sed -i "s/senderLoginPassword/${emailPassword}/g" ${installDir}/alertmanager.yml
+sed -i "s/senderLoginPassword/${emailPassword}/g" "${installDir}"/alertmanager.yml
 
 # Input the receiver email
-sed -i "s/receiverEmail/${receiverEmail}/g" ${installDir}/alertmanager.yml
+sed -i "s/receiverEmail/${receiverEmail}/g" "${installDir}"/alertmanager.yml
 echo '******************************Check the Modification******************************'
 echo "Setting in ${installDir}/prometheus/prometheus.yml file."
 grep -E "3001|3002|3003" "${installDir}/prometheus/prometheus.yml"
 echo
 echo "Setting in ${installDir}/grafana/provisioning/datasources/datasource.yml file."
-grep url ${installDir}/grafana/provisioning/datasources/datasource.yml
+grep url "${installDir}"/grafana/provisioning/datasources/datasource.yml
 echo
 echo "Setting in ${installDir}/alertmanager.yml file."
 grep -E 'smtp|to' "${installDir}/alertmanager.yml"


### PR DESCRIPTION
#### Short description of what this resolves:

Fix shellcheck SC2086, SC2248, and SC2046 (variable-quoting) findings across the shell files checked in CI. This is the first of several focused PRs chipping away at the full shellcheck backlog — remaining codes (SC2044 find-loops, SC2154 unset vars, SC2310/SC2312 set -e behavior, etc.) are queued for follow-up PRs.

After this PR, `shellcheck --include=SC2086,SC2248,SC2046` is clean on every file the CI workflow scans.

#### Changes proposed in this pull request:

- Quote variables in `docker/openemr/{7.0.4,8.0.0}/{openemr,ssl}.sh`, the `fsupgrade-*.sh` scripts, `packages/standard/{ami,scripts}/*.sh`, and the three `utilities/` installer/migrator/monitor scripts.
- Where word-splitting is intentional, add targeted per-line `# shellcheck disable=SC2086` with a reason comment:
  - `openemr.sh`: `CONFIGURATION` intentionally splits into multiple `-f` flags (see #539).
  - `ssl.sh`: `EMAIL` intentionally splits to pass `-m address` as separate args.
- In `fsupgrade-*.sh` scripts, remove redundant `if [ ! -d X ]; then mkdir -p X; fi` guards (`mkdir -p` is already idempotent) and collapse the 13 sequential `mkdir -p` calls into a single multi-arg `mkdir -p`.
- Re-sync `docker/openemr/8.0.0/upgrade/fsupgrade-{1..7}.sh` from the updated `7.0.4/` copies so the CI content-hash dedup still collapses byte-identical files.

CI's shellcheck workflow remains failing — those failures are all from SC codes queued for follow-up PRs, not from any fix in this change.

#### AI disclosure:
- [x] Yes, I used AI to help with this PR
