### PR TITLE
feat: refactor build-patch.yml to use release tools (Phase 3)

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -39,11 +39,23 @@ on:
         description: Generate and verify the app token (use with dry run to test permissions)
         type: boolean
         default: false
+      skip_milestone_check:
+        description: Skip milestone open-items check
+        type: boolean
+        default: false
+      skip_ghsa_check:
+        description: Skip unpublished GHSA check
+        type: boolean
+        default: false
 
 jobs:
   build-patch:
     runs-on: ubuntu-24.04
     name: Build Patch
+    env:
+      DEVOPS_DIR: ${{ github.workspace }}/devops-tools
+      OPENEMR_DIR: ${{ github.workspace }}/openemr
+      TOOLS_DIR: devops-tools/tools/release
     steps:
     - name: Validate inputs
       if: "!inputs.dry_run && inputs.release_tag == ''"
@@ -65,7 +77,6 @@ jobs:
       if: '!inputs.dry_run || inputs.validate_token'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        MILESTONE_NAME: ${{ inputs.milestone }}
       run: |
         echo "Checking app token can access openemr/openemr milestones..."
         gh api repos/openemr/openemr/milestones --jq '.[].title' | head -5
@@ -76,173 +87,71 @@ jobs:
       with:
         repository: openemr/openemr
         ref: ${{ inputs.version_branch }}
+        path: openemr
         token: ${{ steps.app-token.outputs.token || github.token }}
         filter: blob:none
         fetch-depth: 1
 
     - name: Fetch start tag
+      working-directory: openemr
       run: git fetch --filter=blob:none --depth=1 origin tag '${{ inputs.version_start }}'
 
-    - name: Bump version.php
-      env:
-        PATCH_NUMBER: ${{ inputs.patch_number }}
-      run: |
-        sed -i "s/^\$v_realpatch = '[0-9]*';/\$v_realpatch = '${PATCH_NUMBER}';/" version.php
+    - name: Checkout openemr-devops (release tools)
+      uses: actions/checkout@v6
+      with:
+        path: devops-tools
+        sparse-checkout: tools/release
 
-        echo 'Updated version.php:'
-        grep -n 'v_realpatch' version.php
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.4'
+
+    - name: Install Taskfile
+      uses: arduino/setup-task@v2
+      with:
+        version: 3.x
+
+    - name: Install release tools
+      run: task release:setup
+      working-directory: devops-tools
+
+    - name: Preflight checks
+      if: '!inputs.skip_milestone_check || !inputs.skip_ghsa_check'
+      working-directory: devops-tools
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+      run: >-
+        task release:preflight
+        MILESTONE='${{ inputs.milestone }}'
+        SKIP_MILESTONE='${{ inputs.skip_milestone_check }}'
+        SKIP_GHSA='${{ inputs.skip_ghsa_check }}'
+
+    - name: Bump version.php
+      working-directory: devops-tools
+      run: >-
+        task release:version-bump
+        MODE=patch
+        PATCH_NUMBER='${{ inputs.patch_number }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 
     - name: Commit and push version bump
       if: '!inputs.dry_run'
-      env:
-        PATCH_NUMBER: ${{ inputs.patch_number }}
+      working-directory: openemr
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
         git add version.php
-        git commit -m "chore: bump \$v_realpatch to ${PATCH_NUMBER} for patch release"
+        git commit -m 'chore: bump $v_realpatch to ${{ inputs.patch_number }} for patch release'
         git push origin HEAD:'${{ inputs.version_branch }}'
 
     - name: Generate changelog
+      working-directory: devops-tools
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-        MILESTONE_NAME: ${{ inputs.milestone }}
-      run: |
-        # Find the milestone number from the name
-        milestone_number=$(
-          gh api repos/openemr/openemr/milestones --paginate \
-            --jq ".[] | select(.title == \"${MILESTONE_NAME}\") | .number"
-        )
-
-        if [[ -z "$milestone_number" ]]; then
-          echo "::warning::Milestone '${MILESTONE_NAME}' not found — skipping changelog"
-          echo 'No changelog generated (milestone not found).' > /tmp/changelog.md
-          exit 0
-        fi
-
-        milestone_url="https://github.com/openemr/openemr/milestone/${milestone_number}?closed=1"
-        today=$(date +%Y-%m-%d)
-
-        # Fetch all closed issues for this milestone
-        gh api "repos/openemr/openemr/issues?milestone=${milestone_number}&state=closed&per_page=100" \
-          --paginate --jq '.[] | {
-            number,
-            title,
-            url: .html_url,
-            developer: ([.labels[].name] | any(. == "developers"))
-          }' > /tmp/issues.jsonl
-
-        # Generate changelog in the same format as the PHP command
-        {
-          echo "## [${MILESTONE_NAME}](${milestone_url}) - ${today}"
-          echo
-
-          for dev_filter in false true; do
-            if [[ "$dev_filter" = 'true' ]]; then
-              echo '### OpenEMR Developer Changes'
-              echo
-            fi
-
-            for section in Added Fixed Changed; do
-              matches=()
-              while IFS= read -r line; do
-                [[ -z "$line" ]] && continue
-
-                is_dev=$(echo "$line" | jq -r '.developer')
-                [[ "$is_dev" != "$dev_filter" ]] && continue
-
-                title=$(echo "$line" | jq -r '.title')
-                number=$(echo "$line" | jq -r '.number')
-                url=$(echo "$line" | jq -r '.url')
-
-                # Parse category from title prefix
-                if [[ "$title" =~ ^([a-zA-Z]+):\ *(.*) ]]; then
-                  category="${BASH_REMATCH[1]}"
-                  clean_title="${BASH_REMATCH[2]}"
-                else
-                  category='bug'
-                  clean_title="$title"
-                fi
-
-                case $section in
-                  Added)  [[ "$category" != 'feat' ]] && continue ;;
-                  Fixed)  [[ "$category" != 'bug' ]] && continue ;;
-                  Changed)
-                    [[ "$category" = 'feat' || "$category" = 'bug' ]] && continue ;;
-                esac
-
-                matches+=("  - ${clean_title} ([#${number}](${url}))")
-              done < /tmp/issues.jsonl
-
-              if (( ${#matches[@]} > 0 )); then
-                echo "### ${section}"
-                printf '%s\n' "${matches[@]}" | sort
-                echo
-              fi
-            done
-          done
-        } > /tmp/changelog.md
-
-        # Copy changelog to workspace for artifact/release upload
-        cp /tmp/changelog.md 'CHANGELOG.md'
-
-        echo 'Generated changelog:'
-        cat CHANGELOG.md
-
-    - name: Generate changed file list
-      id: diff
-      run: |
-        # Exclude removed files and paths that should not ship in a patch.
-        # Production installs do not need CI, testing, build tooling, or
-        # Docker configuration.
-        git diff --name-only --diff-filter=d \
-          '${{ inputs.version_start }}'..'${{ inputs.version_branch }}' \
-          -- . \
-          ':(exclude).github/**' \
-          ':(exclude).phpstan/**' \
-          ':(exclude).git/**' \
-          ':(exclude)ci/**' \
-          ':(exclude)docker/**' \
-          ':(exclude)tests/**' \
-          ':(exclude)tools/**' \
-          ':!.codespell*' \
-          ':!.composer-require-checker.json' \
-          ':!.dclintrc.yaml' \
-          ':!.editorconfig' \
-          ':!.gitattributes' \
-          ':!.gitignore' \
-          ':!.gitmodules' \
-          ':!.hadolint.yaml' \
-          ':!.pre-commit-config.yaml' \
-          ':!.shellcheckrc' \
-          ':!.stylelintignore' \
-          ':!.stylelintrc.json' \
-          ':!build.xml' \
-          ':!cloudbuild.yaml' \
-          ':!codecov.yml' \
-          ':!composer.json' \
-          ':!composer.lock' \
-          ':!eslint.config.mjs' \
-          ':!gulpfile.js' \
-          ':!jest.config.js' \
-          ':!package.json' \
-          ':!package-lock.json' \
-          ':!phpcs.xml.dist' \
-          ':!phpstan.neon.dist' \
-          ':!phpunit*.xml' \
-          ':!rector*.php' \
-          ':!run-semgrep.sh' \
-          ':!semgrep.yaml' \
-          ':!CLAUDE.md' \
-          ':!CONTRIBUTING.md' \
-          ':!CODE_OF_CONDUCT.md' \
-          ':!DOCKER_README.md' \
-          ':!README-Isolated-Testing.md' \
-          > /tmp/changed-files.txt
-
-        file_count=$(wc -l < /tmp/changed-files.txt)
-        printf 'Changed files (excluding removals): %d\n' "$file_count"
-        cat /tmp/changed-files.txt
+      run: >-
+        task release:changelog
+        MILESTONE='${{ inputs.milestone }}'
 
     - name: Build theme styles
       if: inputs.copy_styles
@@ -251,141 +160,40 @@ jobs:
         node-version: '22'
     - name: Install npm and build styles
       if: inputs.copy_styles
+      working-directory: openemr
       run: |
         npm ci
         npm run build
 
-    - name: Assemble patch directory
-      run: |
-        patch_dir='patch-output'
-        mkdir "$patch_dir"
+    - name: Assemble patch
+      working-directory: devops-tools
+      run: >-
+        task release:patch:assemble
+        START_TAG='${{ inputs.version_start }}'
+        BRANCH='${{ inputs.version_branch }}'
+        FILENAME='${{ inputs.patch_filename }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
+        COPY_STYLES='${{ inputs.copy_styles }}'
 
-        # Copy each changed file, preserving directory structure
-        while IFS= read -r file; do
-          if [[ -z "$file" ]]; then
-            continue
-          fi
-          dir="${file%/*}"
-          if [[ "$dir" != "$file" ]]; then
-            mkdir -p "${patch_dir}/${dir}"
-          fi
-          cp "$file" "${patch_dir}/${file}"
-        done < /tmp/changed-files.txt
-
-        # Copy compiled themes if requested
-        if [[ '${{ inputs.copy_styles }}' = 'true' ]]; then
-          echo 'Copying compiled theme styles'
-          mkdir -p "${patch_dir}/public/themes"
-          cp -R public/themes/* "${patch_dir}/public/themes/"
-        fi
-
-        # Blank out setup.php — patch should not re-run setup
-        true > "${patch_dir}/setup.php"
-
-        # Always include version.php and sql_patch.php
-        cp version.php "${patch_dir}/version.php"
-        cp sql_patch.php "${patch_dir}/sql_patch.php"
-
-        # Standardize file permissions
-        find "$patch_dir" -type f -execdir chmod 0644 {} +
-
-        # Report contents
-        echo
-        echo 'Patch file count:'
-        find "$patch_dir" -type f | wc -l
-        echo
-        echo 'Patch file listing:'
-        find "$patch_dir" -type f -printf '%P\n' | sort
-
-    - name: Create patch zip and checksums
-      run: |
-        (
-            cd patch-output &&
-            zip -r '../${{ inputs.patch_filename }}' .
-        )
-
-        md5sum '${{ inputs.patch_filename }}' > '${{ inputs.patch_filename }}.md5'
-        sha256sum '${{ inputs.patch_filename }}' > '${{ inputs.patch_filename }}.sha256'
-        sha512sum '${{ inputs.patch_filename }}' > '${{ inputs.patch_filename }}.sha512'
-
-        echo
-        echo 'MD5:'
-        cat '${{ inputs.patch_filename }}.md5'
-        echo
-        echo 'SHA-256:'
-        cat '${{ inputs.patch_filename }}.sha256'
-        echo
-        echo 'SHA-512:'
-        cat '${{ inputs.patch_filename }}.sha512'
+    - name: Generate checksums
+      working-directory: devops-tools
+      run: >-
+        task release:checksum
+        FILE='tools/release/release-output/${{ inputs.patch_filename }}'
 
     - name: Build summary
-      env:
-        RELEASE_TAG: ${{ inputs.release_tag }}
-        MILESTONE: ${{ inputs.milestone }}
-        PATCH_NUMBER: ${{ inputs.patch_number }}
-      run: |
-        # shellcheck disable=SC2016
-        {
-          echo '## Patch Build Results'
-          echo
-          echo '### Inputs'
-          echo '| Parameter | Value |'
-          echo '|-----------|-------|'
-          echo '| Start tag | `${{ inputs.version_start }}` |'
-          echo '| Release branch | `${{ inputs.version_branch }}` |'
-          echo '| Patch filename | `${{ inputs.patch_filename }}` |'
-          echo "| Milestone | \`${MILESTONE}\` |"
-          echo "| Patch number | \`${PATCH_NUMBER}\` |"
-          echo "| Release tag | \`${RELEASE_TAG:-(dry run)}\` |"
-          echo '| Dry run | `${{ inputs.dry_run }}` |'
-          echo '| Copy styles | `${{ inputs.copy_styles }}` |'
-          echo
-          echo '### Checksums'
-          echo '```'
-          cat '${{ inputs.patch_filename }}.md5'
-          cat '${{ inputs.patch_filename }}.sha256'
-          cat '${{ inputs.patch_filename }}.sha512'
-          echo '```'
-          echo
-          echo '### Changelog'
-          cat CHANGELOG.md
-          echo
-          printf '<details>\n<summary>Changed files (%d)</summary>\n\n```\n' \
-            "$(wc -l < /tmp/changed-files.txt)"
-          cat /tmp/changed-files.txt
-          printf '```\n</details>\n'
-          echo
-          echo '---'
-          echo
-          echo '### Announcement template'
-          echo
-          echo 'Copy and adapt the following for forums, social media, etc.:'
-          echo
-          echo '> **OpenEMR '"${MILESTONE}"' Patch Release**'
-          echo '>'
-          echo '> OpenEMR '"${MILESTONE}"' has been released. This patch includes'
-          echo "> $(wc -l < /tmp/changed-files.txt) updated files with bug fixes and improvements."
-          echo '>'
-          echo "> Download: https://github.com/openemr/openemr/releases/tag/${RELEASE_TAG:-(tag)}"
-          echo '>'
-          echo '> Changelog:'
-          echo '>'
-          # Indent changelog for blockquote
-          sed 's/^/> /' /tmp/changelog.md
-          echo
-          echo '---'
-          echo
-          echo '### Manual steps remaining'
-          echo
-          echo '- [ ] Upload patch to [website-openemr-files](https://github.com/openemr/website-openemr-files) repo'
-          echo '- [ ] Import via OpenEMR website tool'
-          echo '- [ ] Update [OpenEMR Patches](https://www.open-emr.org/wiki/index.php/OpenEMR_Patches) download page'
-          echo '- [ ] Trigger Docker build in [openemr-devops](https://github.com/openemr/openemr-devops/actions) (update tags first)'
-          echo '- [ ] Update DockerHub readme'
-          echo '- [ ] Update [Release History](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads) on wiki'
-          echo '- [ ] Point demo farm to new tag'
-          echo '- [ ] Announce: forums, chat, Twitter, Facebook, Diaspora, Mastodon, LinkedIn group+company, Reddit, Hacker News, registered users'
-        } >> "$GITHUB_STEP_SUMMARY"
+      working-directory: devops-tools
+      run: >-
+        task release:summary
+        TYPE=patch
+        MILESTONE='${{ inputs.milestone }}'
+        START_TAG='${{ inputs.version_start }}'
+        VERSION_BRANCH='${{ inputs.version_branch }}'
+        PATCH_FILENAME='${{ inputs.patch_filename }}'
+        PATCH_NUMBER='${{ inputs.patch_number }}'
+        RELEASE_TAG='${{ inputs.release_tag }}'
+        DRY_RUN='${{ inputs.dry_run }}'
+        COPY_STYLES='${{ inputs.copy_styles }}'
 
     - name: Upload workflow artifact (dry run)
       if: inputs.dry_run
@@ -394,23 +202,22 @@ jobs:
         name: ${{ inputs.patch_filename }}
         compression-level: 0
         path: |
-          ${{ inputs.patch_filename }}
-          ${{ inputs.patch_filename }}.md5
-          ${{ inputs.patch_filename }}.sha256
-          ${{ inputs.patch_filename }}.sha512
-          CHANGELOG.md
+          ${{ env.TOOLS_DIR }}/release-output/${{ inputs.patch_filename }}
+          ${{ env.TOOLS_DIR }}/release-output/${{ inputs.patch_filename }}.md5
+          ${{ env.TOOLS_DIR }}/release-output/${{ inputs.patch_filename }}.sha256
+          ${{ env.TOOLS_DIR }}/release-output/${{ inputs.patch_filename }}.sha512
+          ${{ env.TOOLS_DIR }}/release-output/changelog.md
         retention-days: 7
 
     - name: Create annotated tag and GitHub release
       if: '!inputs.dry_run'
+      working-directory: openemr
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: |
         tag='${{ inputs.release_tag }}'
+        output_dir='${{ env.DEVOPS_DIR }}/tools/release/release-output'
 
-        # Create an annotated tag. gh release create only makes lightweight
-        # tags, which are not copied into forks and are invisible to
-        # git describe without --tags.
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
@@ -421,71 +228,31 @@ jobs:
           git push origin "$tag"
         fi
 
-        # Create the release with changelog as release notes
         if ! gh release view "$tag" --repo openemr/openemr > /dev/null 2>&1; then
           echo "Creating release $tag"
           gh release create "$tag" \
             --repo openemr/openemr \
             --title "$tag" \
-            --notes-file /tmp/changelog.md \
+            --notes-file "${output_dir}/changelog.md" \
             --verify-tag
         fi
 
-        # Upload patch zip, checksums, and changelog
         gh release upload "$tag" \
           --repo openemr/openemr \
-          '${{ inputs.patch_filename }}' \
-          '${{ inputs.patch_filename }}.md5' \
-          '${{ inputs.patch_filename }}.sha256' \
-          '${{ inputs.patch_filename }}.sha512' \
-          'CHANGELOG.md' \
+          "${output_dir}/${{ inputs.patch_filename }}" \
+          "${output_dir}/${{ inputs.patch_filename }}.md5" \
+          "${output_dir}/${{ inputs.patch_filename }}.sha256" \
+          "${output_dir}/${{ inputs.patch_filename }}.sha512" \
+          "${output_dir}/changelog.md" \
           --clobber
 
     - name: Create CHANGELOG PRs
       if: '!inputs.dry_run'
+      working-directory: devops-tools
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
-        MILESTONE: ${{ inputs.milestone }}
-        VERSION_BRANCH: ${{ inputs.version_branch }}
-      run: |
-        git config user.name 'github-actions[bot]'
-        git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-
-        # Save the generated changelog entry before switching branches
-        cp /tmp/changelog.md /tmp/changelog-entry.md
-
-        for target in "$VERSION_BRANCH" master; do
-          branch="changelog-${MILESTONE}-${target}"
-
-          git checkout "$target"
-          git pull origin "$target"
-          git checkout -b "$branch"
-
-          # Prepend the new entry after the "# CHANGELOG.md" header line
-          if [[ -f CHANGELOG.md ]]; then
-            {
-              head -1 CHANGELOG.md
-              echo
-              cat /tmp/changelog-entry.md
-              echo
-              tail -n +2 CHANGELOG.md
-            } > CHANGELOG.md.tmp
-            mv CHANGELOG.md.tmp CHANGELOG.md
-          else
-            { echo '# CHANGELOG.md'; echo; cat /tmp/changelog-entry.md; } > CHANGELOG.md
-          fi
-
-          git add CHANGELOG.md
-          git commit -m "docs: add ${MILESTONE} changelog"
-          git push origin "$branch"
-
-          gh pr create \
-            --repo openemr/openemr \
-            --base "$target" \
-            --head "$branch" \
-            --title "docs: add ${MILESTONE} changelog" \
-            --body "Auto-generated changelog update from patch release workflow."
-
-          # Clean up branch for the next iteration
-          git checkout --detach
-        done
+      run: >-
+        task release:changelog-pr
+        MILESTONE='${{ inputs.milestone }}'
+        BRANCHES='${{ inputs.version_branch }},master'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -51,6 +51,8 @@ tasks:
         php bin/preflight.php
         --milestone={{shellQuote .MILESTONE}}
         --repo={{shellQuote .REPO}}
+        {{if .SKIP_MILESTONE}}--skip-milestone{{end}}
+        {{if .SKIP_GHSA}}--skip-ghsa{{end}}
 
   checksum:
     desc: Generate checksum sidecar files
@@ -135,3 +137,10 @@ tasks:
         --type={{shellQuote .TYPE}}
         --milestone={{shellQuote .MILESTONE}}
         --output-dir={{shellQuote .OUTPUT_DIR}}
+        {{if .RELEASE_TAG}}--release-tag={{shellQuote .RELEASE_TAG}}{{end}}
+        {{if .START_TAG}}--start-tag={{shellQuote .START_TAG}}{{end}}
+        {{if .VERSION_BRANCH}}--version-branch={{shellQuote .VERSION_BRANCH}}{{end}}
+        {{if .PATCH_FILENAME}}--patch-filename={{shellQuote .PATCH_FILENAME}}{{end}}
+        {{if .PATCH_NUMBER}}--patch-number={{shellQuote .PATCH_NUMBER}}{{end}}
+        {{if .DRY_RUN}}--dry-run{{end}}
+        {{if .COPY_STYLES}}--copy-styles{{end}}

--- a/tools/release/bin/patch-assemble.php
+++ b/tools/release/bin/patch-assemble.php
@@ -69,24 +69,53 @@ use Symfony\Component\Process\Process;
         mkdir($patchDir, 0755, true);
 
         // Get changed files, excluding CI/dev/test paths
+        // Exclude CI, testing, build tooling, and Docker configuration.
+        // Keep in sync with build-patch.yml's exclude list.
         $excludes = [
+            // Directories
             ':(exclude).github/**',
             ':(exclude).phpstan/**',
             ':(exclude).git/**',
+            ':(exclude)ci/**',
             ':(exclude)docker/**',
             ':(exclude)tests/**',
-            ':(exclude).dockerignore',
-            ':(exclude).editorconfig',
-            ':(exclude).eslintrc.js',
-            ':(exclude).markdownlint.json',
-            ':(exclude).overcommit.yml',
-            ':(exclude).phpcs.xml',
-            ':(exclude).phpunit*',
-            ':(exclude).stylelintrc.json',
-            ':(exclude)phpstan*',
-            ':(exclude)phpunit*',
-            ':(exclude)package.json',
-            ':(exclude)package-lock.json',
+            ':(exclude)tools/**',
+            // Dotfiles
+            ':!.codespell*',
+            ':!.composer-require-checker.json',
+            ':!.dclintrc.yaml',
+            ':!.editorconfig',
+            ':!.gitattributes',
+            ':!.gitignore',
+            ':!.gitmodules',
+            ':!.hadolint.yaml',
+            ':!.pre-commit-config.yaml',
+            ':!.shellcheckrc',
+            ':!.stylelintignore',
+            ':!.stylelintrc.json',
+            // Build/CI config files
+            ':!build.xml',
+            ':!cloudbuild.yaml',
+            ':!codecov.yml',
+            ':!composer.json',
+            ':!composer.lock',
+            ':!eslint.config.mjs',
+            ':!gulpfile.js',
+            ':!jest.config.js',
+            ':!package.json',
+            ':!package-lock.json',
+            ':!phpcs.xml.dist',
+            ':!phpstan.neon.dist',
+            ':!phpunit*.xml',
+            ':!rector*.php',
+            ':!run-semgrep.sh',
+            ':!semgrep.yaml',
+            // Documentation
+            ':!CLAUDE.md',
+            ':!CONTRIBUTING.md',
+            ':!CODE_OF_CONDUCT.md',
+            ':!DOCKER_README.md',
+            ':!README-Isolated-Testing.md',
         ];
 
         $diff = new Process(

--- a/tools/release/bin/summary.php
+++ b/tools/release/bin/summary.php
@@ -19,6 +19,8 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
 
 (new SingleCommandApplication())
     ->setName('summary')
@@ -27,6 +29,13 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
     ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Release artifacts directory', './release-output')
     ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file (or GITHUB_STEP_SUMMARY)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Release tag')
+    ->addOption('start-tag', null, InputOption::VALUE_REQUIRED, 'Start tag')
+    ->addOption('version-branch', null, InputOption::VALUE_REQUIRED, 'Release branch')
+    ->addOption('patch-filename', null, InputOption::VALUE_REQUIRED, 'Patch filename')
+    ->addOption('patch-number', null, InputOption::VALUE_REQUIRED, 'Patch number')
+    ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Whether this is a dry run')
+    ->addOption('copy-styles', null, InputOption::VALUE_NONE, 'Whether styles were copied')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         /** @var string $type */
         $type = $input->getOption('type');
@@ -47,60 +56,61 @@ use Symfony\Component\Console\SingleCommandApplication;
             return 1;
         }
 
-        $lines = [];
-        $lines[] = "## Release Summary: {$milestone}";
-        $lines[] = '';
+        $templateDir = dirname(__DIR__) . '/templates';
+        $templateFile = "{$type}-summary.md.twig";
+        if (!file_exists("{$templateDir}/{$templateFile}")) {
+            $output->writeln("<error>Template not found: {$templateFile}</error>");
+            return 1;
+        }
 
-        // Include checksums if available
+        // Collect checksums
+        $checksums = [];
         foreach (['md5', 'sha256', 'sha512'] as $ext) {
             $globResult = glob("{$outputDir}/*.{$ext}");
             if ($globResult === false) {
                 continue;
             }
             foreach ($globResult as $file) {
-                $content = trim((string) file_get_contents($file));
-                $lines[] = "**" . basename($file) . ":** `{$content}`";
+                $checksums[] = trim((string) file_get_contents($file));
             }
         }
-        $lines[] = '';
 
-        // Include changelog
+        // Read changelog
         $changelogFile = "{$outputDir}/changelog.md";
-        if (file_exists($changelogFile)) {
-            $lines[] = trim((string) file_get_contents($changelogFile));
-            $lines[] = '';
-        }
+        $changelog = file_exists($changelogFile)
+            ? trim((string) file_get_contents($changelogFile))
+            : '';
 
-        // Include changed files if patch
+        // Read changed files
+        $changedFiles = [];
         $changedFilesPath = "{$outputDir}/changed-files.txt";
-        if ($type === 'patch' && file_exists($changedFilesPath)) {
-            $changedFiles = file($changedFilesPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-            if ($changedFiles !== false) {
+        if (file_exists($changedFilesPath)) {
+            $raw = file($changedFilesPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            if ($raw !== false) {
+                $changedFiles = $raw;
                 sort($changedFiles);
-                $count = count($changedFiles);
-                $lines[] = "<details><summary>Changed files ({$count})</summary>";
-                $lines[] = '';
-                $lines[] = '```';
-                foreach ($changedFiles as $file) {
-                    $lines[] = $file;
-                }
-                $lines[] = '```';
-                $lines[] = '</details>';
-                $lines[] = '';
             }
         }
 
-        // Manual checklist
-        $lines[] = '### Post-Release Checklist';
-        $lines[] = '';
-        $lines[] = '- [ ] Upload to SourceForge';
-        $lines[] = '- [ ] Update Docker version files';
-        $lines[] = '- [ ] Update website';
-        $lines[] = '- [ ] Update wiki';
-        $lines[] = '- [ ] Post announcement to community forum';
-        $lines[] = '- [ ] Post announcement to chat';
+        $twig = new Environment(
+            new FilesystemLoader($templateDir),
+            ['autoescape' => false],
+        );
 
-        $content = implode("\n", $lines) . "\n";
+        $content = $twig->render($templateFile, [
+            'milestone' => $milestone,
+            'type' => $type,
+            'checksums' => $checksums,
+            'changelog' => $changelog,
+            'changed_files' => $changedFiles,
+            'release_tag' => $input->getOption('release-tag'),
+            'start_tag' => $input->getOption('start-tag'),
+            'version_branch' => $input->getOption('version-branch'),
+            'patch_filename' => $input->getOption('patch-filename'),
+            'patch_number' => $input->getOption('patch-number'),
+            'dry_run' => (bool) $input->getOption('dry-run'),
+            'copy_styles' => (bool) $input->getOption('copy-styles'),
+        ]);
 
         // Determine output destination
         /** @var ?string $outputFile */

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -7,7 +7,8 @@
         "php": ">=8.2",
         "nikic/php-parser": "^5.0",
         "symfony/console": "^7.0",
-        "symfony/process": "^7.0"
+        "symfony/process": "^7.0",
+        "twig/twig": "^3.24"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.48",

--- a/tools/release/composer.lock
+++ b/tools/release/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd34676694adb7b35678e72638537837",
+    "content-hash": "9ce59809361947bc65d9ac7a0fd2efb6",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -858,6 +858,86 @@
                 }
             ],
             "time": "2026-02-09T10:14:57+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-17T21:31:11+00:00"
         }
     ],
     "packages-dev": [

--- a/tools/release/templates/patch-checklist.md
+++ b/tools/release/templates/patch-checklist.md
@@ -1,0 +1,20 @@
+### Manual steps remaining
+
+- [ ] Upload patch to [website-openemr-files](https://github.com/openemr/website-openemr-files) repo
+- [ ] Import via OpenEMR website tool
+- [ ] Update [OpenEMR Patches](https://www.open-emr.org/wiki/index.php/OpenEMR_Patches) download page
+- [ ] Trigger Docker build in [openemr-devops](https://github.com/openemr/openemr-devops/actions) (update tags first)
+- [ ] Update DockerHub readme
+- [ ] Update [Release History](https://www.open-emr.org/wiki/index.php/OpenEMR_Downloads) on wiki
+- [ ] Point demo farm to new tag
+- [ ] Announce
+  - [ ] Forums
+  - [ ] Chat
+  - [ ] Twitter
+  - [ ] Facebook
+  - [ ] Diaspora
+  - [ ] Mastodon
+  - [ ] LinkedIn group+company
+  - [ ] Reddit
+  - [ ] Hacker News
+  - [ ] Registered users

--- a/tools/release/templates/patch-summary.md.twig
+++ b/tools/release/templates/patch-summary.md.twig
@@ -1,0 +1,55 @@
+## Patch Build Results
+
+### Inputs
+| Parameter | Value |
+|-----------|-------|
+| Start tag | `{{ start_tag }}` |
+| Release branch | `{{ version_branch }}` |
+| Patch filename | `{{ patch_filename }}` |
+| Milestone | `{{ milestone }}` |
+| Patch number | `{{ patch_number }}` |
+| Release tag | `{{ release_tag ?? '(dry run)' }}` |
+| Dry run | `{{ dry_run ? 'true' : 'false' }}` |
+| Copy styles | `{{ copy_styles ? 'true' : 'false' }}` |
+
+{% if checksums is not empty %}
+### Checksums
+```
+{% for checksum in checksums %}
+{{ checksum }}
+{% endfor %}
+```
+
+{% endif %}
+{% if changelog is not empty %}
+### Changelog
+{{ changelog }}
+
+{% endif %}
+{% if changed_files is not empty %}
+<details><summary>Changed files ({{ changed_files | length }})</summary>
+
+```
+{% for file in changed_files %}
+{{ file }}
+{% endfor %}
+```
+</details>
+
+{% endif %}
+---
+
+### Announcement template
+
+> **OpenEMR {{ milestone }} Patch Release**
+>
+> OpenEMR {{ milestone }} has been released.
+{% if changed_files is not empty %}
+> This patch includes {{ changed_files | length }} updated files with bug fixes and improvements.
+{% endif %}
+>
+> Download: https://github.com/openemr/openemr/releases/tag/{{ release_tag ?? '(tag)' }}
+
+---
+
+{% include 'patch-checklist.md' %}


### PR DESCRIPTION
## Summary

Phase 3 of #593 — refactors `build-patch.yml` to use the release tools from Phases 1 and 2.

**Before:** ~490 lines of inline bash in workflow YAML
**After:** workflow calls `task release:*`, net -29 lines, all logic in PHP scripts and Twig templates

Changes:
- Workflow uses `task release:*` commands throughout (not `php bin/*.php` directly)
- Adds `skip_milestone_check` and `skip_ghsa_check` workflow inputs
- Summary fully rendered via Twig (`templates/patch-summary.md.twig`)
- Manual checklist extracted to `templates/patch-checklist.md`, included by Twig
- `patch-assemble.php` exclude list synced with workflow's comprehensive set (45 entries)
- Taskfile updated with preflight skip flags and summary pass-through options
- Added `twig/twig` dependency

## Test plan

- [ ] Trigger `build-patch.yml` with `dry_run=true` and compare artifact output to a previous real patch release
- [ ] Verify preflight checks run (and can be skipped with flags)
- [ ] Verify version.php bump appears in the build
- [ ] Verify changelog matches expected format
- [ ] Verify summary includes inputs table, checksums, changelog, changed files, announcement, and checklist
- [ ] CI checks pass (phpcs, PHPStan, Rector, require-checker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)