### PR TITLE
feat(flex): add pcov support for faster code coverage

### DIFF
--- a/docker/openemr/flex/Dockerfile
+++ b/docker/openemr/flex/Dockerfile
@@ -228,9 +228,10 @@ COPY openemr.conf /etc/apache2/conf.d/
 # Copy main startup and configuration scripts
 # - openemr.sh: Main container startup script (handles setup, upgrades, Apache)
 # - ssl.sh: SSL/TLS certificate management script
-# - xdebug.sh: XDebug configuration script (for development)
+# - xdebug.sh: XDebug configuration script (for development debugging)
+# - pcov.sh: PCOV configuration script (for code coverage)
 # - auto_configure.php: Automated OpenEMR installation script
-COPY openemr.sh ssl.sh xdebug.sh auto_configure.php /var/www/localhost/htdocs/
+COPY openemr.sh ssl.sh xdebug.sh pcov.sh auto_configure.php /var/www/localhost/htdocs/
 
 # Copy admin unlock utilities (for password recovery)
 COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
@@ -238,7 +239,7 @@ COPY utilities/unlock_admin.php utilities/unlock_admin.sh /root/
 # Set script permissions:
 # - Executable scripts: 500 (read and execute for owner only)
 # - PHP scripts: 000 (no access) - prevents accidental execution until enabled
-RUN chmod 500 openemr.sh ssl.sh xdebug.sh /root/unlock_admin.sh \
+RUN chmod 500 openemr.sh ssl.sh xdebug.sh pcov.sh /root/unlock_admin.sh \
     && chmod 000 auto_configure.php /root/unlock_admin.php
 
 # ============================================================================

--- a/docker/openemr/flex/pcov.sh
+++ b/docker/openemr/flex/pcov.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ============================================================================
+# OpenEMR Flex PCOV Configuration Script
+# ============================================================================
+# This script configures PCOV for PHP code coverage collection.
+# PCOV is a lightweight alternative to XDebug specifically designed for
+# code coverage, offering significantly faster execution.
+#
+# Environment Variables:
+#   PCOV_ON - Set to "1" to enable PCOV for code coverage
+#
+# Note:
+#   - PCOV and XDebug cannot be loaded simultaneously
+#   - PCOV is coverage-only; use XDebug if you need debugging/profiling
+#   - PCOV works with opcache enabled (unlike XDebug in debug mode)
+#
+# Usage:
+#   Called automatically by openemr.sh when PCOV is enabled
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# VALIDATION
+# ============================================================================
+# Ensure PCOV is actually requested before proceeding.
+
+# PCOV_ON is normalized to "true"/"false" by openemr.sh before calling this script
+# shellcheck disable=SC2154
+if [[ "${PCOV_ON}" != true ]]; then
+    echo "Error: PCOV script called but PCOV_ON is not enabled" >&2
+    exit 1
+fi
+
+# ============================================================================
+# INSTALL AND CONFIGURE PCOV
+# ============================================================================
+# Install the PCOV PHP extension and configure it in php.ini.
+# This only runs once per container to avoid repeated installations.
+
+if [[ ! -f /etc/php-pcov-configured ]]; then
+    echo "Installing PCOV extension..."
+
+    # Install PCOV extension from Alpine package repository
+    apk update
+    apk add --no-cache "php${PHP_VERSION_ABBR?}-pecl-pcov"
+
+    # Configure PCOV in php.ini
+    # Note: PHP_VERSION_ABBR is set by the Dockerfile (e.g., "84" for PHP 8.4)
+    {
+        echo "; ========================================================================"
+        echo "; PCOV Configuration (Code Coverage)"
+        echo "; ========================================================================"
+        echo "; Load PCOV extension"
+        echo "zend_extension=/usr/lib/php${PHP_VERSION_ABBR}/modules/pcov.so"
+        echo ""
+        echo "; Enable PCOV (can be disabled at runtime via pcov.enabled=0)"
+        echo "pcov.enabled=1"
+        echo ""
+        echo "; Directory filter - only collect coverage for files under this path"
+        echo "; Default covers the OpenEMR installation directory"
+        echo "pcov.directory=/var/www/localhost/htdocs/openemr"
+        echo ""
+        echo "; Exclude test files from coverage collection"
+        echo "pcov.exclude=\"~/(vendor|tests|node_modules)/~\""
+        echo ""
+    } >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
+
+    # Ensure only configure this one time
+    touch /etc/php-pcov-configured
+    echo "PCOV installed and configured"
+fi
+
+echo "PCOV configuration completed"


### PR DESCRIPTION
## Summary

- Adds PCOV as an alternative to XDebug for PHP code coverage collection
- PCOV is significantly faster than XDebug for coverage-only use cases (CI)
- New `PCOV_ON` environment variable to enable

## Changes

- **pcov.sh**: Runtime installation script (mirrors xdebug.sh pattern)
- **openemr.sh**: Added PCOV_ON env var handling with precedence over XDebug
- **Dockerfile**: Include pcov.sh in the image

## Usage

```bash
# Enable pcov for code coverage (CI)
docker run -e PCOV_ON=1 openemr/openemr:flex-3.22

# Enable xdebug for debugging (development) 
docker run -e XDEBUG_ON=1 openemr/openemr:flex-3.22
```

## Notes

- PCOV and XDebug are mutually exclusive; PCOV takes precedence if both set
- PCOV works with opcache enabled (unlike XDebug) but requires JIT disabled
- Related OpenEMR issue: https://github.com/openemr/openemr/issues/10328

## AI Disclosure

Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)