### PR TITLE
style(shell): whole-word quoting, command consolidation, and grep cleanup

### DIFF
--- a/docker/openemr/7.0.4/openemr.sh
+++ b/docker/openemr/7.0.4/openemr.sh
@@ -32,14 +32,15 @@ auto_setup() {
     mkdir "${TMP_FILE_CACHE_LOCATION}"
 
     #create auto_configure.ini to be able to leverage opcache for operations
-    touch auto_configure.ini
-    echo "opcache.enable=1" >> auto_configure.ini
-    echo "opcache.enable_cli=1" >> auto_configure.ini
-    echo "opcache.file_cache=${TMP_FILE_CACHE_LOCATION}" >> auto_configure.ini
-    echo "opcache.file_cache_only=1" >> auto_configure.ini
-    echo "opcache.file_cache_consistency_checks=1" >> auto_configure.ini
-    echo "opcache.enable_file_override=1" >> auto_configure.ini
-    echo "opcache.max_accelerated_files=1000000" >> auto_configure.ini
+    {
+        echo opcache.enable=1
+        echo opcache.enable_cli=1
+        echo "opcache.file_cache=${TMP_FILE_CACHE_LOCATION}"
+        echo opcache.file_cache_only=1
+        echo opcache.file_cache_consistency_checks=1
+        echo opcache.enable_file_override=1
+        echo opcache.max_accelerated_files=1000000
+    } > auto_configure.ini
 
     #run auto_configure
     # shellcheck disable=SC2086 # CONFIGURATION intentionally word-splits into multiple -f flags (see openemr/openemr-devops#539)
@@ -247,7 +248,7 @@ if
         while [ "${c}" -le "${DOCKER_VERSION_ROOT}" ]; do
             if [ "${c}" -gt "${DOCKER_VERSION_SITES}" ] ; then
                 echo "Start: Processing fsupgrade-${c}.sh upgrade script"
-                sh /root/fsupgrade-"${c}".sh
+                sh "/root/fsupgrade-${c}.sh"
                 echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             fi
             c=$(( c + 1 ))
@@ -270,8 +271,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
     #    version 5.3.7 .
     if [ "${PHPREDIS_BUILD}" != "" ]; then
       apk update
-      apk del --no-cache php"${PHP_VERSION_ABBR}"-redis
-      apk add --no-cache git php"${PHP_VERSION_ABBR}"-dev php"${PHP_VERSION_ABBR}"-pecl-igbinary gcc make g++
+      apk del --no-cache "php${PHP_VERSION_ABBR}-redis"
+      apk add --no-cache git "php${PHP_VERSION_ABBR}-dev" "php${PHP_VERSION_ABBR}-pecl-igbinary" gcc make g++
       mkdir /tmpredis
       cd /tmpredis
       git clone https://github.com/phpredis/phpredis.git
@@ -285,9 +286,9 @@ if [ "${REDIS_SERVER}" != "" ] &&
       ./configure --with-php-config=/usr/bin/php-config83 --enable-redis-igbinary
       make -j "$(nproc --all)"
       make install
-      echo "extension=redis" > /etc/php"${PHP_VERSION_ABBR}"/conf.d/20_redis.ini
+      echo "extension=redis" > "/etc/php${PHP_VERSION_ABBR}/conf.d/20_redis.ini"
       rm -fr /tmpredis/phpredis
-      apk del --no-cache git php"${PHP_VERSION_ABBR}"-dev gcc make g++
+      apk del --no-cache git "php${PHP_VERSION_ABBR}-dev" gcc make g++
       cd /var/www/localhost/htdocs/openemr
     fi
 
@@ -437,14 +438,16 @@ if [ "${XDEBUG_IDE_KEY}" != "" ] ||
    sh xdebug.sh
    #also need to turn off opcache since it can not be turned on with xdebug
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.enable=0" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      echo "opcache.enable=0" >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 else
    # Configure opcache jit if Xdebug is not being used (note opcache is already on, so just need to add setting(s) to php.ini that are different from the default setting(s))
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.jit=tracing" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
-      echo "opcache.jit_buffer_size=100M" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      {
+         echo "opcache.jit=tracing"
+         echo "opcache.jit_buffer_size=100M"
+      } >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 fi

--- a/docker/openemr/7.0.4/ssl.sh
+++ b/docker/openemr/7.0.4/ssl.sh
@@ -17,8 +17,7 @@ set -e
 fi
 
 if [ ! -f /etc/ssl/docker-selfsigned-configured ]; then
-    rm -f /etc/ssl/certs/webserver.cert.pem
-    rm -f /etc/ssl/private/webserver.key.pem
+    rm -f /etc/ssl/certs/webserver.cert.pem /etc/ssl/private/webserver.key.pem
     ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
     ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
     touch /etc/ssl/docker-selfsigned-configured
@@ -33,7 +32,7 @@ if [ "${DOMAIN}" != "" ]; then
     fi
     # if a domain has been set, set up LE and target those certs
 
-    if ! [ -f /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem ]; then
+    if ! [ -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" ]; then
         /usr/sbin/httpd -k start
         sleep 2
         # shellcheck disable=SC2086 # EMAIL intentionally word-splits to pass "-m address" as separate args
@@ -44,10 +43,9 @@ if [ "${DOMAIN}" != "" ]; then
 
     # run letsencrypt as a daemon and reference the correct cert
     if [ ! -f /etc/ssl/docker-letsencrypt-configured ]; then
-        rm -f /etc/ssl/certs/webserver.cert.pem
-        rm -f /etc/ssl/private/webserver.key.pem
-        ln -s /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/ssl/certs/webserver.cert.pem
-        ln -s /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/ssl/private/webserver.key.pem
+        rm -f /etc/ssl/certs/webserver.cert.pem /etc/ssl/private/webserver.key.pem
+        ln -s "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" /etc/ssl/certs/webserver.cert.pem
+        ln -s "/etc/letsencrypt/live/${DOMAIN}/privkey.pem" /etc/ssl/private/webserver.key.pem
         touch /etc/ssl/docker-letsencrypt-configured
     fi
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
@@ -12,56 +12,55 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d "${dir}"/era ]; then
-        if [ "$(ls "${dir}"/era)" ]; then
-            mv -f "${dir}"/era/* "${dir}"/documents/era/
+    if [ -d "${dir}/era" ]; then
+        if [ "$(ls "${dir}/era")" ]; then
+            mv -f "${dir}/era"/* "${dir}/documents/era/"
         fi
-        rm -rf "${dir}"/era
+        rm -rf "${dir}/era"
     fi
-    if [ -d "${dir}"/edi ]; then
-        if [ "$(ls "${dir}"/edi)" ]; then
-            mv -f "${dir}"/edi/* "${dir}"/documents/edi/
+    if [ -d "${dir}/edi" ]; then
+        if [ "$(ls "${dir}/edi")" ]; then
+            mv -f "${dir}/edi"/* "${dir}/documents/edi/"
         fi
-        rm -rf "${dir}"/edi
+        rm -rf "${dir}/edi"
     fi
-    if [ -d "${dir}"/letter_templates ]; then
-        if [ "$(ls "${dir}"/letter_templates)" ]; then
-            if [ -f "${dir}"/letter_templates/custom_pdf.php ]; then
-                mv -f "${dir}"/letter_templates/custom_pdf.php "${dir}"/
+    if [ -d "${dir}/letter_templates" ]; then
+        if [ "$(ls "${dir}/letter_templates")" ]; then
+            if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
+                mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
             fi
-            mv -f "${dir}"/letter_templates/* "${dir}"/documents/letter_templates/
+            mv -f "${dir}/letter_templates"/* "${dir}/documents/letter_templates/"
         fi
-        rm -rf "${dir}"/letter_templates
+        rm -rf "${dir}/letter_templates"
     fi
-    if [ -d "${dir}"/procedure_results ]; then
-        if [ "$(ls "${dir}"/procedure_results)" ]; then
-            mv -f "${dir}"/procedure_results/* "${dir}"/documents/procedure_results/
+    if [ -d "${dir}/procedure_results" ]; then
+        if [ "$(ls "${dir}/procedure_results")" ]; then
+            mv -f "${dir}/procedure_results"/* "${dir}/documents/procedure_results/"
         fi
-        rm -rf "${dir}"/procedure_results
+        rm -rf "${dir}/procedure_results"
     fi
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
+++ b/docker/openemr/7.0.4/utilities/devtoolsLibrary.source
@@ -153,10 +153,10 @@ restoreOpenemr() {
 changeEncodingCollation() {
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
 }
 
 forceHttps() {

--- a/docker/openemr/8.0.0/openemr.sh
+++ b/docker/openemr/8.0.0/openemr.sh
@@ -32,14 +32,15 @@ auto_setup() {
     mkdir "${TMP_FILE_CACHE_LOCATION}"
 
     #create auto_configure.ini to be able to leverage opcache for operations
-    touch auto_configure.ini
-    echo "opcache.enable=1" >> auto_configure.ini
-    echo "opcache.enable_cli=1" >> auto_configure.ini
-    echo "opcache.file_cache=${TMP_FILE_CACHE_LOCATION}" >> auto_configure.ini
-    echo "opcache.file_cache_only=1" >> auto_configure.ini
-    echo "opcache.file_cache_consistency_checks=1" >> auto_configure.ini
-    echo "opcache.enable_file_override=1" >> auto_configure.ini
-    echo "opcache.max_accelerated_files=1000000" >> auto_configure.ini
+    {
+        echo opcache.enable=1
+        echo opcache.enable_cli=1
+        echo "opcache.file_cache=${TMP_FILE_CACHE_LOCATION}"
+        echo opcache.file_cache_only=1
+        echo opcache.file_cache_consistency_checks=1
+        echo opcache.enable_file_override=1
+        echo opcache.max_accelerated_files=1000000
+    } > auto_configure.ini
 
     #run auto_configure
     # shellcheck disable=SC2086 # CONFIGURATION intentionally word-splits into multiple -f flags (see openemr/openemr-devops#539)
@@ -247,7 +248,7 @@ if
         while [ "${c}" -le "${DOCKER_VERSION_ROOT}" ]; do
             if [ "${c}" -gt "${DOCKER_VERSION_SITES}" ] ; then
                 echo "Start: Processing fsupgrade-${c}.sh upgrade script"
-                sh /root/fsupgrade-"${c}".sh
+                sh "/root/fsupgrade-${c}.sh"
                 echo "Completed: Processing fsupgrade-${c}.sh upgrade script"
             fi
             c=$(( c + 1 ))
@@ -270,8 +271,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
     #    version 5.3.7 .
     if [ "${PHPREDIS_BUILD}" != "" ]; then
       apk update
-      apk del --no-cache php"${PHP_VERSION_ABBR}"-redis
-      apk add --no-cache git php"${PHP_VERSION_ABBR}"-dev php"${PHP_VERSION_ABBR}"-pecl-igbinary gcc make g++
+      apk del --no-cache "php${PHP_VERSION_ABBR}-redis"
+      apk add --no-cache git "php${PHP_VERSION_ABBR}-dev" "php${PHP_VERSION_ABBR}-pecl-igbinary" gcc make g++
       mkdir /tmpredis
       cd /tmpredis
       git clone https://github.com/phpredis/phpredis.git
@@ -285,9 +286,9 @@ if [ "${REDIS_SERVER}" != "" ] &&
       ./configure --with-php-config=/usr/bin/php-config83 --enable-redis-igbinary
       make -j "$(nproc --all)"
       make install
-      echo "extension=redis" > /etc/php"${PHP_VERSION_ABBR}"/conf.d/20_redis.ini
+      echo "extension=redis" > "/etc/php${PHP_VERSION_ABBR}/conf.d/20_redis.ini"
       rm -fr /tmpredis/phpredis
-      apk del --no-cache git php"${PHP_VERSION_ABBR}"-dev gcc make g++
+      apk del --no-cache git "php${PHP_VERSION_ABBR}-dev" gcc make g++
       cd /var/www/localhost/htdocs/openemr
     fi
 
@@ -437,14 +438,16 @@ if [ "${XDEBUG_IDE_KEY}" != "" ] ||
    sh xdebug.sh
    #also need to turn off opcache since it can not be turned on with xdebug
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.enable=0" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      echo "opcache.enable=0" >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 else
    # Configure opcache jit if Xdebug is not being used (note opcache is already on, so just need to add setting(s) to php.ini that are different from the default setting(s))
    if [ ! -f /etc/php-opcache-jit-configured ]; then
-      echo "opcache.jit=tracing" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
-      echo "opcache.jit_buffer_size=100M" >> /etc/php"${PHP_VERSION_ABBR}"/php.ini
+      {
+         echo "opcache.jit=tracing"
+         echo "opcache.jit_buffer_size=100M"
+      } >> "/etc/php${PHP_VERSION_ABBR}/php.ini"
       touch /etc/php-opcache-jit-configured
    fi
 fi

--- a/docker/openemr/8.0.0/ssl.sh
+++ b/docker/openemr/8.0.0/ssl.sh
@@ -17,8 +17,7 @@ set -e
 fi
 
 if [ ! -f /etc/ssl/docker-selfsigned-configured ]; then
-    rm -f /etc/ssl/certs/webserver.cert.pem
-    rm -f /etc/ssl/private/webserver.key.pem
+    rm -f /etc/ssl/certs/webserver.cert.pem /etc/ssl/private/webserver.key.pem
     ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
     ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
     touch /etc/ssl/docker-selfsigned-configured
@@ -33,7 +32,7 @@ if [ "${DOMAIN}" != "" ]; then
     fi
     # if a domain has been set, set up LE and target those certs
 
-    if ! [ -f /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem ]; then
+    if ! [ -f "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" ]; then
         /usr/sbin/httpd -k start
         sleep 2
         # shellcheck disable=SC2086 # EMAIL intentionally word-splits to pass "-m address" as separate args
@@ -44,10 +43,9 @@ if [ "${DOMAIN}" != "" ]; then
 
     # run letsencrypt as a daemon and reference the correct cert
     if [ ! -f /etc/ssl/docker-letsencrypt-configured ]; then
-        rm -f /etc/ssl/certs/webserver.cert.pem
-        rm -f /etc/ssl/private/webserver.key.pem
-        ln -s /etc/letsencrypt/live/"${DOMAIN}"/fullchain.pem /etc/ssl/certs/webserver.cert.pem
-        ln -s /etc/letsencrypt/live/"${DOMAIN}"/privkey.pem /etc/ssl/private/webserver.key.pem
+        rm -f /etc/ssl/certs/webserver.cert.pem /etc/ssl/private/webserver.key.pem
+        ln -s "/etc/letsencrypt/live/${DOMAIN}/fullchain.pem" /etc/ssl/certs/webserver.cert.pem
+        ln -s "/etc/letsencrypt/live/${DOMAIN}/privkey.pem" /etc/ssl/private/webserver.key.pem
         touch /etc/ssl/docker-letsencrypt-configured
     fi
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
@@ -12,56 +12,55 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d "${dir}"/era ]; then
-        if [ "$(ls "${dir}"/era)" ]; then
-            mv -f "${dir}"/era/* "${dir}"/documents/era/
+    if [ -d "${dir}/era" ]; then
+        if [ "$(ls "${dir}/era")" ]; then
+            mv -f "${dir}/era"/* "${dir}/documents/era/"
         fi
-        rm -rf "${dir}"/era
+        rm -rf "${dir}/era"
     fi
-    if [ -d "${dir}"/edi ]; then
-        if [ "$(ls "${dir}"/edi)" ]; then
-            mv -f "${dir}"/edi/* "${dir}"/documents/edi/
+    if [ -d "${dir}/edi" ]; then
+        if [ "$(ls "${dir}/edi")" ]; then
+            mv -f "${dir}/edi"/* "${dir}/documents/edi/"
         fi
-        rm -rf "${dir}"/edi
+        rm -rf "${dir}/edi"
     fi
-    if [ -d "${dir}"/letter_templates ]; then
-        if [ "$(ls "${dir}"/letter_templates)" ]; then
-            if [ -f "${dir}"/letter_templates/custom_pdf.php ]; then
-                mv -f "${dir}"/letter_templates/custom_pdf.php "${dir}"/
+    if [ -d "${dir}/letter_templates" ]; then
+        if [ "$(ls "${dir}/letter_templates")" ]; then
+            if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
+                mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
             fi
-            mv -f "${dir}"/letter_templates/* "${dir}"/documents/letter_templates/
+            mv -f "${dir}/letter_templates"/* "${dir}/documents/letter_templates/"
         fi
-        rm -rf "${dir}"/letter_templates
+        rm -rf "${dir}/letter_templates"
     fi
-    if [ -d "${dir}"/procedure_results ]; then
-        if [ "$(ls "${dir}"/procedure_results)" ]; then
-            mv -f "${dir}"/procedure_results/* "${dir}"/documents/procedure_results/
+    if [ -d "${dir}/procedure_results" ]; then
+        if [ "$(ls "${dir}/procedure_results")" ]; then
+            mv -f "${dir}/procedure_results"/* "${dir}/documents/procedure_results/"
         fi
-        rm -rf "${dir}"/procedure_results
+        rm -rf "${dir}/procedure_results"
     fi
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
@@ -12,25 +12,24 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
     mkdir -p \
-        "${dir}"/documents/certificates \
-        "${dir}"/documents/couchdb \
-        "${dir}"/documents/custom_menus/patient_menus \
-        "${dir}"/documents/edi \
-        "${dir}"/documents/era \
-        "${dir}"/documents/letter_templates \
-        "${dir}"/documents/logs_and_misc/methods \
-        "${dir}"/documents/mpdf/pdf_tmp \
-        "${dir}"/documents/onsite_portal_documents/templates \
-        "${dir}"/documents/procedure_results \
-        "${dir}"/documents/smarty/gacl \
-        "${dir}"/documents/smarty/main \
-        "${dir}"/documents/temp
+        "${dir}/documents/certificates" \
+        "${dir}/documents/couchdb" \
+        "${dir}/documents/custom_menus/patient_menus" \
+        "${dir}/documents/edi" \
+        "${dir}/documents/era" \
+        "${dir}/documents/letter_templates" \
+        "${dir}/documents/logs_and_misc/methods" \
+        "${dir}/documents/mpdf/pdf_tmp" \
+        "${dir}/documents/onsite_portal_documents/templates" \
+        "${dir}/documents/procedure_results" \
+        "${dir}/documents/smarty/gacl" \
+        "${dir}/documents/smarty/main" \
+        "${dir}/documents/temp"
     echo "Completed: Ensure have all directories in ${sitename}"
 
     # Clear smarty cache
     echo "Start: Clear smarty cache in ${sitename}"
-    rm -fr "${dir}"/documents/smarty/gacl/*
-    rm -fr "${dir}"/documents/smarty/main/*
+    rm -fr "${dir}/documents/smarty/gacl"/* "${dir}/documents/smarty/main"/*
     echo "Completed: Clear smarty cache in ${sitename}"
 done
 

--- a/docker/openemr/8.0.0/utilities/devtoolsLibrary.source
+++ b/docker/openemr/8.0.0/utilities/devtoolsLibrary.source
@@ -153,10 +153,10 @@ restoreOpenemr() {
 changeEncodingCollation() {
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}"
 }
 
 forceHttps() {

--- a/docker/openemr/8.1.0/utilities/devtoolsLibrary.source
+++ b/docker/openemr/8.1.0/utilities/devtoolsLibrary.source
@@ -445,12 +445,12 @@ changeEncodingCollation() {
     # Generate and execute ALTER DATABASE statement
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
     
     # Generate and execute ALTER TABLE statements for all tables
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
 }
 
 # ============================================================================

--- a/docker/openemr/8.1.1/utilities/devtoolsLibrary.source
+++ b/docker/openemr/8.1.1/utilities/devtoolsLibrary.source
@@ -445,12 +445,12 @@ changeEncodingCollation() {
     # Generate and execute ALTER DATABASE statement
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
     
     # Generate and execute ALTER TABLE statements for all tables
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
 }
 
 # ============================================================================

--- a/docker/openemr/binary/utilities/devtoolsLibrary.source
+++ b/docker/openemr/binary/utilities/devtoolsLibrary.source
@@ -445,12 +445,12 @@ changeEncodingCollation() {
     # Generate and execute ALTER DATABASE statement
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER DATABASE `",TABLE_SCHEMA,"` CHARACTER SET = '"${1}"' COLLATE = '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
     
     # Generate and execute ALTER TABLE statements for all tables
     # Single quotes intentionally used for SQL syntax - variables expand on server side
     # shellcheck disable=SC2016,SC2312  # Pipeline return value is intentionally ignored
-    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep -E '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
+    mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e 'SELECT concat("ALTER TABLE `",TABLE_SCHEMA,"`.`",TABLE_NAME,"` CONVERT TO CHARACTER SET '"${1}"' COLLATE '"${2}"';") as _sql FROM `information_schema`.`TABLES` where `TABLE_SCHEMA` like "'"${CUSTOM_DATABASE}"'" and `TABLE_TYPE`="BASE TABLE" group by `TABLE_SCHEMA`, `TABLE_NAME`;' | grep '^ALTER' | mariadb --skip-ssl -u "${CUSTOM_ROOT_USER}" --password="${MYSQL_ROOT_PASS}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" || true
 }
 
 # ============================================================================

--- a/docker/openemr/flex/utilities/devtools
+++ b/docker/openemr/flex/utilities/devtools
@@ -385,10 +385,12 @@ if [ "$1" = "backup" ]; then
         echo "Missing a backup identifier"
         exit
     fi
-    if echo "$2" | grep -Eq '[^a-zA-Z0-9\-]'; then
-        echo "Invalid identifier (can only contain numbers and letters)"
-        exit
-    fi
+    case $2 in
+        *[!a-zA-Z0-9-]*)
+            echo "Invalid identifier (can only contain numbers and letters)"
+            exit
+            ;;
+    esac
     if [ -f "/snapshots/${2}.tgz" ]; then
         echo "Identifier has already been used. Try with another identifier."
         exit
@@ -403,10 +405,12 @@ if [ "$1" = "restore" ]; then
         echo "Missing a restore identifier"
         exit
     fi
-    if echo "$2" | grep -Eq '[^a-zA-Z0-9\-]'; then
-        echo "Invalid identifier (can only contain numbers and letters)"
-        exit
-    fi
+    case $2 in
+        *[!a-zA-Z0-9-]*)
+            echo "Invalid identifier (can only contain numbers and letters)"
+            exit
+            ;;
+    esac
     if [ ! -f "/snapshots/${2}.tgz" ]; then
         echo "A backup with the identifier does not exist"
         exit

--- a/utilities/openemr-env-installer/openemr-env-installer
+++ b/utilities/openemr-env-installer/openemr-env-installer
@@ -514,8 +514,8 @@ elif [[ "${os_type}" = "Darwin" ]]; then
         else
             echo -e "\033[30m===>\033[0m \033[32mInstalling Homebrew... \033[0m"
             brew_installer=$(mktemp -d)
-            curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh > "${brew_installer}"/install.sh
-            chmod +x "${brew_installer}"/install.sh
+            curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh > "${brew_installer}/install.sh"
+            chmod +x "${brew_installer}/install.sh"
             "${brew_installer}/install.sh"
             echo
         fi

--- a/utilities/openemr-monitor/monitor-installer
+++ b/utilities/openemr-monitor/monitor-installer
@@ -28,47 +28,48 @@ if [[ $# -ne 6 ]]; then
 fi
 
 # Install location
-[[ ! -d "${installDir}" ]] && mkdir "${installDir}"/grafana/provisioning/{dashboards,datasources} -p
-mkdir "${installDir}"/prometheus -p
+mkdir -p \
+    "${installDir}/prometheus" \
+    "${installDir}/grafana/provisioning"/{dashboards,datasources}
 echo
 
 # Download the yml files
 echo 'Downloading the configuration files...'
 echo
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/prometheus.yml  > "${installDir}"/prometheus/prometheus.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/alert-rules.yml > "${installDir}"/prometheus/alert-rules.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/alertmanager.yml           > "${installDir}"/alertmanager.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/docker-compose.yml         > "${installDir}"/docker-compose.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard-193.json > "${installDir}"/grafana/provisioning/dashboards/dashboard-193.json
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard.yml > "${installDir}"/grafana/provisioning/dashboards/dashboard.yml
-curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/datasources/datasource.yml > "${installDir}"/grafana/provisioning/datasources/datasource.yml
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/prometheus.yml  > "${installDir}/prometheus/prometheus.yml"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/prometheus/alert-rules.yml > "${installDir}/prometheus/alert-rules.yml"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/alertmanager.yml           > "${installDir}/alertmanager.yml"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/docker-compose.yml         > "${installDir}/docker-compose.yml"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard-193.json > "${installDir}/grafana/provisioning/dashboards/dashboard-193.json"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/dashboards/dashboard.yml > "${installDir}/grafana/provisioning/dashboards/dashboard.yml"
+curl -L https://raw.githubusercontent.com/openemr/openemr-devops/master/utilities/openemr-monitor/grafana/provisioning/datasources/datasource.yml > "${installDir}/grafana/provisioning/datasources/datasource.yml"
 echo
 
 # Input Host ip
-sed -i "s/hostIp/${hostIp}/g" "${installDir}"/prometheus/prometheus.yml
-sed -i "s/hostIp/${hostIp}/g" "${installDir}"/grafana/provisioning/datasources/datasource.yml
+sed -i "s/hostIp/${hostIp}/g" "${installDir}/prometheus/prometheus.yml"
+sed -i "s/hostIp/${hostIp}/g" "${installDir}/grafana/provisioning/datasources/datasource.yml"
 
 # Input Smtp Server
-sed -i "s/smtpServer/${smtpServer}/g" "${installDir}"/alertmanager.yml
+sed -i "s/smtpServer/${smtpServer}/g" "${installDir}/alertmanager.yml"
 
 # Input the sender email
-sed -i "s/senderEmail/${senderEmail}/g" "${installDir}"/alertmanager.yml
-sed -i "s/senderUsername/${senderEmail}/g" "${installDir}"/alertmanager.yml
+sed -i "s/senderEmail/${senderEmail}/g" "${installDir}/alertmanager.yml"
+sed -i "s/senderUsername/${senderEmail}/g" "${installDir}/alertmanager.yml"
 
 # Input the sender email password
-sed -i "s/senderLoginPassword/${emailPassword}/g" "${installDir}"/alertmanager.yml
+sed -i "s/senderLoginPassword/${emailPassword}/g" "${installDir}/alertmanager.yml"
 
 # Input the receiver email
-sed -i "s/receiverEmail/${receiverEmail}/g" "${installDir}"/alertmanager.yml
+sed -i "s/receiverEmail/${receiverEmail}/g" "${installDir}/alertmanager.yml"
 echo '******************************Check the Modification******************************'
 echo "Setting in ${installDir}/prometheus/prometheus.yml file."
-grep -E "3001|3002|3003" "${installDir}/prometheus/prometheus.yml"
+grep -F -e 3001 -e 3002 -e 3003 "${installDir}/prometheus/prometheus.yml"
 echo
 echo "Setting in ${installDir}/grafana/provisioning/datasources/datasource.yml file."
-grep url "${installDir}"/grafana/provisioning/datasources/datasource.yml
+grep -F url "${installDir}/grafana/provisioning/datasources/datasource.yml"
 echo
 echo "Setting in ${installDir}/alertmanager.yml file."
-grep -E 'smtp|to' "${installDir}/alertmanager.yml"
+grep -F -e smtp -e to "${installDir}/alertmanager.yml"
 echo '**********************************************************************************'
 echo
 echo '=======================Startup========================'


### PR DESCRIPTION
#### Short description of what this resolves:

Style follow-up to #459. Related shell-style cleanups applied across the touched files:

1. **Whole-word quoting.** `"${dir}"/documents/era` becomes `"${dir}/documents/era"` — one path, one quoted string. Where the trailing element must stay unquoted (globs, brace expansion), the quote is scoped up to that point (e.g. `"${dir}/path"/*`).
2. **Combine consecutive identical commands** into one multi-arg call (collapsed two `rm -f` in `ssl.sh`, the smarty `rm -fr` pairs in `fsupgrade-{1..9}.sh`, and the prometheus + grafana `mkdir -p` calls in `monitor-installer`).
3. **Group redirects to the same file.** Resolves SC2129 in `openemr.sh`: seven `echo X >> auto_configure.ini` lines (plus a redundant `touch`) become one `{ ...; } > file` brace group, and the two `echo X >> php.ini` opcache-jit lines are wrapped in `{ ...; } >> file`.
4. **`grep` cleanup.**
   - `monitor-installer`: `grep -F` for literal `url` / `smtp`/`to` / port-number matches.
   - `devtoolsLibrary.source` and `flex/utilities/devtools`: drop `-E` where BRE suffices (`^ALTER`, bracket expressions).
   - `flex/utilities/devtools`: replace `echo "$2" | grep -q '[^...]'` identifier validation with POSIX `case $2 in *[!...]*) ...` — one shell, no subprocess.

7.0.4 and 8.0.0 mirrors stay byte-identical so the CI shellcheck content-hash dedup keeps collapsing them. `fsupgrade-8.sh`'s pre-existing header-comment divergence between 7.0.4 and 8.0.0 is left untouched.

No behavior change.

#### Changes proposed in this pull request:

- `docker/openemr/{7.0.4,8.0.0}/openemr.sh` — whole-word quote `"${PHP_VERSION_ABBR}"`-suffixed paths and `fsupgrade-"${c}".sh`; `{ ...; } > auto_configure.ini` brace group; `{ ...; } >> php.ini` brace group.
- `docker/openemr/{7.0.4,8.0.0}/ssl.sh` — whole-word quote `${DOMAIN}` paths; combine `rm -f` pairs.
- `docker/openemr/{7.0.4,8.0.0}/upgrade/fsupgrade-{1..9}.sh` — whole-word quote the `mkdir -p` block, the era/edi/letter_templates/procedure_results migration blocks in fsupgrade-1, and the smarty paths; combine the two smarty `rm -fr` lines.
- `docker/openemr/{7.0.4,8.0.0,8.1.0,8.1.1,binary}/utilities/devtoolsLibrary.source` — drop `-E` from `grep '^ALTER'`.
- `docker/openemr/flex/utilities/devtools` — replace two `grep`-pipeline identifier validators with POSIX `case` statements.
- `utilities/openemr-monitor/monitor-installer` — whole-word quote `${installDir}` paths; collapse mkdirs into one call and drop the redundant `[[ ! -d ]]` guard; `grep -F` for the three literal matches.
- `utilities/openemr-env-installer/openemr-env-installer` — whole-word quote `${brew_installer}` paths.

`shellcheck --include=SC2086,SC2248,SC2046,SC2129` is clean on every touched file.

Out-of-scope follow-ups filed during review: #644, #645, #646, #647, #648.

#### AI disclosure:
- [x] Yes, I used AI to help with this PR
