### PR TITLE
fix: prefix bare redirections with : to satisfy SC2188

### DIFF
--- a/.github/workflows/dclint.yml
+++ b/.github/workflows/dclint.yml
@@ -108,7 +108,7 @@ jobs:
             # Check if we've seen this hash before
             [[ -f "/tmp/dclint-hashes/$hash" ]] && continue
             # New unique file
-            > "/tmp/dclint-hashes/$hash"
+            : > "/tmp/dclint-hashes/$hash"
             unique_files+=( "$file" )
           done
 

--- a/.github/workflows/hadolint.yml
+++ b/.github/workflows/hadolint.yml
@@ -85,7 +85,7 @@ jobs:
             # Check if we've seen this hash before
             [[ -f "/tmp/hadolint-hashes/$hash" ]] && continue
             # New unique file
-            > "/tmp/hadolint-hashes/$hash"
+            : > "/tmp/hadolint-hashes/$hash"
             unique_files+=( "$file" )
           done
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -132,7 +132,7 @@ jobs:
             # Check if we've seen this hash before
             [[ -f "/tmp/shellcheck-hashes/$hash" ]] && continue
             # New unique file
-            > "/tmp/shellcheck-hashes/$hash"
+            : > "/tmp/shellcheck-hashes/$hash"
             unique_files+=( "$file" )
           done
 


### PR DESCRIPTION
## Summary
- Bare `> file` redirections in workflow inline scripts trigger shellcheck SC2188
- Replace with `: > file` (`:` is the shell no-op builtin) in dclint, hadolint, and shellcheck workflows
- Fixes the actionlint CI failure on master

## Test plan
- [ ] actionlint CI passes on this PR