### PR TITLE
fix(chown): exclude .git from chown

### DIFF
--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -492,8 +492,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
         echo "redis setup"
     fi
 
-    sed -i "s@session.save_handler = files@session.save_handler = redis@" /etc/php${PHP_VERSION_ABBR}/php.ini
-    sed -i 's@;session.save_path = "/tmp"@session.save_path = "'"${REDIS_PATH}"'"@"' /etc/php${PHP_VERSION_ABBR}/php.ini
+    sed -i "s@session.save_handler = files@session.save_handler = redis@" "/etc/php${PHP_VERSION_ABBR?}/php.ini"
+    sed -i 's@;session.save_path = "/tmp"@session.save_path = "'"${REDIS_PATH}"'"@"' "/etc/php${PHP_VERSION_ABBR?}/php.ini"
     # Ensure only configure this one time
     touch /etc/php-redis-configured
 fi
@@ -503,14 +503,16 @@ if [ "${XDEBUG_IDE_KEY}" != "" ] ||
    sh xdebug.sh
    #also need to turn off opcache since it can not be turned on with xdebug
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.enable=0" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      echo "opcache.enable=0" >> "/etc/php${PHP_VERSION_ABBR?}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 else
    # Configure opcache jit if Xdebug is not being used (note opcache is already on, so just need to add setting(s) to php.ini that are different from the default setting(s))
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.jit=tracing" >> /etc/php${PHP_VERSION_ABBR}/php.ini
-      echo "opcache.jit_buffer_size=100M" >> /etc/php${PHP_VERSION_ABBR}/php.ini
+      {
+        echo "opcache.jit=tracing"
+        echo "opcache.jit_buffer_size=100M"
+      } >> "/etc/php${PHP_VERSION_ABBR?}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 fi

--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -289,7 +289,7 @@ if [ "${AUTHORITY}" = "yes" ] ||
 fi
 
 if [ -f /var/www/localhost/htdocs/auto_configure.php ]; then
-    chown -R apache /var/www/localhost/htdocs/openemr/
+    find /var/www/localhost/htdocs/openemr/ -name ".git" -prune -o -exec chown apache {} \+
 fi
 
 CONFIG=$(php -r "require_once('/var/www/localhost/htdocs/openemr/sites/default/sqlconf.php'); echo \$config;")


### PR DESCRIPTION
Fixes openemr/openemr#8591

#### Short description of what this resolves:

Don't try to chmod the .git directory (or file, if a worktree)