### PR TITLE
feat(installer): activate with env

### DIFF
--- a/.github/actions/test-actions-core/action.yml
+++ b/.github/actions/test-actions-core/action.yml
@@ -79,7 +79,9 @@ runs:
 
     - name: Install
       run: |
-        docker compose exec --workdir /var/www/localhost/htdocs/openemr/contrib/util/installScripts \
+        docker compose exec \
+          --env OPENEMR_ENABLE_INSTALLER_AUTO=1 \
+          --workdir /var/www/localhost/htdocs/openemr/contrib/util/installScripts \
           "${OPENEMR_SERVICE_NAME}" sh -c 'sed -e "s@^exit;@ @" InstallerAuto.php |
                                            php -- rootpass=root server=mysql loginhost=%'
       shell: bash

--- a/docker/openemr/7.0.3/utilities/devtoolsLibrary.source
+++ b/docker/openemr/7.0.3/utilities/devtoolsLibrary.source
@@ -234,6 +234,9 @@ importRandomPatients() {
 # parameter 1 is number of multisites to create
 generateMultisiteBank() {
     echo "Setting up a multisite bank with following number of multisites (labeled run1, run2, run3, ...): run1...run${1}"
+    # Activate newer versions of InstallerAuto that support environment variable activation.
+    export OPENEMR_ENABLE_INSTALLER_AUTO=1
+    # Activate older versions of InstallerAuto that require `sed` activation.
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php
     a=1
     while [ ${a} -le "$1" ]

--- a/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
+++ b/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
@@ -234,6 +234,9 @@ importRandomPatients() {
 # parameter 1 is number of multisites to create
 generateMultisiteBank() {
     echo "Setting up a multisite bank with following number of multisites (labeled run1, run2, run3, ...): run1...run${1}"
+    # Activate newer versions of InstallerAuto that support environment variable activation.
+    export OPENEMR_ENABLE_INSTALLER_AUTO=1
+    # Activate older versions of InstallerAuto that require `sed` activation.
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php
     a=1
     while [ ${a} -le "$1" ]

--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -250,6 +250,9 @@ importRandomPatients() {
 # parameter 1 is number of multisites to create
 generateMultisiteBank() {
     echo "Setting up a multisite bank with following number of multisites (labeled run1, run2, run3, ...): run1...run${1}"
+    # Activate newer versions of InstallerAuto that support environment variable activation.
+    export OPENEMR_ENABLE_INSTALLER_AUTO=1
+    # Activate older versions of InstallerAuto that require `sed` activation.
     sed -i "s@exit;@//exit;@" /var/www/localhost/htdocs/openemr/contrib/util/installScripts/InstallerAuto.php
     a=1
     while [ "${a}" -le "${1}" ]; do


### PR DESCRIPTION
Fixes #468

#### Short description of what this resolves:

Activates the installer with both env var and sed


#### Changes proposed in this pull request:

- Provide the `env` way of activating the installer.
- Keep the `sed` way, too, for backwards compatibility.
