### PR TITLE
fix: upgrade Java 11 to 17 for Synthea in importRandomPatients

### DIFF
--- a/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
+++ b/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
@@ -238,7 +238,7 @@ importRandomPatients() {
     if [ ! -d /root/synthea ]; then
         echo "Setting up synthea first"
         apk update
-        apk add openjdk11-jre
+        apk add openjdk17-jre
         mkdir /root/synthea
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar

--- a/docker/openemr/8.0.0/utilities/devtoolsLibrary.source
+++ b/docker/openemr/8.0.0/utilities/devtoolsLibrary.source
@@ -238,7 +238,7 @@ importRandomPatients() {
     if [ ! -d /root/synthea ]; then
         echo "Setting up synthea first"
         apk update
-        apk add openjdk11-jre
+        apk add openjdk17-jre
         mkdir /root/synthea
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar

--- a/docker/openemr/8.0.1/utilities/devtoolsLibrary.source
+++ b/docker/openemr/8.0.1/utilities/devtoolsLibrary.source
@@ -635,7 +635,7 @@ importRandomPatients() {
     if [[ ! -d /root/synthea ]]; then
         echo "Setting up synthea first"
         apk update
-        apk add openjdk11-jre
+        apk add openjdk17-jre
         mkdir /root/synthea
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar

--- a/docker/openemr/binary/utilities/devtoolsLibrary.source
+++ b/docker/openemr/binary/utilities/devtoolsLibrary.source
@@ -635,7 +635,7 @@ importRandomPatients() {
     if [[ ! -d /root/synthea ]]; then
         echo "Setting up synthea first"
         apk update
-        apk add openjdk11-jre
+        apk add openjdk17-jre
         mkdir /root/synthea
         cd /root/synthea || exit
         wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar

--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -500,7 +500,7 @@ importRandomPatients() {
         if [[ ! -d /root/synthea ]]; then
             echo "Setting up synthea first"
             apk update
-            apk add openjdk11-jre
+            apk add openjdk17-jre
             mkdir /root/synthea
             cd /root/synthea || exit
             wget https://github.com/synthetichealth/synthea/releases/download/master-branch-latest/synthea-with-dependencies.jar


### PR DESCRIPTION
## Summary

- Synthea's `master-branch-latest` release now requires Java 17+ (class file version 61.0)
- All `devtoolsLibrary.source` files install `openjdk11-jre` (Java 11), causing `UnsupportedClassVersionError` when running `openemr-cmd irp`
- Change `openjdk11-jre` → `openjdk17-jre` in all active container versions (7.0.3, 7.0.4, 8.0.0, 8.0.1, binary, flex)

All affected images use Alpine 3.20+, which includes `openjdk17-jre`.

Fixes #578

## Test plan

- [ ] `openemr-cmd irp` successfully imports random patients with the flex image

🤖 Generated with [Claude Code](https://claude.com/claude-code)