### PR TITLE
refactor: rewrite changelog generator to use commit ranges instead of milestones

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -1,4 +1,5 @@
 name: Build Patch Release
+run-name: "Build Patch Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry run)' || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,9 +16,13 @@ on:
         description: Patch zip filename (e.g., 8-0-0-Patch-1.zip)
         required: true
         type: string
-      milestone:
-        description: GitHub milestone name for changelog (e.g., 8.0.0.1)
+      version:
+        description: Human-readable version (e.g., 8.0.0.1)
         required: true
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.0.0.1)
+        required: false
         type: string
       patch_number:
         description: Patch number to set in version.php $v_realpatch (e.g., 1)
@@ -117,15 +122,15 @@ jobs:
       working-directory: devops-tools
 
     - name: Preflight checks
-      if: '!inputs.skip_milestone_check || !inputs.skip_ghsa_check'
+      if: '(!inputs.skip_milestone_check && inputs.milestone != '''') || !inputs.skip_ghsa_check'
       working-directory: devops-tools
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:preflight
         MILESTONE='${{ inputs.milestone }}'
-        SKIP_MILESTONE='${{ inputs.skip_milestone_check }}'
-        SKIP_GHSA='${{ inputs.skip_ghsa_check }}'
+        SKIP_MILESTONE='${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}'
+        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
 
     - name: Bump version.php
       working-directory: devops-tools
@@ -151,7 +156,9 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:changelog
-        MILESTONE='${{ inputs.milestone }}'
+        BASE_REF='${{ inputs.version_start }}'
+        HEAD_REF='${{ inputs.version_branch }}'
+        TITLE='${{ inputs.version }}'
 
     - name: Build theme styles
       if: inputs.copy_styles
@@ -253,6 +260,6 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:changelog-pr
-        MILESTONE='${{ inputs.milestone }}'
+        VERSION='${{ inputs.version }}'
         BRANCHES='${{ inputs.version_branch }},master'
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,5 @@
 name: Build Release
+run-name: "Build Release ${{ inputs.version }}${{ inputs.dry_run && ' (dry run)' || '' }}"
 
 on:
   workflow_dispatch:
@@ -15,9 +16,13 @@ on:
         description: Git tag (e.g., v8_0_0). Required unless dry run.
         required: false
         type: string
-      milestone:
-        description: GitHub milestone name (e.g., 8.0.0)
+      base_ref:
+        description: Previous release tag for changelog (e.g., v7_3_7)
         required: true
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.0.0)
+        required: false
         type: string
       dry_run:
         description: Dry run — build only, skip release
@@ -113,15 +118,15 @@ jobs:
       run: task release:setup
 
     - name: Preflight checks
-      if: '!inputs.skip_milestone_check || !inputs.skip_ghsa_check'
+      if: '(!inputs.skip_milestone_check && inputs.milestone != '''') || !inputs.skip_ghsa_check'
       working-directory: devops-tools
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:preflight
         MILESTONE='${{ inputs.milestone }}'
-        SKIP_MILESTONE='${{ inputs.skip_milestone_check }}'
-        SKIP_GHSA='${{ inputs.skip_ghsa_check }}'
+        SKIP_MILESTONE='${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}'
+        SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
 
     - name: Version bump (full mode)
       working-directory: devops-tools
@@ -146,7 +151,9 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:changelog
-        MILESTONE='${{ inputs.milestone }}'
+        BASE_REF='${{ inputs.base_ref }}'
+        HEAD_REF='${{ inputs.version_branch }}'
+        TITLE='${{ inputs.version }}'
 
     - name: Create annotated tag and GitHub release
       if: '!inputs.dry_run'
@@ -240,7 +247,7 @@ jobs:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
       run: >-
         task release:changelog-pr
-        MILESTONE='${{ inputs.milestone }}'
+        VERSION='${{ inputs.version }}'
         BRANCHES='${{ inputs.version_branch }},master'
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -16,17 +16,20 @@ tasks:
       - vendor/autoload.php
 
   changelog:
-    desc: Generate changelog from GitHub milestone
+    desc: Generate changelog from commit range
     requires:
-      vars: [MILESTONE]
+      vars: [BASE_REF]
     deps: [setup]
     cmds:
-      - mkdir -p {{.OUTPUT_DIR}}
+      - mkdir -p {{shellQuote .OUTPUT_DIR}}
       - >-
         php bin/changelog.php
-        --milestone={{shellQuote .MILESTONE}}
+        --base={{shellQuote .BASE_REF}}
+        {{if .HEAD_REF}}--head={{shellQuote .HEAD_REF}}{{end}}
+        {{if .TITLE}}--title={{shellQuote .TITLE}}{{end}}
         --repo={{shellQuote .REPO}}
         --output={{shellQuote .OUTPUT_DIR}}/changelog.md
+        {{if eq .NO_GHSA "1"}}--no-ghsa{{end}}
 
   version-bump:
     desc: Bump version numbers in OpenEMR source files
@@ -43,16 +46,14 @@ tasks:
 
   preflight:
     desc: Run pre-release checks
-    requires:
-      vars: [MILESTONE]
     deps: [setup]
     cmds:
       - >-
         php bin/preflight.php
-        --milestone={{shellQuote .MILESTONE}}
+        {{if and .MILESTONE (ne .SKIP_MILESTONE "1")}}--milestone={{shellQuote .MILESTONE}}{{end}}
         --repo={{shellQuote .REPO}}
-        {{if .SKIP_MILESTONE}}--skip-milestone{{end}}
-        {{if .SKIP_GHSA}}--skip-ghsa{{end}}
+        {{if eq .SKIP_MILESTONE "1"}}--skip-milestone{{end}}
+        {{if eq .SKIP_GHSA "1"}}--skip-ghsa{{end}}
 
   checksum:
     desc: Generate checksum sidecar files
@@ -100,12 +101,12 @@ tasks:
   changelog-pr:
     desc: Create CHANGELOG.md update PRs
     requires:
-      vars: [MILESTONE, BRANCHES, OPENEMR_DIR]
+      vars: [VERSION, BRANCHES, OPENEMR_DIR]
     deps: [setup]
     cmds:
       - >-
         php bin/changelog-pr.php
-        --milestone={{shellQuote .MILESTONE}}
+        --version={{shellQuote .VERSION}}
         --branches={{shellQuote .BRANCHES}}
         --openemr-dir={{shellQuote .OPENEMR_DIR}}
         --changelog-file={{shellQuote .OUTPUT_DIR}}/changelog.md

--- a/tools/release/bin/changelog-pr.php
+++ b/tools/release/bin/changelog-pr.php
@@ -24,14 +24,14 @@ use Symfony\Component\Process\Process;
 (new SingleCommandApplication())
     ->setName('changelog-pr')
     ->setDescription('Create CHANGELOG.md update PRs')
-    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->addOption('version', null, InputOption::VALUE_REQUIRED, 'Version string (e.g., 8.0.0.3)')
     ->addOption('branches', null, InputOption::VALUE_REQUIRED, 'Comma-separated target branches')
     ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to openemr checkout')
     ->addOption('changelog-file', null, InputOption::VALUE_REQUIRED, 'Path to changelog entry file')
     ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo', 'openemr/openemr')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        /** @var string $milestone */
-        $milestone = $input->getOption('milestone');
+        /** @var string $version */
+        $version = $input->getOption('version');
         /** @var string $openemrDir */
         $openemrDir = $input->getOption('openemr-dir');
         /** @var string $changelogFile */
@@ -41,7 +41,7 @@ use Symfony\Component\Process\Process;
         /** @var string $branchesRaw */
         $branchesRaw = $input->getOption('branches');
 
-        foreach (['milestone', 'branches', 'openemr-dir', 'changelog-file'] as $required) {
+        foreach (['version', 'branches', 'openemr-dir', 'changelog-file'] as $required) {
             if ($input->getOption($required) === null) {
                 $output->writeln("<error>--{$required} is required</error>");
                 return 1;
@@ -63,7 +63,7 @@ use Symfony\Component\Process\Process;
 
         foreach ($branches as $branch) {
             $branch = trim($branch);
-            $prBranch = "changelog-{$milestone}-{$branch}";
+            $prBranch = "changelog-{$version}-{$branch}";
 
             // Check if PR already exists
             $check = new Process(
@@ -97,7 +97,7 @@ use Symfony\Component\Process\Process;
             // Commit, push, create PR
             (new Process(['git', 'add', 'CHANGELOG.md'], $openemrDir))->mustRun();
             (new Process(
-                ['git', 'commit', '-m', "docs: add {$milestone} changelog"],
+                ['git', 'commit', '-m', "docs: add {$version} changelog"],
                 $openemrDir,
             ))->mustRun();
             (new Process(['git', 'push', 'origin', $prBranch], $openemrDir))->mustRun();
@@ -106,8 +106,8 @@ use Symfony\Component\Process\Process;
                 '--repo', $repo,
                 '--base', $branch,
                 '--head', $prBranch,
-                '--title', "docs: add {$milestone} changelog",
-                '--body', "Add changelog entry for {$milestone} release.",
+                '--title', "docs: add {$version} changelog",
+                '--body', "Add changelog entry for {$version} release.",
             ]))->mustRun();
 
             $output->writeln("Created PR for <info>{$prBranch}</info> → {$branch}");

--- a/tools/release/bin/changelog.php
+++ b/tools/release/bin/changelog.php
@@ -2,7 +2,7 @@
 <?php
 
 /**
- * Generate a changelog from a GitHub milestone.
+ * Generate a changelog from the commit range between two git refs.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -24,35 +24,38 @@ use Symfony\Component\Console\SingleCommandApplication;
 
 (new SingleCommandApplication())
     ->setName('changelog')
-    ->setDescription('Generate changelog from a GitHub milestone')
-    ->addOption('milestone', 'm', InputOption::VALUE_REQUIRED, 'Milestone name')
+    ->setDescription('Generate changelog from a commit range')
+    ->addOption('base', 'b', InputOption::VALUE_REQUIRED, 'Base ref (tag)')
+    ->addOption('head', null, InputOption::VALUE_REQUIRED, 'Head ref (tag or branch)', 'HEAD')
+    ->addOption('title', 't', InputOption::VALUE_REQUIRED, 'Version string for the heading')
+    ->addOption('no-ghsa', null, InputOption::VALUE_NONE, 'Disable security advisories section')
     ->addOption('repo', 'r', InputOption::VALUE_REQUIRED, 'GitHub repo (owner/name)', 'openemr/openemr')
     ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file path (omit for stdout)')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        /** @var ?string $milestone */
-        $milestone = $input->getOption('milestone');
-        if ($milestone === null) {
-            $output->writeln('<error>--milestone is required</error>');
+        /** @var ?string $base */
+        $base = $input->getOption('base');
+        if ($base === null) {
+            $output->writeln('<error>--base is required</error>');
             return 1;
         }
+
+        /** @var string $head */
+        $head = $input->getOption('head');
+        /** @var ?string $title */
+        $title = $input->getOption('title');
+        $includeGhsa = $input->getOption('no-ghsa') !== true;
 
         /** @var string $repo */
         $repo = $input->getOption('repo');
         $api = new GitHubApi($repo);
 
-        $milestoneNumber = $api->findMilestone($milestone);
         $output->writeln(
-            "Found milestone <info>{$milestone}</info> (#{$milestoneNumber})",
+            "Generating changelog for <info>{$base}...{$head}</info>",
             OutputInterface::VERBOSITY_VERBOSE,
         );
 
-        $issues = $api->closedIssuesForMilestone($milestoneNumber);
-        $output->writeln(
-            sprintf('Fetched <info>%d</info> closed issues', count($issues)),
-            OutputInterface::VERBOSITY_VERBOSE,
-        );
-
-        $changelog = (new ChangelogGenerator())->generate($milestone, $milestoneNumber, $repo, $issues);
+        $generator = new ChangelogGenerator($api, $repo);
+        $changelog = $generator->generate($base, $head, $title, $includeGhsa);
 
         /** @var ?string $outputFile */
         $outputFile = $input->getOption('output');

--- a/tools/release/src/ChangelogGenerator.php
+++ b/tools/release/src/ChangelogGenerator.php
@@ -1,12 +1,11 @@
 <?php
 
 /**
- * Generate a changelog from GitHub milestone issues.
+ * Generate a changelog from the commit range between two git refs.
  *
- * Categorize issues by title prefix (feat: → Added, bug: → Fixed, others → Changed)
- * and separate issues labeled "developers" into their own section.
- *
- * Extracted from openemr/openemr CreateReleaseChangelogCommand by Stephen Nielson.
+ * Walk commits between base and head, resolve to merged PRs, parse
+ * conventional commit prefixes from PR titles, and match published
+ * GHSAs whose fix commits fall in the range.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -21,119 +20,329 @@ declare(strict_types=1);
 
 namespace OpenEMR\Release;
 
+/**
+ * @phpstan-type CategorizedPr array{
+ *     number: int, category: string, area: string,
+ *     title: string, url: string, is_dev: bool,
+ * }
+ * @phpstan-type Advisory array{ghsa_id: string, severity: string, summary: string, url: string}
+ */
 class ChangelogGenerator
 {
+    private const CATEGORY_MAP = [
+        'feat' => 'Added',
+        'fix' => 'Fixed',
+        'deps' => 'Dependencies',
+    ];
+
+    /** @var list<string> */
+    private const SECTION_ORDER = ['Fixed', 'Added', 'Changed', 'Dependencies'];
+
+    private const DEFAULT_CATEGORY = 'Changed';
+
+    /** @var string */
+    private const CC_PATTERN = '/^(feat|fix|deps|chore|refactor|docs|perf|test|ci|build|style)(\(.+?\))?!?:\s*(.+)$/i';
+
     /**
-     * @param array<string, mixed> $issue Raw issue from the GitHub API
-     * @return array{number: int, category: string, title: string, url: string, is_dev: bool}
+     * Labels that are process/meta labels rather than functional areas.
+     * PRs with only these labels get no area sub-group.
+     *
+     * @var list<string>
      */
-    private function categorize(array $issue): array
-    {
-        $title = is_string($issue['title'] ?? null) ? $issue['title'] : '';
-        $category = 'bug';
+    private const SKIP_LABELS = [
+        'backport',
+        'bleeding',
+        'BUMP-NEXT-PATCH',
+        'can\'t fix it all in 1 PR',
+        'Deprecated',
+        'developers',
+        'Double Check',
+        'For Prior Version',
+        'Fund',
+        'good first issue',
+        'help-wanted',
+        'MERGE CONFLICT',
+        'Mentored Item',
+        'needs gifs',
+        'parent issue',
+        'patching',
+        'Priority: Blocking',
+        'Reported Forum Issue',
+        'Resolved. Awaiting authors approval.',
+        'RESPOND NOW OR SUFFER',
+        'Sad State of Affairs',
+        'SPECIAL INSTRUCTIONS',
+        'Stale',
+        'stalebot-ignore',
+        'Status: Can\'t Reproduce',
+        'Status: Needs Issue',
+        'Status: Needs Release Merge',
+        'Status: Needs Review',
+        'Status: Needs Work',
+        'Status: Pending Removal',
+        'Status: Ready for Integration',
+        'Status: Reviewed',
+        'up for grabs demo',
+        'WaitingForInfo',
 
-        $parts = explode(':', $title, 2);
-        if (count($parts) > 1) {
-            $category = trim($parts[0]);
-            $title = trim($parts[1]);
-        }
+        // Meta labels handled separately
+        'AI Code Assistant',
+        'Best PR Title of the Year Finalist',
+        'dependencies',
+        'github-actions',
+        'Clinician Input Requested',
+    ];
 
-        $isDev = false;
-        /** @var list<array<string, mixed>> $labels */
-        $labels = $issue['labels'] ?? [];
-        foreach ($labels as $label) {
-            if (($label['name'] ?? '') === 'developers') {
-                $isDev = true;
-                break;
-            }
-        }
-
-        return [
-            'number' => is_int($issue['number'] ?? null) ? $issue['number'] : 0,
-            'category' => $category,
-            'title' => $title,
-            'url' => is_string($issue['html_url'] ?? null) ? $issue['html_url'] : '',
-            'is_dev' => $isDev,
-        ];
+    public function __construct(
+        private readonly GitHubApi $api,
+        private readonly string $repo = 'openemr/openemr',
+    ) {
     }
 
     /**
-     * Generate a markdown changelog for the given milestone.
+     * Generate a changelog from the commit range between two refs.
      *
-     * @param list<array<string, mixed>> $issues Raw issues from the GitHub API
+     * @param string $base Base ref (tag)
+     * @param string $head Head ref (tag or branch)
+     * @param ?string $title Version string for the heading (omit for body only)
+     * @param bool $includeGhsa Include security advisories section
      */
-    public function generate(string $milestone, int $milestoneNumber, string $repo, array $issues): string
+    public function generate(string $base, string $head, ?string $title = null, bool $includeGhsa = true): string
     {
-        $categorized = array_map($this->categorize(...), $issues);
-        usort($categorized, fn(array $a, array $b): int => strcasecmp($a['title'], $b['title']));
+        $shas = $this->api->commitsBetweenRefs($base, $head);
+        $prs = $this->api->prsForCommits($shas);
 
-        $standard = array_values(array_filter($categorized, fn(array $i): bool => !$i['is_dev']));
-        $developer = array_values(array_filter($categorized, fn(array $i): bool => $i['is_dev']));
+        $categorized = array_map($this->categorize(...), $prs);
+        usort($categorized, static fn(array $a, array $b): int => strcasecmp($a['title'], $b['title']));
+
+        $standard = array_values(array_filter($categorized, static fn(array $i): bool => !$i['is_dev']));
+        $developer = array_values(array_filter($categorized, static fn(array $i): bool => $i['is_dev']));
+
+        /** @var list<Advisory> $advisories */
+        $advisories = [];
+        if ($includeGhsa) {
+            $prNumbers = array_map(static fn(array $pr): int => $pr['number'], $categorized);
+            $advisories = $this->matchAdvisories($shas, $prNumbers);
+        }
 
         $lines = [];
-        $url = "https://github.com/{$repo}/milestone/{$milestoneNumber}?closed=1";
-        $lines[] = "## [{$milestone}]({$url}) - " . date('Y-m-d');
-        $lines[] = '';
-        $lines = array_merge($lines, $this->formatIssues($standard));
+        if ($title !== null) {
+            $encodedBase = rawurlencode($base);
+            $encodedHead = rawurlencode($head);
+            $compareUrl = "https://github.com/{$this->repo}/compare/{$encodedBase}...{$encodedHead}";
+            $lines[] = "## [{$title}]({$compareUrl}) - " . date('Y-m-d');
+            $lines[] = '';
+        }
+
+        if (count($advisories) > 0) {
+            $lines = array_merge($lines, $this->formatAdvisories($advisories));
+        }
+
+        $lines = array_merge($lines, $this->formatPrs($standard, 3));
 
         if (count($developer) > 0) {
-            $lines[] = '### OpenEMR Developer Changes';
-            $lines[] = '';
-            $lines = array_merge($lines, $this->formatIssues($developer));
+            $devLines = $this->formatPrs($developer, 4);
+            if (count($devLines) > 0) {
+                $lines[] = '### OpenEMR Developer Changes';
+                $lines[] = '';
+                $lines = array_merge($lines, $devLines);
+            }
         }
 
         return implode("\n", $lines) . "\n";
     }
 
     /**
-     * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
-     * @return list<string>
+     * @param array{number: int, title: string, labels: list<array{name: string}>, url: string} $pr
+     * @return CategorizedPr
      */
-    private function formatIssues(array $issues): array
+    private function categorize(array $pr): array
     {
-        return array_merge(
-            $this->formatByCategory($issues, 'feat', 'Added'),
-            $this->formatByCategory($issues, 'bug', 'Fixed'),
-            $this->formatOther($issues),
-        );
+        $title = $pr['title'];
+        $category = self::DEFAULT_CATEGORY;
+
+        if (preg_match(self::CC_PATTERN, $title, $matches) === 1) {
+            $type = strtolower($matches[1]);
+            $category = self::CATEGORY_MAP[$type] ?? self::DEFAULT_CATEGORY;
+            $title = trim($matches[3]);
+        }
+
+        $isDev = false;
+        $area = '';
+        $skipSet = array_flip(self::SKIP_LABELS);
+
+        foreach ($pr['labels'] as $label) {
+            if ($label['name'] === 'developers') {
+                $isDev = true;
+                continue;
+            }
+            if ($area === '' && !isset($skipSet[$label['name']])) {
+                $area = $label['name'];
+            }
+        }
+
+        return [
+            'number' => $pr['number'],
+            'category' => $category,
+            'area' => $area,
+            'title' => $title,
+            'url' => $pr['url'],
+            'is_dev' => $isDev,
+        ];
     }
 
     /**
-     * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
-     * @return list<string>
+     * Match published GHSAs whose fix commits or PRs overlap with this release.
+     *
+     * @param list<string> $shas Commit SHAs in the release range
+     * @param list<int> $prNumbers PR numbers in the release
+     * @return list<Advisory>
      */
-    private function formatByCategory(array $issues, string $category, string $heading): array
+    private function matchAdvisories(array $shas, array $prNumbers): array
     {
-        $matches = array_filter($issues, fn(array $i): bool => $i['category'] === $category);
-        if (count($matches) === 0) {
-            return [];
+        $allAdvisories = $this->api->publishedAdvisories();
+        $shaSet = array_flip($shas);
+        $prSet = array_flip($prNumbers);
+
+        $severityOrder = ['critical' => 0, 'high' => 1, 'medium' => 2, 'low' => 3];
+
+        /** @var list<Advisory> $matched */
+        $matched = [];
+
+        foreach ($allAdvisories as $advisory) {
+            if (!$this->advisoryMatchesRange($advisory, $shaSet, $prSet)) {
+                continue;
+            }
+
+            $matched[] = [
+                'ghsa_id' => is_string($advisory['ghsa_id'] ?? null) ? $advisory['ghsa_id'] : '',
+                'severity' => is_string($advisory['severity'] ?? null) ? $advisory['severity'] : 'unknown',
+                'summary' => is_string($advisory['summary'] ?? null) ? $advisory['summary'] : '',
+                'url' => is_string($advisory['html_url'] ?? null) ? $advisory['html_url'] : '',
+            ];
         }
 
-        $lines = ["### {$heading}", ''];
-        foreach ($matches as $issue) {
-            $lines[] = "  - {$issue['title']} ([#{$issue['number']}]({$issue['url']}))";
+        usort($matched, static function (array $a, array $b) use ($severityOrder): int {
+            $aOrder = $severityOrder[$a['severity']] ?? 99;
+            $bOrder = $severityOrder[$b['severity']] ?? 99;
+            $cmp = $aOrder <=> $bOrder;
+            return $cmp !== 0 ? $cmp : strcasecmp($a['summary'], $b['summary']);
+        });
+
+        return $matched;
+    }
+
+    /**
+     * Check if an advisory's references overlap with the commit/PR set.
+     *
+     * @param array<string, mixed> $advisory
+     * @param array<string, int> $shaSet Flipped SHA array for O(1) lookup
+     * @param array<int, int> $prSet Flipped PR number array for O(1) lookup
+     */
+    private function advisoryMatchesRange(array $advisory, array $shaSet, array $prSet): bool
+    {
+        /** @var list<array<string, mixed>> $references */
+        $references = is_array($advisory['references'] ?? null) ? $advisory['references'] : [];
+
+        foreach ($references as $ref) {
+            $url = is_string($ref['url'] ?? null) ? $ref['url'] : '';
+
+            // Match commit SHA references
+            if (preg_match('#/commit/([0-9a-f]{40})#i', $url, $matches) === 1 && isset($shaSet[$matches[1]])) {
+                return true;
+            }
+
+            // Match PR number references
+            if (preg_match('#/pull/(\d+)#', $url, $matches) === 1 && isset($prSet[(int) $matches[1]])) {
+                return true;
+            }
         }
+
+        return false;
+    }
+
+    /**
+     * Format advisories as a Security Fixes section.
+     *
+     * @param list<Advisory> $advisories
+     * @return list<string>
+     */
+    private function formatAdvisories(array $advisories): array
+    {
+        $lines = ['### Security Fixes', ''];
+
+        foreach ($advisories as $advisory) {
+            $severity = ucfirst($advisory['severity']);
+            $lines[] = "  - [{$severity}] {$advisory['summary']} ([{$advisory['ghsa_id']}]({$advisory['url']}))";
+        }
+
         $lines[] = '';
+        return $lines;
+    }
+
+    /**
+     * Format PRs grouped by category and area label.
+     *
+     * @param list<CategorizedPr> $prs
+     * @param int $depth Markdown heading depth for category headings (3 = ###)
+     * @return list<string>
+     */
+    private function formatPrs(array $prs, int $depth = 3): array
+    {
+        $lines = [];
+
+        foreach (self::SECTION_ORDER as $section) {
+            $sectionLines = $this->formatByCategory($prs, $section, $depth);
+            $lines = array_merge($lines, $sectionLines);
+        }
 
         return $lines;
     }
 
     /**
-     * @param list<array{number: int, category: string, title: string, url: string, is_dev: bool}> $issues
+     * Format PRs for a single category, sub-grouped by area label.
+     *
+     * @param list<CategorizedPr> $prs
+     * @param int $depth Markdown heading depth for the category heading
      * @return list<string>
      */
-    private function formatOther(array $issues): array
+    private function formatByCategory(array $prs, string $category, int $depth = 3): array
     {
-        $matches = array_filter($issues, fn(array $i): bool => !in_array($i['category'], ['feat', 'bug'], true));
+        $matches = array_values(array_filter($prs, static fn(array $i): bool => $i['category'] === $category));
         if (count($matches) === 0) {
             return [];
         }
 
-        $lines = ['### Changed', ''];
-        foreach ($matches as $issue) {
-            $lines[] = "  - {$issue['title']} ([#{$issue['number']}]({$issue['url']}))";
+        // Group by area label
+        /** @var array<string, list<CategorizedPr>> $byArea */
+        $byArea = [];
+        foreach ($matches as $pr) {
+            $byArea[$pr['area']][] = $pr;
         }
-        $lines[] = '';
+        ksort($byArea);
+
+        $heading = str_repeat('#', $depth);
+        $lines = ["{$heading} {$category}", ''];
+
+        // Unlabeled PRs first (empty area key)
+        if (isset($byArea[''])) {
+            foreach ($byArea[''] as $pr) {
+                $lines[] = "  - {$pr['title']} ([#{$pr['number']}]({$pr['url']}))";
+            }
+            $lines[] = '';
+            unset($byArea['']);
+        }
+
+        // Area sub-groups
+        $subHeading = str_repeat('#', $depth + 1);
+        foreach ($byArea as $area => $areaPrs) {
+            $lines[] = "{$subHeading} {$area}";
+            $lines[] = '';
+            foreach ($areaPrs as $pr) {
+                $lines[] = "  - {$pr['title']} ([#{$pr['number']}]({$pr['url']}))";
+            }
+            $lines[] = '';
+        }
 
         return $lines;
     }

--- a/tools/release/src/GitHubApi.php
+++ b/tools/release/src/GitHubApi.php
@@ -76,4 +76,86 @@ class GitHubApi
     {
         return $this->paginate("/issues?milestone={$milestoneNumber}&state=closed&per_page=100");
     }
+
+    /**
+     * Get all commit SHAs between two refs using the compare API.
+     *
+     * @return list<string>
+     */
+    public function commitsBetweenRefs(string $base, string $head): array
+    {
+        $endpoint = "/repos/{$this->repo}/compare/{$base}...{$head}";
+        $shas = [];
+        $page = 1;
+        $maxPages = 50;
+
+        do {
+            $process = new Process([
+                'gh', 'api',
+                "{$endpoint}?per_page=250&page={$page}",
+                '--jq', '.commits[].sha',
+            ]);
+            $process->mustRun();
+
+            $output = trim($process->getOutput());
+            if ($output === '') {
+                break;
+            }
+
+            $pageShas = explode("\n", $output);
+            $shas = array_merge($shas, $pageShas);
+            $page++;
+        } while (count($pageShas) === 250 && $page <= $maxPages);
+
+        if ($page > $maxPages) {
+            throw new \RuntimeException(
+                "Compare {$base}...{$head} exceeded {$maxPages} pages — results may be truncated",
+            );
+        }
+
+        return $shas;
+    }
+
+    /**
+     * Resolve commit SHAs to their associated pull requests.
+     *
+     * Deduplicates by PR number. Returns PRs in the same shape as gh pr list --json.
+     *
+     * @param list<string> $shas
+     * @return list<array{number: int, title: string, labels: list<array{name: string}>, url: string}>
+     */
+    public function prsForCommits(array $shas): array
+    {
+        /** @var array<int, array{number: int, title: string, labels: list<array{name: string}>, url: string}> $seen */
+        $seen = [];
+
+        foreach ($shas as $sha) {
+            $process = new Process([
+                'gh', 'api',
+                "/repos/{$this->repo}/commits/{$sha}/pulls",
+                '--jq', '[.[] | {number, title, labels: [.labels[] | {name}], url: .html_url}]',
+            ]);
+            $process->mustRun();
+
+            /** @var list<array{number: int, title: string, labels: list<array{name: string}>, url: string}> $prs */
+            $prs = json_decode($process->getOutput(), true) ?? [];
+            foreach ($prs as $pr) {
+                if (!isset($seen[$pr['number']])) {
+                    $seen[$pr['number']] = $pr;
+                }
+            }
+        }
+
+        return array_values($seen);
+    }
+
+    /**
+     * Fetch all published security advisories.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function publishedAdvisories(): array
+    {
+        return $this->paginate('/security-advisories?state=published&per_page=100');
+    }
 }


### PR DESCRIPTION
## Summary

- Replace the milestone-based changelog generator with one that walks commit ancestry between two git refs (`--base`/`--head`)
- Resolve commits to merged PRs and parse conventional commit prefixes from PR titles (`feat:` → Added, `fix:` → Fixed, `deps:` → Dependencies, everything else → Changed)
- Automatically collect published GHSAs whose fix commits or PRs fall within the release's commit range
- Milestones remain available for preflight checks but are no longer required or used for changelog generation

## Motivation

The previous generator required everything to be in a milestone and used the issues API (which conflates issues and PRs). PRs merged without a milestone were invisible, and security advisories had to be hand-curated into release notes.

## Changes

- **`GitHubApi.php`** — Add `commitsBetweenRefs()`, `prsForCommits()`, `publishedAdvisories()`
- **`ChangelogGenerator.php`** — Full rewrite with conventional commit parsing and GHSA matching
- **`bin/changelog.php`** — Replace `--milestone` with `--base`/`--head`/`--title`/`--no-ghsa`
- **`bin/changelog-pr.php`** — Replace `--milestone` with `--version`
- **`Taskfile.yml`** — Update `changelog` and `changelog-pr` tasks
- **`build-release.yml`** — Add `base_ref` input, make `milestone` optional
- **`build-patch.yml`** — Add `version` input, make `milestone` optional, use `version_start` as base ref

## Test plan

- [ ] Dry-run `build-patch.yml` from this branch with `version_start=v8_0_0_2`, `version=8.0.0.3` and compare output with the hand-curated v8_0_0_3 release notes
- [ ] Verify GHSA matching produces the expected Security Fixes section