### PR TITLE
fix(flex): remove tests from pcov.exclude pattern

### DIFF
--- a/docker/openemr/flex/pcov.sh
+++ b/docker/openemr/flex/pcov.sh
@@ -61,8 +61,8 @@ if [[ ! -f /etc/php-pcov-configured ]]; then
         echo "; Default covers the OpenEMR installation directory"
         echo "pcov.directory=/var/www/localhost/htdocs/openemr"
         echo ""
-        echo "; Exclude test files from coverage collection"
-        echo "pcov.exclude=\"~/(vendor|tests|node_modules)/~\""
+        echo "; Exclude vendor and node_modules from coverage collection"
+        echo "pcov.exclude=\"~/(vendor|node_modules)/~\""
         echo ""
     } >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
 


### PR DESCRIPTION
Fixes #559

## What this resolves

The `pcov.exclude` pattern prevented coverage collection for test files, causing the `e2e-tests` and `api-tests` Codecov flags to show 0% coverage.

## Changes proposed in this pull request

- Remove `tests` from the `pcov.exclude` regex pattern in `docker/openemr/flex/pcov.sh`
- Update the comment to reflect the actual exclusions (vendor and node_modules)

OpenEMR's CI explicitly includes the `tests/` directory in coverage filtering via `coverage_filter_dirs` in `ci/ciLibrary.source`, so this exclusion was counterproductive.

## AI Disclosure

Yes - Claude Code assisted with this change.