### PR TITLE
ci: add build patch release workflow

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -238,7 +238,10 @@ jobs:
           if [[ -z "$file" ]]; then
             continue
           fi
-          mkdir -p "${patch_dir}/${file%/*}"
+          dir="${file%/*}"
+          if [[ "$dir" != "$file" ]]; then
+            mkdir -p "${patch_dir}/${dir}"
+          fi
           cp "$file" "${patch_dir}/${file}"
         done < /tmp/changed-files.txt
 


### PR DESCRIPTION
## Summary

- Move the "Build Patch Release" workflow from openemr/openemr to openemr-devops for better performance/latency
- Workflow checks out openemr/openemr using an `OPENEMR_TOKEN` secret for cross-repo access (version bump push, tag creation, release upload)
- Split version.php bump into two steps so dry runs produce an accurate patch preview without pushing changes to the release branch
- All `gh release` commands use `--repo openemr/openemr` since the workflow now runs from a different repo

## Setup required

Create an `OPENEMR_TOKEN` repository secret in openemr-devops with a PAT that has:
- **Contents: write** on openemr/openemr (push version bump + tags)
- **Issues: read** on openemr/openemr (milestone/changelog generation)

## Test plan

- [ ] Create the `OPENEMR_TOKEN` secret
- [ ] Run the workflow with `dry_run: true` and verify the patch zip artifact contains the correct `$v_realpatch` value
- [ ] Run the workflow with `dry_run: false` against a test tag/milestone and verify the release is created on openemr/openemr

🤖 Generated with [Claude Code](https://claude.com/claude-code)