### PR TITLE
feat: support worktrees in the easy dev environments

### DIFF
--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -395,7 +395,16 @@ cmd_worktree_remove() {
     fi
 
     wt_info "Removing git worktree"
-    git -C "${OPENEMR_ROOT}" worktree remove --force "${dir}" 2>/dev/null || rm -rf "${dir}"
+
+    if ! git -C "${OPENEMR_ROOT}" worktree remove --force "${dir}" 2>/dev/null; then
+        # Validate dir before recursive delete — guard against corrupted state file
+        if [[ -z "${dir}" ]] || \
+           [[ "${dir}" != "${WORKTREE_PARENT}/openemr-wt-"* ]] || \
+           [[ "${dir}" == "/" ]]; then
+            wt_die "Refusing to delete '${dir}': path does not match expected worktree location"
+        fi
+        rm -rf "${dir}"
+    fi
     git -C "${OPENEMR_ROOT}" worktree prune
 
     wt_state_remove "${branch}"


### PR DESCRIPTION
support worktrees in the easy dev environments

This will allow running easy/easy-light/easy-redis docker dev environments in multiple worktrees at same time.

Generated-By: Claude


Needs following PR in core to work:
https://github.com/openemr/openemr/pull/11410

to create a new worktree (and a new branch)
git worktree add awesome -b

to create a new worktree (with a already existent branch)
git worktree add awesome

other commands are documented via `openemr-cmd` or `openemr-cmd worktree`