### PR TITLE
ci: add actionlint workflow for GitHub Actions linting

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,23 @@
+name: actionlint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: error


### PR DESCRIPTION
## Summary

Add an actionlint CI workflow that lints all workflow files on push/PR to master.

Uses [reviewdog/action-actionlint](https://github.com/reviewdog/action-actionlint) which runs actionlint and posts inline annotations on PRs.

## Test plan

- [ ] CI runs and reports any existing actionlint findings as annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)