### PR TITLE
build(Dockerfile): add syntax declaration

### DIFF
--- a/docker/mysql-xtrabackup-final/Dockerfile
+++ b/docker/mysql-xtrabackup-final/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM openemr/mysql-xtrabackup:1.0.7
 
 RUN rm /root/xbackup-wrapper.sh /root/xrecovery-final.sh

--- a/docker/mysql-xtrabackup/Dockerfile
+++ b/docker/mysql-xtrabackup/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM debian:jessie
 
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added

--- a/docker/openemr/7.0.3/Dockerfile
+++ b/docker/openemr/7.0.3/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM alpine:3.20
 
 #Install dependencies and fix issue in apache

--- a/docker/openemr/7.0.4/Dockerfile
+++ b/docker/openemr/7.0.4/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 
 # Below allows easy centralized setting of alpine version
 #  (note NOT meant to use this has an actually argument in building docker like the flex series does)

--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 
 ARG ALPINE_VERSION=3.22
 FROM alpine:${ALPINE_VERSION} AS base


### PR DESCRIPTION
Fixes #471

#### Short description of what this resolves:

Adds syntax declaration to (non-obsolete) Dockerfiles


#### Changes proposed in this pull request:

- [x] Add syntax declaration to (non-obsolete) Dockerfiles
