### PR TITLE
fix(dockers): Increase apache LimitRequestFieldSize to 32KB to support large number of API client scopes

### DIFF
--- a/docker/openemr/7.0.4/openemr.conf
+++ b/docker/openemr/7.0.4/openemr.conf
@@ -1,6 +1,9 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule allowmethods_module modules/mod_allowmethods.so
 
+# Allow larger HTTP header field (default: 8192 bytes) to support large number of API client scopes
+LimitRequestFieldSize 32768
+
 ## Security Options
 # Strong HTTP Protocol
 HTTPProtocolOptions Strict

--- a/docker/openemr/flex/openemr.conf
+++ b/docker/openemr/flex/openemr.conf
@@ -1,6 +1,9 @@
 LoadModule rewrite_module modules/mod_rewrite.so
 LoadModule allowmethods_module modules/mod_allowmethods.so
 
+# Allow larger HTTP header field (default: 8192 bytes) to support large number of API client scopes
+LimitRequestFieldSize 32768
+
 ## Security Options
 # Strong HTTP Protocol
 HTTPProtocolOptions Strict


### PR DESCRIPTION
Increase apache LimitRequestFieldSize to 32KB to support large number of API client scopes