### PR TITLE
fix: correct doubled path in build-patch checksum step

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -179,7 +179,7 @@ jobs:
       working-directory: devops-tools
       run: >-
         task release:checksum
-        FILE='tools/release/release-output/${{ inputs.patch_filename }}'
+        FILE='release-output/${{ inputs.patch_filename }}'
 
     - name: Build summary
       working-directory: devops-tools


### PR DESCRIPTION
## Summary
- The `Generate checksums` step passed `FILE='tools/release/release-output/...'` but the task already runs from `tools/release/` (set by the root Taskfile's `dir:` directive), creating a doubled path: `tools/release/tools/release/release-output/...`
- Fix: pass `release-output/...` instead

## Failed run
https://github.com/openemr/openemr-devops/actions/runs/23554789683/job/68578448773

🤖 Generated with [Claude Code](https://claude.com/claude-code)