### PR TITLE
docs: change OpenEMR image version to 8.0.1

### DIFF
--- a/docker/openemr/8.0.1/README.md
+++ b/docker/openemr/8.0.1/README.md
@@ -93,7 +93,6 @@ It is recommended to specify a version number in production, to ensure your buil
 # MYSQL_HOST and MYSQL_ROOT_PASS are required for openemr
 # MYSQL_USER, MYSQL_PASS, OE_USER, MYSQL_PASS are optional for openemr and
 #   if not provided, then default to openemr, openemr, admin, and pass respectively.
-version: '3.1'
 services:
   mysql:
     restart: always
@@ -105,7 +104,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
   openemr:
     restart: always
-    image: openemr/openemr:7.0.5
+    image: openemr/openemr:8.0.1
     ports:
     - 80:80
     - 443:443


### PR DESCRIPTION
<!--
(Thanks for sending a pull request!
-->

<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->

#### Short description of what this resolves:

Use the correct image in the 8.0.1 README.


#### Changes proposed in this pull request:

- use image tag 8.0.1 for the OpenEMR version
- also removed the version property as it is deprecated in compose

BTW: the link to Play With Docker refers to the wrong gist (v7.0.5)