### PR TITLE
fix(flex): apache log to stdio

### DIFF
--- a/docker/openemr/7.0.3/openemr.conf
+++ b/docker/openemr/7.0.3/openemr.conf
@@ -18,8 +18,9 @@ Header set X-XSS-Protection "1; mode=block"
 # Narrow document root
 DocumentRoot /var/www/localhost/htdocs/openemr
 
-ErrorLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/error.log 86400"
-CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
+# Send logs to stdout/stderr for Docker container logs while maintaining file logging
+ErrorLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/error.log 86400 >&2"
+CustomLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
 
 # These are the overrides if a virtual host does not exist.
 <Directory /var/www/localhost/htdocs/openemr>

--- a/docker/openemr/7.0.4/openemr.conf
+++ b/docker/openemr/7.0.4/openemr.conf
@@ -21,8 +21,9 @@ Header set X-XSS-Protection "1; mode=block"
 # Narrow document root
 DocumentRoot /var/www/localhost/htdocs/openemr
 
-ErrorLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/error.log 86400"
-CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
+# Send logs to stdout/stderr for Docker container logs while maintaining file logging
+ErrorLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/error.log 86400 >&2"
+CustomLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
 
 # These are the overrides if a virtual host does not exist.
 <Directory /var/www/localhost/htdocs/openemr>

--- a/docker/openemr/flex/openemr.conf
+++ b/docker/openemr/flex/openemr.conf
@@ -21,8 +21,9 @@ Header set X-XSS-Protection "1; mode=block"
 # Narrow document root
 DocumentRoot /var/www/localhost/htdocs/openemr
 
-ErrorLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/error.log 86400"
-CustomLog "|/usr/sbin/rotatelogs -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
+# Send logs to stdout/stderr for Docker container logs while maintaining file logging
+ErrorLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/error.log 86400 >&2"
+CustomLog "|/usr/sbin/rotatelogs -e -n 5 ${APACHE_LOG_DIR}/access.log 86400" combined
 
 # These are the overrides if a virtual host does not exist.
 <Directory /var/www/localhost/htdocs/openemr>


### PR DESCRIPTION
Fixes openemr/openemr#9365

#### Short description of what this resolves:

Configures apache on the flex image to log to stdout and stderr instead of logging to /var/log/apache2. This is much easier to work with in a containerized system. You can use `docker compose logs openemr` to see everything, instead of having to exec into the container to extract the logs.


#### Changes proposed in this pull request:

- change the output files to stdio for apache in the flex container
