### PR TITLE
fix: openemr-cmd worktree fixes

### DIFF
--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -565,11 +565,13 @@ cmd_worktree_list() {
         status="stopped"
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
+        local validate_result=0
+        wt_validate_dir_safe "${dir}"; validate_result=$?
         if [[ ! -d "${dir}" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
             status="missing"
-        elif ! wt_validate_dir_safe "${dir}"; then
+        elif [[ "${validate_result}" -ne 0 ]]; then
             status="invalid"
         else
             ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -138,8 +138,27 @@ wt_validate_dir() {
 
     # 3. Ensure it is a registered git worktree of OPENEMR_ROOT
     if ! git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null \
-            | grep -qx "worktree ${dir_real}"; then
+            | grep -Fqx "worktree ${dir_real}"; then
         wt_die "Path '${dir_real}' is not a registered git worktree of '${OPENEMR_ROOT}'"
+    fi
+}
+
+# Non-fatal version of wt_validate_dir for use in listing context.
+# Returns 1 on failure instead of calling wt_die (which exits the script),
+# so a single bad state entry does not abort the entire list command.
+wt_validate_dir_safe() {
+    local dir=$1
+    local dir_real worktree_parent_real
+
+    dir_real=$(realpath -e "${dir}" 2>/dev/null) || return 1
+
+    worktree_parent_real=$(realpath -e "${WORKTREE_PARENT}" 2>/dev/null) || return 1
+    if [[ "${dir_real}" != "${worktree_parent_real}/"* ]]; then
+        return 1
+    fi
+
+    if ! git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null             | grep -Fqx "worktree ${dir_real}"; then
+        return 1
     fi
 }
 
@@ -191,9 +210,37 @@ wt_write_override() {
     local compose_subdir
     compose_subdir=$(wt_compose_subdir "${env}")
 
-    local lib_root env_root
-    lib_root=$(realpath "${dir}/docker/library")
-    env_root=$(realpath "${dir}/${compose_subdir}")
+    local lib_root env_root wt_root_real
+    # Resolve the worktree root once for bounds checking below
+    wt_root_real=$(realpath -e "${dir}")
+
+    # Guard against nested symlinks that could resolve volume mount sources
+    # outside the worktree (e.g., docker/library -> /etc).
+    [[ -L "${dir}/docker/library" ]] && wt_die "Refusing: '${dir}/docker/library' is a symlink"
+    lib_root=$(realpath -e "${dir}/docker/library")         || wt_die "Missing directory: '${dir}/docker/library'"
+    if [[ "${lib_root}/" != "${wt_root_real}/"* ]]; then
+        wt_die "Refusing: docker/library resolves outside worktree: '${lib_root}'"
+    fi
+
+    [[ -L "${dir}/${compose_subdir}" ]] && wt_die "Refusing: '${dir}/${compose_subdir}' is a symlink"
+    env_root=$(realpath -e "${dir}/${compose_subdir}")         || wt_die "Missing directory: '${dir}/${compose_subdir}'"
+    if [[ "${env_root}/" != "${wt_root_real}/"* ]]; then
+        wt_die "Refusing: compose subdir resolves outside worktree: '${env_root}'"
+    fi
+
+    # For easy-redis: also guard php.ini since it is mounted directly into the container
+    if [[ "${env}" == "easy-redis" ]]; then
+        local php_ini="${dir}/${compose_subdir}/php.ini"
+        if [[ -e "${php_ini}" ]]; then
+            [[ -L "${php_ini}" ]] && wt_die "Refusing: '${php_ini}' is a symlink"
+            local php_ini_real
+            php_ini_real=$(realpath -e "${php_ini}") \
+                || wt_die "Cannot resolve: '${php_ini}'"
+            if [[ "${php_ini_real}" != "${wt_root_real}" && "${php_ini_real}/" != "${wt_root_real}/"* ]]; then
+                wt_die "Refusing: php.ini resolves outside worktree: '${php_ini_real}'"
+            fi
+        fi
+    fi
 
     local override_file="${dir}/${compose_subdir}/docker-compose.override.yml"
 
@@ -301,6 +348,11 @@ wt_compose_cmd() {
     check_docker_compose_install
     local slug
     slug=$(wt_slug "${branch}")
+    # Security note: docker-compose.yml is intentionally loaded from the
+    # worktree checkout so that compose changes on the branch are testable.
+    # This tool is designed for use on branches you own and trust — do not
+    # run worktree up/down/list against untrusted branches or PRs, as a
+    # malicious compose file could mount host paths or run arbitrary images.
     "${DOCKER_COMPOSE_CMD[@]}" \
         --env-file "${dir}/${compose_subdir}/.env" \
         -p "openemr-${slug}" \
@@ -513,21 +565,11 @@ cmd_worktree_list() {
         status="stopped"
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
-        # Validate the worktree dir before using it for compose operations.
-        # wt_validate_dir calls wt_die internally, so we cannot call it inside
-        # an if/!/|| condition (shellcheck SC2310/SC2311/SC2312 — set -e is
-        # disabled in those contexts). Instead, temporarily disable set -e so
-        # we can call the function standalone and capture its exit code cleanly.
-        local validate_result=0
-        set +e
-        wt_validate_dir "${dir}" 2>/dev/null
-        validate_result=$?
-        set -e
         if [[ ! -d "${dir}" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
             status="missing"
-        elif [[ "${validate_result}" -ne 0 ]]; then
+        elif ! wt_validate_dir_safe "${dir}"; then
             status="invalid"
         else
             ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -513,11 +513,13 @@ cmd_worktree_list() {
         status="stopped"
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
+        local validate_result=0
+        wt_validate_dir "${dir}" 2>/dev/null || validate_result=$?
         if [[ ! -d "${dir}" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
             status="missing"
-        elif ! wt_validate_dir "${dir}" 2>/dev/null; then
+        elif [[ "${validate_result}" -ne 0 ]]; then
             status="invalid"
         else
             ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -116,6 +116,33 @@ wt_slug() {
     echo "$1" | tr '/' '-' | tr -cd 'a-zA-Z0-9_-' | tr '[:upper:]' '[:lower:]'
 }
 
+# Validates that a worktree dir from state is safe to use for compose operations.
+# Guards against corrupted/tampered state by checking:
+#   1. dir resolves to a real path (realpath -e)
+#   2. it is within WORKTREE_PARENT
+#   3. it is a known git worktree of OPENEMR_ROOT
+wt_validate_dir() {
+    local dir=$1
+    local dir_real worktree_parent_real
+
+    # 1. Resolve to real path — fails if path does not exist
+    dir_real=$(realpath -e "${dir}" 2>/dev/null) \
+        || wt_die "Worktree path does not exist or cannot be resolved: '${dir}'"
+
+    # 2. Ensure it is within WORKTREE_PARENT
+    worktree_parent_real=$(realpath -e "${WORKTREE_PARENT}" 2>/dev/null) \
+        || wt_die "Cannot resolve WORKTREE_PARENT: '${WORKTREE_PARENT}'"
+    if [[ "${dir_real}" != "${worktree_parent_real}/"* ]]; then
+        wt_die "Worktree path '${dir_real}' is not within expected parent '${worktree_parent_real}'"
+    fi
+
+    # 3. Ensure it is a registered git worktree of OPENEMR_ROOT
+    if ! git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null \
+            | grep -qx "worktree ${dir_real}"; then
+        wt_die "Path '${dir_real}' is not a registered git worktree of '${OPENEMR_ROOT}'"
+    fi
+}
+
 # ============================================================================
 # COMPOSE FILE GENERATORS
 # ============================================================================
@@ -269,6 +296,7 @@ wt_compose_cmd() {
     dir=$(wt_state_get "${branch}" dir)
     env=$(wt_state_get "${branch}" env)
     if [[ -z "${dir}" ]]; then wt_die "No worktree found for branch '${branch}'"; fi
+    wt_validate_dir "${dir}"
     compose_subdir=$(wt_compose_subdir "${env}")
     check_docker_compose_install
     local slug
@@ -328,7 +356,29 @@ cmd_worktree_add() {
     fi
 
     wt_info "Setting up compose files (env=${env}, offset=${offset})"
+
+    # Guard against symlink attacks: a malicious branch could commit
+    # docker/ or docker/development-<env>/ as a symlink pointing outside
+    # the worktree. Refuse to proceed if either is a symlink.
+    if [[ -L "${dir}/docker" ]]; then
+        git -C "${OPENEMR_ROOT}" worktree remove --force "${dir}" 2>/dev/null || true
+        wt_die "Refusing: '${dir}/docker' is a symlink in the checked-out branch"
+    fi
+    if [[ -L "${dir}/${compose_subdir}" ]]; then
+        git -C "${OPENEMR_ROOT}" worktree remove --force "${dir}" 2>/dev/null || true
+        wt_die "Refusing: '${dir}/${compose_subdir}' is a symlink in the checked-out branch"
+    fi
+
     mkdir -p "${dir}/${compose_subdir}"
+
+    # Verify the compose subdir resolved within the worktree root (no traversal)
+    local wt_root_real compose_dir_real
+    wt_root_real=$(realpath -e "${dir}")
+    compose_dir_real=$(realpath -m "${dir}/${compose_subdir}")
+    if [[ "${compose_dir_real}/" != "${wt_root_real}/"* ]]; then
+        git -C "${OPENEMR_ROOT}" worktree remove --force "${dir}" 2>/dev/null || true
+        wt_die "Refusing: compose directory '${compose_dir_real}' is outside worktree root '${wt_root_real}'"
+    fi
 
     wt_write_env      "${dir}" "${branch}" "${offset}" "${env}"
     wt_write_override "${dir}" "${branch}" "${offset}" "${env}"
@@ -467,6 +517,8 @@ cmd_worktree_list() {
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
             status="missing"
+        elif ! wt_validate_dir "${dir}" 2>/dev/null; then
+            status="invalid"
         else
             ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \
                 --env-file "${dir}/${compose_subdir}/.env" \

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -514,7 +514,9 @@ cmd_worktree_list() {
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
         local validate_result=0
-        wt_validate_dir "${dir}" 2>/dev/null || validate_result=$?
+        if ! wt_validate_dir "${dir}" 2>/dev/null; then
+            validate_result=1
+        fi
         if [[ ! -d "${dir}" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -513,10 +513,16 @@ cmd_worktree_list() {
         status="stopped"
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
+        # Validate the worktree dir before using it for compose operations.
+        # wt_validate_dir calls wt_die internally, so we cannot call it inside
+        # an if/!/|| condition (shellcheck SC2310/SC2311/SC2312 — set -e is
+        # disabled in those contexts). Instead, temporarily disable set -e so
+        # we can call the function standalone and capture its exit code cleanly.
         local validate_result=0
-        if ! wt_validate_dir "${dir}" 2>/dev/null; then
-            validate_result=1
-        fi
+        set +e
+        wt_validate_dir "${dir}" 2>/dev/null
+        validate_result=$?
+        set -e
         if [[ ! -d "${dir}" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.26"
+VERSION="1.0.27"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -165,8 +165,8 @@ wt_write_override() {
     compose_subdir=$(wt_compose_subdir "${env}")
 
     local lib_root env_root
-    lib_root=$(realpath "${OPENEMR_ROOT}/docker/library")
-    env_root=$(realpath "${OPENEMR_ROOT}/${compose_subdir}")
+    lib_root=$(realpath "${dir}/docker/library")
+    env_root=$(realpath "${dir}/${compose_subdir}")
 
     local override_file="${dir}/${compose_subdir}/docker-compose.override.yml"
 
@@ -190,6 +190,8 @@ volumes:
     name: openemr-${slug}_vendor
   ccdanodemodules:
     name: openemr-${slug}_ccdanodemodules
+  ccdanodemodules2:
+    name: openemr-${slug}_ccdanodemodules2
   logvolume:
     name: openemr-${slug}_logs
   couchdbvolume:
@@ -234,7 +236,7 @@ OVEOF
     # Redis-specific overrides.
     # The base compose uses hardcoded container_name which bypasses Docker project
     # namespacing — override with branch-scoped names so multiple worktrees coexist.
-    # Also patch relative ./redis/, ./sentinel/, and ./php.ini paths to absolute.
+    # Also patch relative ./php.ini path to absolute.
     if [[ "${env}" == "easy-redis" ]]; then
         cat >> "${override_file}" <<OVEOF
 
@@ -244,28 +246,18 @@ OVEOF
 
   redis-master:
     container_name: openemr-${slug}-redis-master
-    volumes:
-      - "${env_root}/redis/redis.conf:/etc/redis/redis.conf"
 
   redis-replica-1:
     container_name: openemr-${slug}-redis-replica-1
-    volumes:
-      - "${env_root}/redis/redis.conf:/etc/redis/redis.conf"
 
   redis-replica-2:
     container_name: openemr-${slug}-redis-replica-2
-    volumes:
-      - "${env_root}/redis/redis.conf:/etc/redis/redis.conf"
 
   sentinel-1:
     container_name: openemr-${slug}-sentinel-1
-    volumes:
-      - "${env_root}/sentinel/sentinel-1.conf:/etc/redis/sentinel.conf"
 
   sentinel-2:
     container_name: openemr-${slug}-sentinel-2
-    volumes:
-      - "${env_root}/sentinel/sentinel-2.conf:/etc/redis/sentinel.conf"
 OVEOF
     fi
 }
@@ -284,7 +276,7 @@ wt_compose_cmd() {
     "${DOCKER_COMPOSE_CMD[@]}" \
         --env-file "${dir}/${compose_subdir}/.env" \
         -p "openemr-${slug}" \
-        -f "${OPENEMR_ROOT}/${compose_subdir}/docker-compose.yml" \
+        -f "${dir}/${compose_subdir}/docker-compose.yml" \
         -f "${dir}/${compose_subdir}/docker-compose.override.yml" \
         "${@:2}"
 }
@@ -479,7 +471,7 @@ cmd_worktree_list() {
             ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \
                 --env-file "${dir}/${compose_subdir}/.env" \
                 -p "openemr-${slug}" \
-                -f "${OPENEMR_ROOT}/${compose_subdir}/docker-compose.yml" \
+                -f "${dir}/${compose_subdir}/docker-compose.yml" \
                 -f "${dir}/${compose_subdir}/docker-compose.override.yml" \
                 ps --services --filter "status=running" 2>/dev/null) || true
             if echo "${ps_output}" | grep -q openemr; then


### PR DESCRIPTION
1. Use the docker environment in the worktree, not base
2. Update to support planned easy-redis environment changes (removed config files/volumes)
3. added support for the ccdanodemodules2 volume