### PR TITLE
feat: add release task components and CI workflow (Phase 2)

### DIFF
--- a/.github/workflows/release-tools-php.yml
+++ b/.github/workflows/release-tools-php.yml
@@ -1,0 +1,75 @@
+name: Release Tools PHP
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'tools/release/**.php'
+      - 'tools/release/composer.json'
+      - 'tools/release/composer.lock'
+      - 'tools/release/phpstan.neon'
+      - 'tools/release/phpcs.xml'
+      - 'tools/release/rector.php'
+      - '.github/workflows/release-tools-php.yml'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'tools/release/**.php'
+      - 'tools/release/composer.json'
+      - 'tools/release/composer.lock'
+      - 'tools/release/phpstan.neon'
+      - 'tools/release/phpcs.xml'
+      - 'tools/release/rector.php'
+      - '.github/workflows/release-tools-php.yml'
+
+defaults:
+  run:
+    working-directory: tools/release
+
+jobs:
+  phpcs:
+    name: PHP CodeSniffer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: cs2pr
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/phpcs --report=checkstyle | cs2pr
+
+  phpstan:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/phpstan analyse
+
+  rector:
+    name: Rector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/rector process --dry-run
+
+  require-checker:
+    name: Composer Require Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+      - run: composer install --no-interaction --no-progress
+      - run: vendor/bin/composer-require-checker check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 .idea
+/.task/

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -27,3 +27,111 @@ tasks:
         --milestone={{shellQuote .MILESTONE}}
         --repo={{shellQuote .REPO}}
         --output={{shellQuote .OUTPUT_DIR}}/changelog.md
+
+  version-bump:
+    desc: Bump version numbers in OpenEMR source files
+    requires:
+      vars: [MODE, OPENEMR_DIR]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/version-bump.php
+        --mode={{shellQuote .MODE}}
+        {{if eq .MODE "patch"}}--patch-number={{shellQuote .PATCH_NUMBER}}{{end}}
+        --version-file={{shellQuote .OPENEMR_DIR}}/version.php
+        --globals-file={{shellQuote .OPENEMR_DIR}}/library/globals.inc.php
+
+  preflight:
+    desc: Run pre-release checks
+    requires:
+      vars: [MILESTONE]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/preflight.php
+        --milestone={{shellQuote .MILESTONE}}
+        --repo={{shellQuote .REPO}}
+
+  checksum:
+    desc: Generate checksum sidecar files
+    requires:
+      vars: [FILE]
+    cmds:
+      - md5sum {{shellQuote .FILE}} > {{shellQuote .FILE}}.md5
+      - sha256sum {{shellQuote .FILE}} > {{shellQuote .FILE}}.sha256
+      - sha512sum {{shellQuote .FILE}} > {{shellQuote .FILE}}.sha512
+
+  tag:
+    desc: Create annotated git tag and push
+    requires:
+      vars: [TAG, REF]
+    status:
+      - git rev-parse {{shellQuote .TAG}} >/dev/null 2>&1
+    cmds:
+      - git tag -a {{shellQuote .TAG}} {{shellQuote .REF}} -m "Release {{.TAG}}"
+      - git push origin {{shellQuote .TAG}}
+
+  release:
+    desc: Create GitHub release
+    requires:
+      vars: [TAG]
+    status:
+      - gh release view {{shellQuote .TAG}} --repo {{shellQuote .REPO}} >/dev/null 2>&1
+    cmds:
+      - >-
+        gh release create {{shellQuote .TAG}}
+        --repo {{shellQuote .REPO}}
+        --title {{shellQuote .TAG}}
+        {{if .NOTES_FILE}}--notes-file {{shellQuote .NOTES_FILE}}{{end}}
+
+  release:upload:
+    desc: Upload assets to an existing GitHub release
+    requires:
+      vars: [TAG, ASSETS]
+    cmds:
+      - >-
+        gh release upload {{shellQuote .TAG}}
+        --repo {{shellQuote .REPO}}
+        --clobber
+        {{.ASSETS}}
+
+  changelog-pr:
+    desc: Create CHANGELOG.md update PRs
+    requires:
+      vars: [MILESTONE, BRANCHES, OPENEMR_DIR]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/changelog-pr.php
+        --milestone={{shellQuote .MILESTONE}}
+        --branches={{shellQuote .BRANCHES}}
+        --openemr-dir={{shellQuote .OPENEMR_DIR}}
+        --changelog-file={{shellQuote .OUTPUT_DIR}}/changelog.md
+        --repo={{shellQuote .REPO}}
+
+  patch:assemble:
+    desc: Build cumulative patch zip from diff between tags
+    requires:
+      vars: [START_TAG, BRANCH, FILENAME, OPENEMR_DIR]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/patch-assemble.php
+        --start-tag={{shellQuote .START_TAG}}
+        --branch={{shellQuote .BRANCH}}
+        --filename={{shellQuote .FILENAME}}
+        --openemr-dir={{shellQuote .OPENEMR_DIR}}
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+        {{if .COPY_STYLES}}--copy-styles{{end}}
+
+  summary:
+    desc: Generate release summary
+    requires:
+      vars: [TYPE, MILESTONE]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/summary.php
+        --type={{shellQuote .TYPE}}
+        --milestone={{shellQuote .MILESTONE}}
+        --output-dir={{shellQuote .OUTPUT_DIR}}

--- a/tools/release/bin/changelog-pr.php
+++ b/tools/release/bin/changelog-pr.php
@@ -1,0 +1,121 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Create CHANGELOG.md update PRs for release and master branches.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Process\Process;
+
+(new SingleCommandApplication())
+    ->setName('changelog-pr')
+    ->setDescription('Create CHANGELOG.md update PRs')
+    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->addOption('branches', null, InputOption::VALUE_REQUIRED, 'Comma-separated target branches')
+    ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to openemr checkout')
+    ->addOption('changelog-file', null, InputOption::VALUE_REQUIRED, 'Path to changelog entry file')
+    ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo', 'openemr/openemr')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var string $milestone */
+        $milestone = $input->getOption('milestone');
+        /** @var string $openemrDir */
+        $openemrDir = $input->getOption('openemr-dir');
+        /** @var string $changelogFile */
+        $changelogFile = $input->getOption('changelog-file');
+        /** @var string $repo */
+        $repo = $input->getOption('repo');
+        /** @var string $branchesRaw */
+        $branchesRaw = $input->getOption('branches');
+
+        foreach (['milestone', 'branches', 'openemr-dir', 'changelog-file'] as $required) {
+            if ($input->getOption($required) === null) {
+                $output->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        if (!file_exists($changelogFile)) {
+            $output->writeln("<error>Changelog file not found: {$changelogFile}</error>");
+            return 1;
+        }
+
+        $changelogEntry = file_get_contents($changelogFile);
+        if ($changelogEntry === false) {
+            $output->writeln("<error>Cannot read: {$changelogFile}</error>");
+            return 1;
+        }
+
+        $branches = explode(',', $branchesRaw);
+
+        foreach ($branches as $branch) {
+            $branch = trim($branch);
+            $prBranch = "changelog-{$milestone}-{$branch}";
+
+            // Check if PR already exists
+            $check = new Process(
+                ['gh', 'pr', 'list', '--repo', $repo, '--head', $prBranch, '--json', 'number', '--jq', 'length'],
+            );
+            $check->mustRun();
+            if ((int) trim($check->getOutput()) > 0) {
+                $output->writeln("PR already exists for <comment>{$prBranch}</comment>, skipping");
+                continue;
+            }
+
+            // Create branch from target
+            (new Process(['git', 'checkout', '-b', $prBranch, "origin/{$branch}"], $openemrDir))->mustRun();
+
+            // Prepend changelog entry after the first heading line
+            $existingChangelog = file_get_contents("{$openemrDir}/CHANGELOG.md");
+            if ($existingChangelog === false) {
+                $output->writeln("<error>Cannot read CHANGELOG.md in {$openemrDir}</error>");
+                return 1;
+            }
+            $firstNewline = strpos($existingChangelog, "\n");
+            if ($firstNewline === false) {
+                $merged = $existingChangelog . "\n\n" . $changelogEntry;
+            } else {
+                $merged = substr($existingChangelog, 0, $firstNewline + 1)
+                    . "\n" . $changelogEntry
+                    . substr($existingChangelog, $firstNewline + 1);
+            }
+            file_put_contents("{$openemrDir}/CHANGELOG.md", $merged);
+
+            // Commit, push, create PR
+            (new Process(['git', 'add', 'CHANGELOG.md'], $openemrDir))->mustRun();
+            (new Process(
+                ['git', 'commit', '-m', "docs: add {$milestone} changelog"],
+                $openemrDir,
+            ))->mustRun();
+            (new Process(['git', 'push', 'origin', $prBranch], $openemrDir))->mustRun();
+            (new Process([
+                'gh', 'pr', 'create',
+                '--repo', $repo,
+                '--base', $branch,
+                '--head', $prBranch,
+                '--title', "docs: add {$milestone} changelog",
+                '--body', "Add changelog entry for {$milestone} release.",
+            ]))->mustRun();
+
+            $output->writeln("Created PR for <info>{$prBranch}</info> → {$branch}");
+
+            // Return to previous branch
+            (new Process(['git', 'checkout', '-'], $openemrDir))->mustRun();
+        }
+
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/changelog.php
+++ b/tools/release/bin/changelog.php
@@ -4,7 +4,7 @@
 /**
  * Generate a changelog from a GitHub milestone.
  *
- * @package   openemr
+ * @package   openemr-devops
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
@@ -29,12 +29,14 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo (owner/name)', 'openemr/openemr')
     ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file path (omit for stdout)')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var ?string $milestone */
         $milestone = $input->getOption('milestone');
         if ($milestone === null) {
             $output->writeln('<error>--milestone is required</error>');
             return 1;
         }
 
+        /** @var string $repo */
         $repo = $input->getOption('repo');
         $api = new GitHubApi($repo);
 
@@ -52,6 +54,7 @@ use Symfony\Component\Console\SingleCommandApplication;
 
         $changelog = (new ChangelogGenerator())->generate($milestone, $milestoneNumber, $repo, $issues);
 
+        /** @var ?string $outputFile */
         $outputFile = $input->getOption('output');
         if ($outputFile !== null) {
             $dir = dirname($outputFile);

--- a/tools/release/bin/patch-assemble.php
+++ b/tools/release/bin/patch-assemble.php
@@ -1,0 +1,152 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Build a cumulative patch zip from the diff between a start tag and release branch.
+ *
+ * The patch is an overlay archive: users extract it on top of their existing
+ * install. It can't delete files (but can empty them like setup.php) and always
+ * includes version.php and sql_patch.php.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+use Symfony\Component\Process\Process;
+
+(new SingleCommandApplication())
+    ->setName('patch-assemble')
+    ->setDescription('Build cumulative patch zip from diff between tags')
+    ->addOption('start-tag', null, InputOption::VALUE_REQUIRED, 'Base tag for diff (e.g., v8_0_0)')
+    ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g., rel-800)')
+    ->addOption('filename', null, InputOption::VALUE_REQUIRED, 'Output zip filename')
+    ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to openemr checkout')
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output directory', './release-output')
+    ->addOption('copy-styles', null, InputOption::VALUE_NONE, 'Include compiled theme styles')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var string $startTag */
+        $startTag = $input->getOption('start-tag');
+        /** @var string $branch */
+        $branch = $input->getOption('branch');
+        /** @var string $filename */
+        $filename = $input->getOption('filename');
+        /** @var string $openemrDir */
+        $openemrDir = $input->getOption('openemr-dir');
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output-dir');
+
+        foreach (['start-tag', 'branch', 'filename', 'openemr-dir'] as $required) {
+            if ($input->getOption($required) === null) {
+                $output->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        if (!is_dir($openemrDir)) {
+            $output->writeln("<error>OpenEMR directory not found: {$openemrDir}</error>");
+            return 1;
+        }
+
+        $patchDir = "{$outputDir}/patch-staging";
+
+        if (is_dir($patchDir)) {
+            (new Process(['rm', '-rf', $patchDir]))->mustRun();
+        }
+        if (!is_dir($outputDir)) {
+            mkdir($outputDir, 0755, true);
+        }
+        mkdir($patchDir, 0755, true);
+
+        // Get changed files, excluding CI/dev/test paths
+        $excludes = [
+            ':(exclude).github/**',
+            ':(exclude).phpstan/**',
+            ':(exclude).git/**',
+            ':(exclude)docker/**',
+            ':(exclude)tests/**',
+            ':(exclude).dockerignore',
+            ':(exclude).editorconfig',
+            ':(exclude).eslintrc.js',
+            ':(exclude).markdownlint.json',
+            ':(exclude).overcommit.yml',
+            ':(exclude).phpcs.xml',
+            ':(exclude).phpunit*',
+            ':(exclude).stylelintrc.json',
+            ':(exclude)phpstan*',
+            ':(exclude)phpunit*',
+            ':(exclude)package.json',
+            ':(exclude)package-lock.json',
+        ];
+
+        $diff = new Process(
+            ['git', 'diff', '--name-only', '--diff-filter=d', "{$startTag}..{$branch}", '--', '.', ...$excludes],
+            $openemrDir,
+        );
+        $diff->mustRun();
+
+        $changedFiles = array_filter(
+            explode("\n", trim($diff->getOutput())),
+            static fn(string $line): bool => $line !== '',
+        );
+        file_put_contents("{$outputDir}/changed-files.txt", implode("\n", $changedFiles) . "\n");
+        $output->writeln(sprintf('<info>%d</info> changed files', count($changedFiles)));
+
+        // Copy each changed file preserving directory structure
+        foreach ($changedFiles as $filepath) {
+            $targetDir = "{$patchDir}/" . dirname($filepath);
+            if (!is_dir($targetDir)) {
+                mkdir($targetDir, 0755, true);
+            }
+            copy("{$openemrDir}/{$filepath}", "{$patchDir}/{$filepath}");
+        }
+
+        // Copy compiled theme styles if requested
+        $copyStyles = (bool) $input->getOption('copy-styles');
+        if ($copyStyles && is_dir("{$openemrDir}/public/themes")) {
+            $themesDir = "{$patchDir}/public/themes";
+            if (!is_dir($themesDir)) {
+                mkdir($themesDir, 0755, true);
+            }
+            (new Process(['cp', '-R', "{$openemrDir}/public/themes/.", $themesDir]))->mustRun();
+        }
+
+        // Blank out setup.php so patch doesn't re-run setup
+        file_put_contents("{$patchDir}/setup.php", '');
+
+        // Always include version.php and sql_patch.php
+        copy("{$openemrDir}/version.php", "{$patchDir}/version.php");
+        copy("{$openemrDir}/sql_patch.php", "{$patchDir}/sql_patch.php");
+
+        // Standardize permissions
+        (new Process(['find', $patchDir, '-type', 'f', '-exec', 'chmod', '0644', '{}', '+']))->mustRun();
+
+        // Count files in patch
+        $findProcess = new Process(['find', $patchDir, '-type', 'f']);
+        $findProcess->mustRun();
+        $fileCount = count(array_filter(
+            explode("\n", trim($findProcess->getOutput())),
+            static fn(string $l): bool => $l !== '',
+        ));
+        $output->writeln(sprintf('<info>%d</info> files in patch', $fileCount));
+
+        // Build zip
+        (new Process(['zip', '-r', "../{$filename}", '.'], $patchDir))->mustRun();
+
+        // Clean up staging directory
+        (new Process(['rm', '-rf', $patchDir]))->mustRun();
+
+        $output->writeln("Patch built: <info>{$outputDir}/{$filename}</info>");
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/preflight.php
+++ b/tools/release/bin/preflight.php
@@ -1,0 +1,60 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Run pre-release checks: milestone completeness and unpublished GHSAs.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\GitHubApi;
+use OpenEMR\Release\PreflightChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('preflight')
+    ->setDescription('Run pre-release checks')
+    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo', 'openemr/openemr')
+    ->addOption('skip-milestone', null, InputOption::VALUE_NONE, 'Skip milestone check')
+    ->addOption('skip-ghsa', null, InputOption::VALUE_NONE, 'Skip GHSA check')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var ?string $milestone */
+        $milestone = $input->getOption('milestone');
+        /** @var string $repo */
+        $repo = $input->getOption('repo');
+        $api = new GitHubApi($repo);
+        $checker = new PreflightChecker($api, $repo);
+        $failures = 0;
+
+        /** @var bool $skipMilestone */
+        $skipMilestone = $input->getOption('skip-milestone');
+        /** @var bool $skipGhsa */
+        $skipGhsa = $input->getOption('skip-ghsa');
+
+        if (!$skipMilestone) {
+            if ($milestone === null) {
+                $output->writeln('<error>--milestone is required (or use --skip-milestone)</error>');
+                return 1;
+            }
+            $failures += $checker->checkMilestone($milestone, $output);
+        }
+
+        if (!$skipGhsa) {
+            $failures += $checker->checkGhsa($output);
+        }
+
+        return $failures > 0 ? 1 : 0;
+    })
+    ->run();

--- a/tools/release/bin/summary.php
+++ b/tools/release/bin/summary.php
@@ -1,0 +1,120 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Generate a release summary for GitHub step summary.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('summary')
+    ->setDescription('Generate release summary for GitHub step summary')
+    ->addOption('type', null, InputOption::VALUE_REQUIRED, 'Release type: "patch" or "full"')
+    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Release artifacts directory', './release-output')
+    ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file (or GITHUB_STEP_SUMMARY)')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var string $type */
+        $type = $input->getOption('type');
+        /** @var string $milestone */
+        $milestone = $input->getOption('milestone');
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output-dir');
+
+        foreach (['type', 'milestone'] as $required) {
+            if ($input->getOption($required) === null) {
+                $output->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        if (!in_array($type, ['patch', 'full'], true)) {
+            $output->writeln('<error>--type must be "patch" or "full"</error>');
+            return 1;
+        }
+
+        $lines = [];
+        $lines[] = "## Release Summary: {$milestone}";
+        $lines[] = '';
+
+        // Include checksums if available
+        foreach (['md5', 'sha256', 'sha512'] as $ext) {
+            $globResult = glob("{$outputDir}/*.{$ext}");
+            if ($globResult === false) {
+                continue;
+            }
+            foreach ($globResult as $file) {
+                $content = trim((string) file_get_contents($file));
+                $lines[] = "**" . basename($file) . ":** `{$content}`";
+            }
+        }
+        $lines[] = '';
+
+        // Include changelog
+        $changelogFile = "{$outputDir}/changelog.md";
+        if (file_exists($changelogFile)) {
+            $lines[] = trim((string) file_get_contents($changelogFile));
+            $lines[] = '';
+        }
+
+        // Include changed files if patch
+        $changedFilesPath = "{$outputDir}/changed-files.txt";
+        if ($type === 'patch' && file_exists($changedFilesPath)) {
+            $changedFiles = file($changedFilesPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($changedFiles !== false) {
+                sort($changedFiles);
+                $count = count($changedFiles);
+                $lines[] = "<details><summary>Changed files ({$count})</summary>";
+                $lines[] = '';
+                $lines[] = '```';
+                foreach ($changedFiles as $file) {
+                    $lines[] = $file;
+                }
+                $lines[] = '```';
+                $lines[] = '</details>';
+                $lines[] = '';
+            }
+        }
+
+        // Manual checklist
+        $lines[] = '### Post-Release Checklist';
+        $lines[] = '';
+        $lines[] = '- [ ] Upload to SourceForge';
+        $lines[] = '- [ ] Update Docker version files';
+        $lines[] = '- [ ] Update website';
+        $lines[] = '- [ ] Update wiki';
+        $lines[] = '- [ ] Post announcement to community forum';
+        $lines[] = '- [ ] Post announcement to chat';
+
+        $content = implode("\n", $lines) . "\n";
+
+        // Determine output destination
+        /** @var ?string $outputFile */
+        $outputFile = $input->getOption('output');
+        $envSummary = getenv('GITHUB_STEP_SUMMARY');
+        $target = $outputFile ?? ($envSummary !== false ? $envSummary : null);
+
+        if ($target !== null) {
+            file_put_contents($target, $content, FILE_APPEND);
+            $output->writeln("Summary written to <info>{$target}</info>");
+        } else {
+            $output->write($content);
+        }
+
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/version-bump.php
+++ b/tools/release/bin/version-bump.php
@@ -1,0 +1,73 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Bump version numbers in OpenEMR source files.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\VersionBumper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('version-bump')
+    ->setDescription('Bump version numbers in OpenEMR source files')
+    ->addOption('mode', null, InputOption::VALUE_REQUIRED, 'Bump mode: "patch" or "full"')
+    ->addOption('patch-number', null, InputOption::VALUE_REQUIRED, 'Patch number (required for patch mode)')
+    ->addOption('version-file', null, InputOption::VALUE_REQUIRED, 'Path to version.php', 'version.php')
+    ->addOption('globals-file', null, InputOption::VALUE_REQUIRED, 'Path to globals.inc.php', 'library/globals.inc.php')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        /** @var ?string $mode */
+        $mode = $input->getOption('mode');
+        if (!in_array($mode, ['patch', 'full'], true)) {
+            $output->writeln('<error>--mode must be "patch" or "full"</error>');
+            return 1;
+        }
+
+        /** @var string $versionFile */
+        $versionFile = $input->getOption('version-file');
+        if (!file_exists($versionFile)) {
+            $output->writeln("<error>Version file not found: {$versionFile}</error>");
+            return 1;
+        }
+
+        $bumper = new VersionBumper();
+
+        if ($mode === 'patch') {
+            /** @var ?string $patchNumber */
+            $patchNumber = $input->getOption('patch-number');
+            if ($patchNumber === null) {
+                $output->writeln('<error>--patch-number is required for patch mode</error>');
+                return 1;
+            }
+            $bumper->bumpPatch($versionFile, $patchNumber);
+            $output->writeln("Set \$v_realpatch to <info>{$patchNumber}</info> in {$versionFile}");
+        } else {
+            $bumper->clearDevTag($versionFile);
+            $output->writeln("Removed <info>-dev</info> from \$v_tag in {$versionFile}");
+
+            /** @var string $globalsFile */
+            $globalsFile = $input->getOption('globals-file');
+            if (file_exists($globalsFile)) {
+                $bumper->setGlobalDefault($globalsFile, 'allow_debug_language', '0');
+                $output->writeln("Set <info>allow_debug_language</info> default to '0' in {$globalsFile}");
+            } else {
+                $output->writeln("<comment>Globals file not found, skipping: {$globalsFile}</comment>");
+            }
+        }
+
+        return 0;
+    })
+    ->run();

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -4,10 +4,18 @@
     "type": "project",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "nikic/php-parser": "^5.0",
         "symfony/console": "^7.0",
         "symfony/process": "^7.0"
+    },
+    "require-dev": {
+        "ergebnis/composer-normalize": "^2.48",
+        "maglnet/composer-require-checker": "^4.0",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-strict-rules": "^2.0",
+        "rector/rector": "^2.0",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {
@@ -15,6 +23,26 @@
         }
     },
     "config": {
+        "allow-plugins": {
+            "ergebnis/composer-normalize": true
+        },
         "sort-packages": true
+    },
+    "scripts": {
+        "check": [
+            "@phpcs",
+            "@phpstan",
+            "@rector"
+        ],
+        "fix": [
+            "@phpcbf",
+            "@rector-fix"
+        ],
+        "phpcbf": "phpcbf",
+        "phpcs": "phpcs",
+        "phpstan": "phpstan analyse",
+        "rector": "rector process --dry-run",
+        "rector-fix": "rector process",
+        "require-checker": "composer-require-checker check"
     }
 }

--- a/tools/release/composer.lock
+++ b/tools/release/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4a5272f42c8673263deed7ff0660da2",
+    "content-hash": "bd34676694adb7b35678e72638537837",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -860,14 +860,1209 @@
             "time": "2026-02-09T10:14:57+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "azjezz/psl",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-standard-library/php-standard-library.git",
+                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-standard-library/php-standard-library/zipball/74c95be0214eb7ea39146ed00ac4eb71b45d787b",
+                "reference": "74c95be0214eb7ea39146ed00ac4eb71b45d787b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-sodium": "*",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "revolt/event-loop": "^1.0.7"
+            },
+            "require-dev": {
+                "carthage-software/mago": "^1.6.0",
+                "infection/infection": "^0.31.2",
+                "php-coveralls/php-coveralls": "^2.7.0",
+                "phpbench/phpbench": "^1.4.0",
+                "phpunit/phpunit": "^9.6.22"
+            },
+            "suggest": {
+                "php-standard-library/phpstan-extension": "PHPStan integration",
+                "php-standard-library/psalm-plugin": "Psalm integration"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/hhvm/hsl",
+                    "name": "hhvm/hsl"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/bootstrap.php"
+                ],
+                "psr-4": {
+                    "Psl\\": "src/Psl"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/php-standard-library/php-standard-library/issues",
+                "source": "https://github.com/php-standard-library/php-standard-library/tree/4.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/azjezz",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/veewee",
+                    "type": "github"
+                }
+            ],
+            "abandoned": "php-standard-library/php-standard-library",
+            "time": "2026-02-24T01:58:53+00:00"
+        },
+        {
+            "name": "ergebnis/composer-normalize",
+            "version": "2.50.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/composer-normalize.git",
+                "reference": "80971fe24ff10709789942bcbe9368b2c704097c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/80971fe24ff10709789942bcbe9368b2c704097c",
+                "reference": "80971fe24ff10709789942bcbe9368b2c704097c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "ergebnis/json": "^1.4.0",
+                "ergebnis/json-normalizer": "^4.9.0",
+                "ergebnis/json-printer": "^3.7.0",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2.12 || ^6.0.0",
+                "localheinz/diff": "^1.3.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.9.4",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.59.0",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.20.0",
+                "ergebnis/rector-rules": "^1.9.0",
+                "fakerphp/faker": "^1.24.1",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.38",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.12",
+                "phpstan/phpstan-strict-rules": "^2.0.8",
+                "phpunit/phpunit": "^9.6.33",
+                "rector/rector": "^2.3.5",
+                "symfony/filesystem": "^5.4.41"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Ergebnis\\Composer\\Normalize\\NormalizePlugin",
+                "branch-alias": {
+                    "dev-main": "2.49-dev"
+                },
+                "plugin-optional": true,
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Composer\\Normalize\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a composer plugin for normalizing composer.json.",
+            "homepage": "https://github.com/ergebnis/composer-normalize",
+            "keywords": [
+                "composer",
+                "normalize",
+                "normalizer",
+                "plugin"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/composer-normalize/issues",
+                "security": "https://github.com/ergebnis/composer-normalize/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/composer-normalize"
+            },
+            "time": "2026-02-09T20:57:47+00:00"
+        },
+        {
+            "name": "ergebnis/json",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json.git",
+                "reference": "7b56d2b5d9e897e75b43e2e753075a0904c921b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json/zipball/7b56d2b5d9e897e75b43e2e753075a0904c921b1",
+                "reference": "7b56d2b5d9e897e75b43e2e753075a0904c921b1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.44.0",
+                "ergebnis/data-provider": "^3.3.0",
+                "ergebnis/license": "^2.5.0",
+                "ergebnis/php-cs-fixer-config": "^6.37.0",
+                "ergebnis/phpstan-rules": "^2.11.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.16.1",
+                "fakerphp/faker": "^1.24.0",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.22",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.7",
+                "phpstan/phpstan-strict-rules": "^2.0.6",
+                "phpunit/phpunit": "^9.6.24",
+                "rector/rector": "^2.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.7-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a Json value object for representing a valid JSON string.",
+            "homepage": "https://github.com/ergebnis/json",
+            "keywords": [
+                "json"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json/issues",
+                "security": "https://github.com/ergebnis/json/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/json"
+            },
+            "time": "2025-09-06T09:08:45+00:00"
+        },
+        {
+            "name": "ergebnis/json-normalizer",
+            "version": "4.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-normalizer.git",
+                "reference": "77961faf2c651c3f05977b53c6c68e8434febf62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/77961faf2c651c3f05977b53c6c68e8434febf62",
+                "reference": "77961faf2c651c3f05977b53c6c68e8434febf62",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/json": "^1.2.0",
+                "ergebnis/json-pointer": "^3.4.0",
+                "ergebnis/json-printer": "^3.5.0",
+                "ergebnis/json-schema-validator": "^4.2.0",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2.12 || ^6.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "composer/semver": "^3.4.3",
+                "ergebnis/composer-normalize": "^2.44.0",
+                "ergebnis/data-provider": "^3.3.0",
+                "ergebnis/license": "^2.5.0",
+                "ergebnis/php-cs-fixer-config": "^6.37.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.16.1",
+                "fakerphp/faker": "^1.24.0",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.10",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "phpunit/phpunit": "^9.6.19",
+                "rector/rector": "^1.2.10"
+            },
+            "suggest": {
+                "composer/semver": "If you want to use ComposerJsonNormalizer or VersionConstraintNormalizer"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.11-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Normalizer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides generic and vendor-specific normalizers for normalizing JSON documents.",
+            "homepage": "https://github.com/ergebnis/json-normalizer",
+            "keywords": [
+                "json",
+                "normalizer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-normalizer/issues",
+                "security": "https://github.com/ergebnis/json-normalizer/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/json-normalizer"
+            },
+            "time": "2025-09-06T09:18:13+00:00"
+        },
+        {
+            "name": "ergebnis/json-pointer",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-pointer.git",
+                "reference": "43bef355184e9542635e35dd2705910a3df4c236"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/43bef355184e9542635e35dd2705910a3df4c236",
+                "reference": "43bef355184e9542635e35dd2705910a3df4c236",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.43.0",
+                "ergebnis/data-provider": "^3.2.0",
+                "ergebnis/license": "^2.4.0",
+                "ergebnis/php-cs-fixer-config": "^6.32.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.15.0",
+                "fakerphp/faker": "^1.23.1",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.10",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "phpunit/phpunit": "^9.6.19",
+                "rector/rector": "^1.2.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.8-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Pointer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides an abstraction of a JSON pointer.",
+            "homepage": "https://github.com/ergebnis/json-pointer",
+            "keywords": [
+                "RFC6901",
+                "json",
+                "pointer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-pointer/issues",
+                "security": "https://github.com/ergebnis/json-pointer/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/json-pointer"
+            },
+            "time": "2025-09-06T09:28:19+00:00"
+        },
+        {
+            "name": "ergebnis/json-printer",
+            "version": "3.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-printer.git",
+                "reference": "211d73fc7ec6daf98568ee6ed6e6d133dee8503e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-printer/zipball/211d73fc7ec6daf98568ee6ed6e6d133dee8503e",
+                "reference": "211d73fc7ec6daf98568ee6ed6e6d133dee8503e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.44.0",
+                "ergebnis/data-provider": "^3.3.0",
+                "ergebnis/license": "^2.5.0",
+                "ergebnis/php-cs-fixer-config": "^6.37.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.16.1",
+                "fakerphp/faker": "^1.24.0",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.10",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.1",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "phpunit/phpunit": "^9.6.21",
+                "rector/rector": "^1.2.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.9-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\Printer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON printer, allowing for flexible indentation.",
+            "homepage": "https://github.com/ergebnis/json-printer",
+            "keywords": [
+                "formatter",
+                "json",
+                "printer"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-printer/issues",
+                "security": "https://github.com/ergebnis/json-printer/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/json-printer"
+            },
+            "time": "2025-09-06T09:59:26+00:00"
+        },
+        {
+            "name": "ergebnis/json-schema-validator",
+            "version": "4.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/json-schema-validator.git",
+                "reference": "b739527a480a9e3651360ad351ea77e7e9019df2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/json-schema-validator/zipball/b739527a480a9e3651360ad351ea77e7e9019df2",
+                "reference": "b739527a480a9e3651360ad351ea77e7e9019df2",
+                "shasum": ""
+            },
+            "require": {
+                "ergebnis/json": "^1.2.0",
+                "ergebnis/json-pointer": "^3.4.0",
+                "ext-json": "*",
+                "justinrainbow/json-schema": "^5.2.12 || ^6.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "ergebnis/composer-normalize": "^2.44.0",
+                "ergebnis/data-provider": "^3.3.0",
+                "ergebnis/license": "^2.5.0",
+                "ergebnis/php-cs-fixer-config": "^6.37.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.16.1",
+                "fakerphp/faker": "^1.24.0",
+                "infection/infection": "~0.26.6",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.10",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpstan/phpstan-strict-rules": "^1.6.1",
+                "phpunit/phpunit": "^9.6.20",
+                "rector/rector": "^1.2.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.6-dev"
+                },
+                "composer-normalize": {
+                    "indent-size": 2,
+                    "indent-style": "space"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\Json\\SchemaValidator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com",
+                    "homepage": "https://localheinz.com"
+                }
+            ],
+            "description": "Provides a JSON schema validator, building on top of justinrainbow/json-schema.",
+            "homepage": "https://github.com/ergebnis/json-schema-validator",
+            "keywords": [
+                "json",
+                "schema",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/ergebnis/json-schema-validator/issues",
+                "security": "https://github.com/ergebnis/json-schema-validator/blob/main/.github/SECURITY.md",
+                "source": "https://github.com/ergebnis/json-schema-validator"
+            },
+            "time": "2025-09-06T11:37:35+00:00"
+        },
+        {
+            "name": "justinrainbow/json-schema",
+            "version": "v6.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsonrainbow/json-schema.git",
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.4",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "3.3.0",
+                "json-schema/json-schema-test-suite": "^23.2",
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
+            },
+            "bin": [
+                "bin/validate-json"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JsonSchema\\": "src/JsonSchema/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bruno Prieto Reis",
+                    "email": "bruno.p.reis@gmail.com"
+                },
+                {
+                    "name": "Justin Rainbow",
+                    "email": "justin.rainbow@gmail.com"
+                },
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                },
+                {
+                    "name": "Robert Schönthal",
+                    "email": "seroscho@googlemail.com"
+                }
+            ],
+            "description": "A library to validate a json schema.",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
+            "keywords": [
+                "json",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/jsonrainbow/json-schema/issues",
+                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.2"
+            },
+            "time": "2026-02-15T15:06:22+00:00"
+        },
+        {
+            "name": "localheinz/diff",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/localheinz/diff.git",
+                "reference": "33bd840935970cda6691c23fc7d94ae764c0734c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/localheinz/diff/zipball/33bd840935970cda6691c23fc7d94ae764c0734c",
+                "reference": "33bd840935970cda6691c23fc7d94ae764c0734c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5.0 || ^8.5.23",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Fork of sebastian/diff for use with ergebnis/composer-normalize",
+            "homepage": "https://github.com/localheinz/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/localheinz/diff/issues",
+                "source": "https://github.com/localheinz/diff/tree/1.3.0"
+            },
+            "time": "2025-08-30T09:44:18+00:00"
+        },
+        {
+            "name": "maglnet/composer-require-checker",
+            "version": "4.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maglnet/ComposerRequireChecker.git",
+                "reference": "c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2",
+                "reference": "c62d517ef5ac2d347dd9b3d02c1cc16c0f1091e2",
+                "shasum": ""
+            },
+            "require": {
+                "azjezz/psl": "^4.2.0",
+                "composer-runtime-api": "^2.0.0",
+                "ext-phar": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "symfony/console": "^7.4.1",
+                "webmozart/glob": "^4.7.0"
+            },
+            "conflict": {
+                "revolt/event-loop": "< 1.0.8"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-zend-opcache": "*",
+                "phing/phing": "^3.1.1",
+                "php-standard-library/phpstan-extension": "^2.0.2",
+                "php-standard-library/psalm-plugin": "^2.3",
+                "phpstan/phpstan": "^2.1.33",
+                "phpunit/phpunit": "^12.5.4",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "roave/infection-static-analysis-plugin": "^1.42.0",
+                "spatie/temporary-directory": "^2.3.0",
+                "vimeo/psalm": "^6.14.3"
+            },
+            "bin": [
+                "bin/composer-require-checker"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "ComposerRequireChecker\\": "src/ComposerRequireChecker"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.io/"
+                },
+                {
+                    "name": "Matthias Glaub",
+                    "email": "magl@magl.net",
+                    "homepage": "http://magl.net"
+                }
+            ],
+            "description": "CLI tool to analyze composer dependencies and verify that no unknown symbols are used in the sources of a package",
+            "homepage": "https://github.com/maglnet/ComposerRequireChecker",
+            "keywords": [
+                "cli",
+                "composer",
+                "dependency",
+                "imports",
+                "require",
+                "requirements",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/maglnet/ComposerRequireChecker/issues",
+                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.20.0"
+            },
+            "time": "2025-12-29T11:34:42+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "reference": "bb426fcdd65c60fb3638ef741e8782508fda7eef",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.2"
+            },
+            "time": "2025-09-14T11:18:39+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.42",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-17T14:58:32+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "reference": "1aba28b697c1e3b6bbec8a1725f8b11b6d3e5a5f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.10"
+            },
+            "time": "2026-02-11T14:17:32+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.3.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/917842143fd9f5331a2adefc214b8d7143bd32c4",
+                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.40"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.3.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-03-16T09:43:55+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "reference": "b6fc06dce8e9b523c9946138fa5e62181934f91c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
+            },
+            "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
+                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-10T16:43:36+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/8a2842112d6916e61e0e15e316465b611f3abc17",
+                "reference": "8a2842112d6916e61e0e15e316465b611f3abc17",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.7.0"
+            },
+            "time": "2024-03-07T20:33:40+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.1"
+        "php": ">=8.2"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/tools/release/phpcs.xml
+++ b/tools/release/phpcs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="OpenEMR Release Tools">
+    <description>Coding standard for OpenEMR release tooling</description>
+
+    <arg name="extensions" value="php"/>
+    <arg name="colors"/>
+    <arg value="sp"/>
+
+    <file>src</file>
+    <file>bin</file>
+
+    <exclude-pattern>vendor</exclude-pattern>
+
+    <rule ref="PSR12"/>
+
+    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="150"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/tools/release/phpstan.neon
+++ b/tools/release/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+
+parameters:
+    level: 10
+    phpVersion: 80200
+    paths:
+        - src
+        - bin
+    checkMissingCallableSignature: true
+    checkUninitializedProperties: true
+    checkTooWideReturnTypesInProtectedAndPublicMethods: true
+    reportAlwaysTrueInLastCondition: true

--- a/tools/release/rector.php
+++ b/tools/release/rector.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/bin',
+    ])
+    ->withPhpVersion(Rector\ValueObject\PhpVersion::PHP_82)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+    )
+    ->withCache('/tmp/rector');

--- a/tools/release/src/ChangelogGenerator.php
+++ b/tools/release/src/ChangelogGenerator.php
@@ -8,7 +8,7 @@
  *
  * Extracted from openemr/openemr CreateReleaseChangelogCommand by Stephen Nielson.
  *
- * @package   openemr
+ * @package   openemr-devops
  * @link      https://www.open-emr.org
  * @author    Stephen Nielson <snielson@discoverandchange.com>
  * @author    Michael A. Smith <michael@opencoreemr.com>
@@ -24,12 +24,12 @@ namespace OpenEMR\Release;
 class ChangelogGenerator
 {
     /**
-     * @param list<array<string, mixed>> $issues Raw issues from the GitHub API
+     * @param array<string, mixed> $issue Raw issue from the GitHub API
      * @return array{number: int, category: string, title: string, url: string, is_dev: bool}
      */
-    private static function categorize(array $issue): array
+    private function categorize(array $issue): array
     {
-        $title = (string) $issue['title'];
+        $title = is_string($issue['title'] ?? null) ? $issue['title'] : '';
         $category = 'bug';
 
         $parts = explode(':', $title, 2);
@@ -39,18 +39,20 @@ class ChangelogGenerator
         }
 
         $isDev = false;
-        foreach ($issue['labels'] ?? [] as $label) {
-            if ($label['name'] === 'developers') {
+        /** @var list<array<string, mixed>> $labels */
+        $labels = $issue['labels'] ?? [];
+        foreach ($labels as $label) {
+            if (($label['name'] ?? '') === 'developers') {
                 $isDev = true;
                 break;
             }
         }
 
         return [
-            'number' => (int) $issue['number'],
+            'number' => is_int($issue['number'] ?? null) ? $issue['number'] : 0,
             'category' => $category,
             'title' => $title,
-            'url' => (string) $issue['html_url'],
+            'url' => is_string($issue['html_url'] ?? null) ? $issue['html_url'] : '',
             'is_dev' => $isDev,
         ];
     }
@@ -62,21 +64,22 @@ class ChangelogGenerator
      */
     public function generate(string $milestone, int $milestoneNumber, string $repo, array $issues): string
     {
-        $categorized = array_map(self::categorize(...), $issues);
+        $categorized = array_map($this->categorize(...), $issues);
         usort($categorized, fn(array $a, array $b): int => strcasecmp($a['title'], $b['title']));
 
         $standard = array_values(array_filter($categorized, fn(array $i): bool => !$i['is_dev']));
         $developer = array_values(array_filter($categorized, fn(array $i): bool => $i['is_dev']));
 
         $lines = [];
-        $lines[] = "## [{$milestone}](https://github.com/{$repo}/milestone/{$milestoneNumber}?closed=1) - " . date('Y-m-d');
+        $url = "https://github.com/{$repo}/milestone/{$milestoneNumber}?closed=1";
+        $lines[] = "## [{$milestone}]({$url}) - " . date('Y-m-d');
         $lines[] = '';
-        $lines = array_merge($lines, self::formatIssues($standard));
+        $lines = array_merge($lines, $this->formatIssues($standard));
 
         if (count($developer) > 0) {
             $lines[] = '### OpenEMR Developer Changes';
             $lines[] = '';
-            $lines = array_merge($lines, self::formatIssues($developer));
+            $lines = array_merge($lines, $this->formatIssues($developer));
         }
 
         return implode("\n", $lines) . "\n";
@@ -86,12 +89,12 @@ class ChangelogGenerator
      * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
      * @return list<string>
      */
-    private static function formatIssues(array $issues): array
+    private function formatIssues(array $issues): array
     {
         return array_merge(
-            self::formatByCategory($issues, 'feat', 'Added'),
-            self::formatByCategory($issues, 'bug', 'Fixed'),
-            self::formatOther($issues),
+            $this->formatByCategory($issues, 'feat', 'Added'),
+            $this->formatByCategory($issues, 'bug', 'Fixed'),
+            $this->formatOther($issues),
         );
     }
 
@@ -99,7 +102,7 @@ class ChangelogGenerator
      * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
      * @return list<string>
      */
-    private static function formatByCategory(array $issues, string $category, string $heading): array
+    private function formatByCategory(array $issues, string $category, string $heading): array
     {
         $matches = array_filter($issues, fn(array $i): bool => $i['category'] === $category);
         if (count($matches) === 0) {
@@ -119,7 +122,7 @@ class ChangelogGenerator
      * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
      * @return list<string>
      */
-    private static function formatOther(array $issues): array
+    private function formatOther(array $issues): array
     {
         $matches = array_filter($issues, fn(array $i): bool => !in_array($i['category'], ['feat', 'bug'], true));
         if (count($matches) === 0) {

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -3,7 +3,7 @@
 /**
  * Wrapper around the gh CLI for GitHub API calls.
  *
- * @package   openemr
+ * @package   openemr-devops
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
  * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
@@ -42,6 +42,7 @@ class GitHubApi
         }
 
         // --slurp wraps each page in an outer array: [[...page1...], [...page2...]]
+        /** @var list<list<array<string, mixed>>> $pages */
         return array_merge(...$pages);
     }
 
@@ -56,7 +57,9 @@ class GitHubApi
             $milestones = $this->paginate("/milestones?state={$state}&per_page=100");
             foreach ($milestones as $milestone) {
                 if ($milestone['title'] === $name) {
-                    return (int) $milestone['number'];
+                    /** @var int $number */
+                    $number = $milestone['number'];
+                    return $number;
                 }
             }
         }

--- a/tools/release/src/GlobalDefaultVisitor.php
+++ b/tools/release/src/GlobalDefaultVisitor.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Node visitor that updates the default value of a globals.inc.php setting.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+class GlobalDefaultVisitor extends NodeVisitorAbstract
+{
+    private bool $found = false;
+
+    public function __construct(
+        private readonly string $key,
+        private readonly string $value,
+    ) {
+    }
+
+    public function wasFound(): bool
+    {
+        return $this->found;
+    }
+
+    public function leaveNode(Node $node): ?Node
+    {
+        if (!$node instanceof ArrayItem) {
+            return null;
+        }
+        if (!$node->key instanceof String_ || $node->key->value !== $this->key) {
+            return null;
+        }
+        if (!$node->value instanceof Node\Expr\Array_) {
+            return null;
+        }
+        $defaultItem = $node->value->items[2] ?? null;
+        if (!$defaultItem instanceof ArrayItem) {
+            return null;
+        }
+        if (!$defaultItem->value instanceof String_) {
+            return null;
+        }
+        $defaultItem->value->value = $this->value;
+        $this->found = true;
+        return $node;
+    }
+}

--- a/tools/release/src/PreflightChecker.php
+++ b/tools/release/src/PreflightChecker.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Pre-release checks: milestone completeness and unpublished GHSAs.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+class PreflightChecker
+{
+    public function __construct(
+        private readonly GitHubApi $api,
+        private readonly string $repo,
+    ) {
+    }
+
+    /**
+     * Check that a milestone has no open issues or PRs.
+     *
+     * @return int 0 on success, 1 on failure
+     */
+    public function checkMilestone(string $milestone, OutputInterface $output): int
+    {
+        $process = new Process([
+            'gh', 'api',
+            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            '--jq', '.total_count',
+        ]);
+        $process->mustRun();
+        $count = (int) trim($process->getOutput());
+
+        if ($count === 0) {
+            $output->writeln("<info>✓</info> Milestone {$milestone}: no open items");
+            return 0;
+        }
+
+        $detail = new Process([
+            'gh', 'api',
+            "/search/issues?q=milestone:{$milestone}+repo:{$this->repo}+state:open",
+            '--jq', '.items[] | "  - #\(.number) \(.title)"',
+        ]);
+        $detail->mustRun();
+
+        $output->writeln("<error>✗</error> Milestone {$milestone}: {$count} open item(s)");
+        $output->write($detail->getOutput());
+        return 1;
+    }
+
+    /**
+     * Check for unpublished security advisories.
+     *
+     * @return int 0 on success, 1 on failure
+     */
+    public function checkGhsa(OutputInterface $output): int
+    {
+        $advisories = $this->api->paginate('/security-advisories');
+        $unpublished = array_filter(
+            $advisories,
+            static fn(array $a): bool => $a['state'] !== 'published',
+        );
+
+        if (count($unpublished) === 0) {
+            $output->writeln('<info>✓</info> No unpublished security advisories');
+            return 0;
+        }
+
+        $output->writeln(sprintf(
+            '<error>✗</error> %d unpublished security advisory/ies:',
+            count($unpublished),
+        ));
+        foreach ($unpublished as $advisory) {
+            $severity = is_string($advisory['severity'] ?? null) ? $advisory['severity'] : 'unknown';
+            $summary = is_string($advisory['summary'] ?? null) ? $advisory['summary'] : '';
+            $output->writeln("  - [{$severity}] {$summary}");
+        }
+        return 1;
+    }
+}

--- a/tools/release/src/VersionBumper.php
+++ b/tools/release/src/VersionBumper.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * AST-based version.php manipulator.
+ *
+ * Use php-parser to modify version variables without disturbing
+ * formatting, comments, or other code in the file.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+
+class VersionBumper
+{
+    /**
+     * Set $v_realpatch to the given value in a version.php file.
+     */
+    public function bumpPatch(string $file, string $patchNumber): self
+    {
+        return $this->setStringVariable($file, 'v_realpatch', $patchNumber);
+    }
+
+    /**
+     * Remove '-dev' suffix from $v_tag for a production release.
+     */
+    public function clearDevTag(string $file): self
+    {
+        return $this->transformVariable($file, 'v_tag', static function (String_ $str): void {
+            $str->value = str_replace('-dev', '', $str->value);
+        });
+    }
+
+    /**
+     * Set the default value of a globals.inc.php setting.
+     *
+     * Finds `'$key' => [... , '$value', ...]` in the globals array
+     * and replaces the third element (index 2, the default value).
+     */
+    public function setGlobalDefault(string $file, string $key, string $value): self
+    {
+        [$code, $parser, $origStmts] = $this->parseFile($file);
+
+        $visitor = new GlobalDefaultVisitor($key, $value);
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor($visitor);
+
+        $stmts = $traverser->traverse($origStmts);
+
+        if (!$visitor->wasFound()) {
+            throw new \RuntimeException("Global setting not found: {$key}");
+        }
+
+        $printer = new Standard();
+        file_put_contents(
+            $file,
+            $printer->printFormatPreserving($stmts, $origStmts, $parser->getTokens()),
+        );
+
+        return $this;
+    }
+
+    private function setStringVariable(string $file, string $varName, string $value): self
+    {
+        return $this->transformVariable($file, $varName, static function (String_ $str) use ($value): void {
+            $str->value = $value;
+        });
+    }
+
+    /**
+     * Apply a transformation to a string variable assignment in a PHP file.
+     *
+     * @param \Closure(String_): void $transform
+     */
+    private function transformVariable(string $file, string $varName, \Closure $transform): self
+    {
+        [$code, $parser, $origStmts] = $this->parseFile($file);
+
+        $traverser = new NodeTraverser();
+        $traverser->addVisitor(new class ($varName, $transform) extends NodeVisitorAbstract {
+            /** @param \Closure(String_): void $transform */
+            public function __construct(
+                private readonly string $varName,
+                private readonly \Closure $transform,
+            ) {
+            }
+
+            public function leaveNode(Node $node): ?Node
+            {
+                if (!$node instanceof Node\Stmt\Expression) {
+                    return null;
+                }
+                $expr = $node->expr;
+                if (!$expr instanceof Assign) {
+                    return null;
+                }
+                if (!$expr->var instanceof Variable || $expr->var->name !== $this->varName) {
+                    return null;
+                }
+                if (!$expr->expr instanceof String_) {
+                    return null;
+                }
+                ($this->transform)($expr->expr);
+                return $node;
+            }
+        });
+
+        $stmts = $traverser->traverse($origStmts);
+        $printer = new Standard();
+        file_put_contents(
+            $file,
+            $printer->printFormatPreserving($stmts, $origStmts, $parser->getTokens()),
+        );
+
+        return $this;
+    }
+
+    /**
+     * @return array{string, Parser, array<Node\Stmt>}
+     */
+    private function parseFile(string $file): array
+    {
+        $code = file_get_contents($file);
+        if ($code === false) {
+            throw new \RuntimeException("Cannot read file: {$file}");
+        }
+
+        $parser = (new ParserFactory())->createForNewestSupportedVersion();
+        $stmts = $parser->parse($code);
+        if ($stmts === null) {
+            throw new \RuntimeException("Failed to parse: {$file}");
+        }
+
+        return [$code, $parser, $stmts];
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of #593 — adds all remaining release task components:

- **VersionBumper** (`src/VersionBumper.php`): AST-based `version.php` manipulation using php-parser
  - Patch mode: sets `$v_realpatch`
  - Full mode: clears `-dev` from `$v_tag`, sets `allow_debug_language` default to `'0'`
- **PreflightChecker** (`src/PreflightChecker.php`): milestone open items via search API, unpublished GHSAs via security-advisories API
- **GlobalDefaultVisitor** (`src/GlobalDefaultVisitor.php`): php-parser node visitor for globals.inc.php array manipulation
- **Taskfile tasks**: checksum, tag, release, release:upload, changelog-pr, patch:assemble, summary — all calling PHP scripts, no embedded bash
- **CI workflow**: `.github/workflows/release-tools-php.yml` runs phpcs, PHPStan, Rector, and composer-require-checker in parallel
- **Static analysis config**: phpstan.neon (level 10 + strict rules), phpcs.xml (PSR-12), rector.php (deadCode + codeQuality + typeDeclarations)

### Known limitation

php-parser's format-preserving printer displaces inline comments when modifying `globals.inc.php` array items. Functionally correct, cosmetically imperfect.

## Test plan

- [ ] `task release:version-bump MODE=patch PATCH_NUMBER=3 OPENEMR_DIR=/path/to/openemr` — verify `$v_realpatch` changes
- [ ] `task release:version-bump MODE=full OPENEMR_DIR=/path/to/openemr` — verify `-dev` removed and `allow_debug_language` set to `'0'`
- [ ] `task release:preflight MILESTONE='7.0.3.1'` — milestone passes, GHSAs report unpublished count
- [ ] `task release:checksum FILE=somefile` — generates .md5/.sha256/.sha512 sidecars
- [ ] CI checks pass (phpcs, PHPStan, Rector, require-checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)