### PR TITLE
chore: prune outdated items from release checklists

### DIFF
--- a/tools/release/templates/full-checklist.md
+++ b/tools/release/templates/full-checklist.md
@@ -13,9 +13,5 @@
   - [ ] Chat
   - [ ] Twitter
   - [ ] Facebook
-  - [ ] Diaspora
-  - [ ] Mastodon
   - [ ] LinkedIn group+company
-  - [ ] Reddit
-  - [ ] Hacker News
   - [ ] Registered users

--- a/tools/release/templates/patch-checklist.md
+++ b/tools/release/templates/patch-checklist.md
@@ -1,7 +1,5 @@
 ### Manual steps remaining
 
-- [ ] Upload patch to [website-openemr-files](https://github.com/openemr/website-openemr-files) repo
-- [ ] Import via OpenEMR website tool
 - [ ] Update [OpenEMR Patches](https://www.open-emr.org/wiki/index.php/OpenEMR_Patches) download page
 - [ ] Trigger Docker build in [openemr-devops](https://github.com/openemr/openemr-devops/actions) (update tags first)
 - [ ] Update DockerHub readme
@@ -12,9 +10,5 @@
   - [ ] Chat
   - [ ] Twitter
   - [ ] Facebook
-  - [ ] Diaspora
-  - [ ] Mastodon
   - [ ] LinkedIn group+company
-  - [ ] Reddit
-  - [ ] Hacker News
   - [ ] Registered users


### PR DESCRIPTION
## Summary
- Remove website-openemr-files upload and import steps from patch checklist (no longer used)
- Remove Diaspora, Mastodon, Hacker News, and Reddit from announcement lists in both patch and full release checklists

🤖 Generated with [Claude Code](https://claude.com/claude-code)