### PR TITLE
Fixes #461 restore openemr command path fix

### DIFF
--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -121,6 +121,7 @@ backupOpenemr() {
 
 # parameter 1 is identifier
 restoreOpenemr() (
+    cd /snapshots
     tar -C /snapshots -xzf "${1}.tgz"
     # need to empty the database before the restore database import
     mariadb-dump --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" --add-drop-table --no-data "${CUSTOM_DATABASE}" |

--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -121,7 +121,7 @@ backupOpenemr() {
 
 # parameter 1 is identifier
 restoreOpenemr() (
-    cd /snapshots
+    cd /snapshots || exit
     tar -C /snapshots -xzf "${1}.tgz"
     # need to empty the database before the restore database import
     mariadb-dump --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" --add-drop-table --no-data "${CUSTOM_DATABASE}" |


### PR DESCRIPTION
Adds back in the cd /snapshots to the restore command so that the tar extraction command successfully works.

Fixes #461 