### PR TITLE
Add in the auto_configure.php to root

### DIFF
--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -122,6 +122,8 @@ COPY utilities/devtoolsLibrary.source /root/
 RUN mkdir /snapshots
 RUN mkdir /certs
 RUN mkdir -p /couchdb/original
+#Copy auto_configure so we can do backup/restore with dev tools
+COPY auto_configure.php /root/
 #Copy demo data to root
 COPY utilities/demo_5_0_0_5.sql /root/
 RUN chmod 500 /root/devtools


### PR DESCRIPTION
The devtools for restore / backup require the auto_configure.php to be in the /root/ folder.  The auto_configure.php only gets copied to root via the openemr.sh file if its an easy dev docker setup.  However this messes up the ci installations (such as inferno) which uses the restore/backup in a non-easy dev type setup (where the codebase is not shared).

Just copying auto_configure.php to root solves that issue.

Fixes #463