### PR TITLE
ci: use GitHub App token, allow dry runs without secrets

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -35,6 +35,10 @@ on:
         description: Build and include compiled theme styles
         type: boolean
         default: false
+      validate_token:
+        description: Generate and verify the app token (use with dry run to test permissions)
+        type: boolean
+        default: false
 
 jobs:
   build-patch:
@@ -48,7 +52,7 @@ jobs:
         exit 1
 
     - name: Generate app token
-      if: '!inputs.dry_run'
+      if: '!inputs.dry_run || inputs.validate_token'
       id: app-token
       uses: actions/create-github-app-token@v2
       with:
@@ -58,7 +62,7 @@ jobs:
         repositories: openemr
 
     - name: Verify app token
-      if: '!inputs.dry_run'
+      if: '!inputs.dry_run || inputs.validate_token'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
         MILESTONE_NAME: ${{ inputs.milestone }}


### PR DESCRIPTION
## Summary

- Use `actions/create-github-app-token` to generate a short-lived token for real releases instead of a PAT secret
- App token step only runs for non-dry-run releases
- Dry runs fall back to the default `github.token`, which can read the public openemr/openemr repo — no secrets needed

## Setup required

Create two repository secrets in openemr-devops:
- `RELEASE_APP_ID` — the GitHub App's numeric ID
- `RELEASE_APP_PRIVATE_KEY` — the App's private key (`.pem` contents)

The app needs these permissions on `openemr/openemr`:
- Contents: Read & write
- Issues: Read-only
- Pull requests: Read & write

## Test plan

- [ ] Run with `dry_run: true` — should succeed without any secrets configured
- [ ] Create the GitHub App and add secrets
- [ ] Run with `dry_run: false` against a test milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)