### PR TITLE
fix(flex): load pcov as extension, not zend_extension

### DIFF
--- a/docker/openemr/flex/pcov.sh
+++ b/docker/openemr/flex/pcov.sh
@@ -52,7 +52,7 @@ if [[ ! -f /etc/php-pcov-configured ]]; then
         echo "; PCOV Configuration (Code Coverage)"
         echo "; ========================================================================"
         echo "; Load PCOV extension"
-        echo "zend_extension=/usr/lib/php${PHP_VERSION_ABBR}/modules/pcov.so"
+        echo "extension=pcov"
         echo ""
         echo "; Enable PCOV (can be disabled at runtime via pcov.enabled=0)"
         echo "pcov.enabled=1"


### PR DESCRIPTION
## Summary

- Fix PCOV loading by using `extension=pcov` instead of `zend_extension=...`

PCOV is a regular PHP extension, not a Zend extension. Loading it with `zend_extension` causes:
```
/usr/lib/php84/modules/pcov.so doesn't appear to be a valid Zend extension
```

This prevented PCOV from loading, causing coverage collection to fall back to Xdebug.

## Test plan

- [ ] Build flex image with `PCOV_ON=true`
- [ ] Verify no warning about invalid Zend extension
- [ ] Verify `php -m | grep pcov` shows pcov is loaded

🤖 Generated with [Claude Code](https://claude.ai/code)