### PR TITLE
chore: pin 7.0.3 docker build to specific tag v7_0_3_4

### DIFF
--- a/docker/openemr/7.0.3/Dockerfile
+++ b/docker/openemr/7.0.3/Dockerfile
@@ -23,7 +23,7 @@ RUN ln -sf /usr/bin/php83 /usr/bin/php
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 
 RUN apk add --no-cache git build-base \
-    && git clone https://github.com/openemr/openemr.git --branch rel-703 --depth 1 \
+    && git clone https://github.com/openemr/openemr.git --branch v7_0_3_4 --depth 1 \
     && rm -rf openemr/.git \
     && cd openemr \
     && composer install --no-dev \


### PR DESCRIPTION
chore: pin 7.0.3 docker build to specific tag v7_0_3_4