### PR TITLE
fix(docker): add -f flag support to auto_configure.php

### DIFF
--- a/docker/openemr/7.0.4/auto_configure.php
+++ b/docker/openemr/7.0.4/auto_configure.php
@@ -22,10 +22,23 @@ $installSettings['no_root_db_access']        = 'BLANK';
 $installSettings['development_translations'] = 'BLANK';
 // Collect parameters(if exist) for installation configuration settings
 for ($i=1; $i < count($argv); $i++) {
-    $indexandvalue = explode("=", $argv[$i]);
-    $index = $indexandvalue[0];
-    $value = $indexandvalue[1] ?? '';
-    $installSettings[$index] = $value;
+    if ($argv[$i] === '-f' && isset($argv[$i+1])) {
+        // Handle -f flag: parse space-separated key=value pairs from a single string
+        $configPairs = preg_split('/\s+/', trim($argv[$i+1]));
+        foreach ($configPairs as $pair) {
+            if (strpos($pair, '=') !== false) {
+                list($index, $value) = explode('=', $pair, 2);
+                $installSettings[$index] = $value;
+            }
+        }
+        $i++;
+    } else {
+        // Handle standard key=value parameters
+        $indexandvalue = explode("=", $argv[$i]);
+        $index = $indexandvalue[0];
+        $value = $indexandvalue[1] ?? '';
+        $installSettings[$index] = $value;
+    }
 }
 // Convert BLANK settings to empty
 $tempInstallSettings = array();

--- a/docker/openemr/8.0.0/auto_configure.php
+++ b/docker/openemr/8.0.0/auto_configure.php
@@ -22,10 +22,23 @@ $installSettings['no_root_db_access']        = 'BLANK';
 $installSettings['development_translations'] = 'BLANK';
 // Collect parameters(if exist) for installation configuration settings
 for ($i=1; $i < count($argv); $i++) {
-    $indexandvalue = explode("=", $argv[$i]);
-    $index = $indexandvalue[0];
-    $value = $indexandvalue[1] ?? '';
-    $installSettings[$index] = $value;
+    if ($argv[$i] === '-f' && isset($argv[$i+1])) {
+        // Handle -f flag: parse space-separated key=value pairs from a single string
+        $configPairs = preg_split('/\s+/', trim($argv[$i+1]));
+        foreach ($configPairs as $pair) {
+            if (strpos($pair, '=') !== false) {
+                list($index, $value) = explode('=', $pair, 2);
+                $installSettings[$index] = $value;
+            }
+        }
+        $i++;
+    } else {
+        // Handle standard key=value parameters
+        $indexandvalue = explode("=", $argv[$i]);
+        $index = $indexandvalue[0];
+        $value = $indexandvalue[1] ?? '';
+        $installSettings[$index] = $value;
+    }
 }
 // Convert BLANK settings to empty
 $tempInstallSettings = array();

--- a/docker/openemr/8.0.1/auto_configure.php
+++ b/docker/openemr/8.0.1/auto_configure.php
@@ -125,13 +125,27 @@ $installSettings['development_translations'] = 'BLANK';        // Enable dev tra
 //          This would override the "server" and "rootpass" settings.
 
 for ($i=1; $i < count($argv); $i++) {
-    // Split each argument into key and value (format: "key=value")
-    $indexandvalue = explode("=", $argv[$i]);
-    $index = $indexandvalue[0];              // The setting name (e.g., "server")
-    $value = $indexandvalue[1] ?? '';        // The setting value (e.g., "mysql-lb")
-    
-    // Override the default setting with the command-line value
-    $installSettings[$index] = $value;
+    if ($argv[$i] === '-f' && isset($argv[$i+1])) {
+        // Handle -f flag: parse space-separated key=value pairs from a single string
+        // This format is used by entrypoint.sh: php auto_configure.php -f "server=mysql rootpass=root"
+        $configPairs = preg_split('/\s+/', trim($argv[$i+1]));
+        foreach ($configPairs as $pair) {
+            if (strpos($pair, '=') !== false) {
+                list($index, $value) = explode('=', $pair, 2);
+                $installSettings[$index] = $value;
+            }
+        }
+        $i++;
+    } else {
+        // Handle standard key=value parameters
+        // Split each argument into key and value (format: "key=value")
+        $indexandvalue = explode("=", $argv[$i]);
+        $index = $indexandvalue[0];              // The setting name (e.g., "server")
+        $value = $indexandvalue[1] ?? '';        // The setting value (e.g., "mysql-lb")
+
+        // Override the default setting with the command-line value
+        $installSettings[$index] = $value;
+    }
 }
 
 // ============================================================================

--- a/docker/openemr/binary/auto_configure.php
+++ b/docker/openemr/binary/auto_configure.php
@@ -125,13 +125,27 @@ $installSettings['development_translations'] = 'BLANK';        // Enable dev tra
 //          This would override the "server" and "rootpass" settings.
 
 for ($i=1; $i < count($argv); $i++) {
-    // Split each argument into key and value (format: "key=value")
-    $indexandvalue = explode("=", $argv[$i]);
-    $index = $indexandvalue[0];              // The setting name (e.g., "server")
-    $value = $indexandvalue[1] ?? '';        // The setting value (e.g., "mysql-lb")
-    
-    // Override the default setting with the command-line value
-    $installSettings[$index] = $value;
+    if ($argv[$i] === '-f' && isset($argv[$i+1])) {
+        // Handle -f flag: parse space-separated key=value pairs from a single string
+        // This format is used by entrypoint.sh: php auto_configure.php -f "server=mysql rootpass=root"
+        $configPairs = preg_split('/\s+/', trim($argv[$i+1]));
+        foreach ($configPairs as $pair) {
+            if (strpos($pair, '=') !== false) {
+                list($index, $value) = explode('=', $pair, 2);
+                $installSettings[$index] = $value;
+            }
+        }
+        $i++;
+    } else {
+        // Handle standard key=value parameters
+        // Split each argument into key and value (format: "key=value")
+        $indexandvalue = explode("=", $argv[$i]);
+        $index = $indexandvalue[0];              // The setting name (e.g., "server")
+        $value = $indexandvalue[1] ?? '';        // The setting value (e.g., "mysql-lb")
+
+        // Override the default setting with the command-line value
+        $installSettings[$index] = $value;
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Port the `-f` flag handling from flex to 7.0.4, 8.0.0, 8.0.1, and binary versions
- Allow passing configuration as a single quoted string of space-separated key=value pairs
- Remove reliance on shell word-splitting of unquoted `${CONFIGURATION}` variable

## Context

The flex version of auto_configure.php properly handles a `-f` flag to accept a quoted string of space-separated key=value pairs. The other versions silently ignored `-f` and only worked because `${CONFIGURATION}` was unquoted in the shell scripts, causing word-splitting to separate the arguments.

This fix enables proper quoting of `${CONFIGURATION}` in the shell scripts.

Fixes #539