### PR TITLE
fix(upgrade): preserve dotfiles during fsupgrade-1 migration

### DIFF
--- a/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-1.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="5.0.1"
 echo "Start: Upgrade to docker-version 1"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -29,33 +30,16 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d "${dir}/era" ]; then
-        if [ "$(ls "${dir}/era")" ]; then
-            mv -f "${dir}/era"/* "${dir}/documents/era/"
-        fi
-        rm -rf "${dir}/era"
+    # letter_templates/custom_pdf.php must be hoisted before the subdir is migrated
+    if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
+        mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
     fi
-    if [ -d "${dir}/edi" ]; then
-        if [ "$(ls "${dir}/edi")" ]; then
-            mv -f "${dir}/edi"/* "${dir}/documents/edi/"
+    for sub in era edi letter_templates procedure_results; do
+        if [ -d "${dir}/${sub}" ]; then
+            find "${dir}/${sub}/." ! -name . -prune -exec mv -f {} "${dir}/documents/${sub}/" +
+            rmdir "${dir}/${sub}"
         fi
-        rm -rf "${dir}/edi"
-    fi
-    if [ -d "${dir}/letter_templates" ]; then
-        if [ "$(ls "${dir}/letter_templates")" ]; then
-            if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
-                mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
-            fi
-            mv -f "${dir}/letter_templates"/* "${dir}/documents/letter_templates/"
-        fi
-        rm -rf "${dir}/letter_templates"
-    fi
-    if [ -d "${dir}/procedure_results" ]; then
-        if [ "$(ls "${dir}/procedure_results")" ]; then
-            mv -f "${dir}/procedure_results"/* "${dir}/documents/procedure_results/"
-        fi
-        rm -rf "${dir}/procedure_results"
-    fi
+    done
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
@@ -70,8 +54,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-1.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="5.0.1"
 echo "Start: Upgrade to docker-version 1"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -29,33 +30,16 @@ for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d 
 
     # Update new directory structure
     echo "Start: Update new directory structure in ${sitename}"
-    if [ -d "${dir}/era" ]; then
-        if [ "$(ls "${dir}/era")" ]; then
-            mv -f "${dir}/era"/* "${dir}/documents/era/"
-        fi
-        rm -rf "${dir}/era"
+    # letter_templates/custom_pdf.php must be hoisted before the subdir is migrated
+    if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
+        mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
     fi
-    if [ -d "${dir}/edi" ]; then
-        if [ "$(ls "${dir}/edi")" ]; then
-            mv -f "${dir}/edi"/* "${dir}/documents/edi/"
+    for sub in era edi letter_templates procedure_results; do
+        if [ -d "${dir}/${sub}" ]; then
+            find "${dir}/${sub}/." ! -name . -prune -exec mv -f {} "${dir}/documents/${sub}/" +
+            rmdir "${dir}/${sub}"
         fi
-        rm -rf "${dir}/edi"
-    fi
-    if [ -d "${dir}/letter_templates" ]; then
-        if [ "$(ls "${dir}/letter_templates")" ]; then
-            if [ -f "${dir}/letter_templates/custom_pdf.php" ]; then
-                mv -f "${dir}/letter_templates/custom_pdf.php" "${dir}/"
-            fi
-            mv -f "${dir}/letter_templates"/* "${dir}/documents/letter_templates/"
-        fi
-        rm -rf "${dir}/letter_templates"
-    fi
-    if [ -d "${dir}/procedure_results" ]; then
-        if [ "$(ls "${dir}/procedure_results")" ]; then
-            mv -f "${dir}/procedure_results"/* "${dir}/documents/procedure_results/"
-        fi
-        rm -rf "${dir}/procedure_results"
-    fi
+    done
     echo "Completed: Update new directory structure in ${sitename}"
 
     # Clear smarty cache
@@ -70,8 +54,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes #648 and clears the remaining ShellCheck warnings in `fsupgrade-1.sh` (10 total: SC2243 x4, SC2312 x4, SC2044 x2). Follow-up slice to #649.

The four directory-migration blocks (era, edi, letter_templates, procedure_results) silently lost dotfiles during the 5.0.1->5.0.2 site layout migration. Three bugs compounded:

1. `[ "$(ls "${dir}/era")" ]` — `ls` skips dotfiles, so a directory containing only dotfiles tested as empty and the `mv` was skipped.
2. `mv -f "${dir}/era"/*` — the glob `*` also skips dotfiles, so any dotfiles present were left behind even when the guard passed.
3. `rm -rf "${dir}/era"` — then destroyed whatever dotfiles remained.

For ERA (Electronic Remittance Advice) and other patient billing data this was silent data loss. Each block now uses the POSIX-safe pattern:

```sh
find "${dir}/era/." ! -name . -prune -exec mv -f {} "${dir}/documents/era/" +
rmdir "${dir}/era"
```

`/.` plus `! -name . -prune` enumerates immediate children including dotfiles. `-exec ... +` batches into one `mv`. `rmdir` replaces `rm -rf` so cleanup fails loudly if anything is left over instead of destroying it. The `custom_pdf.php` hoist in the letter_templates block is preserved unchanged.

The two `for dir in $(find sites/* -maxdepth 0 -type d)` loops are rewritten as simple trailing-slash globs (`for dir in /var/.../sites/*/`), clearing SC2044 and handling whitespace safely.

Two copies of the script remain byte-identical.

#### Changes proposed in this pull request:

- `docker/openemr/7.0.4/upgrade/fsupgrade-1.sh`
- `docker/openemr/8.0.0/upgrade/fsupgrade-1.sh`

#### AI disclosure:
- [x] Yes, I used AI to help with this PR