### PR TITLE
style(shell): declare runtime env via stub for ShellCheck (SC1091/SC2154/SC2312)

### DIFF
--- a/packages/standard/ami/ami-configure.sh
+++ b/packages/standard/ami/ami-configure.sh
@@ -5,12 +5,15 @@ exec > /var/log/openemr-configure.log 2>&1
 cd /root/openemr-devops/packages/standard
 
 # pick up cloud settings
+# shellcheck source=packages/standard/cloud-variables.stub
 source /root/cloud-variables
 
 # prepare the encrypted volume CFN just added
 # this used to be in a weird ready-loop but that doesn't make any sense to me
 DVOL_SERIAL=${DVOL/-/}
-DVOL_DEVICE=/dev/$(lsblk -no NAME,SERIAL | awk -v s="${DVOL_SERIAL}" '$2 == s {print $1}')
+# Split across statements so ShellCheck can see lsblk's exit status (SC2312).
+LSBLK_OUTPUT=$(lsblk -no NAME,SERIAL)
+DVOL_DEVICE=/dev/$(awk -v s="${DVOL_SERIAL}" '$2 == s {print $1}' <<< "${LSBLK_OUTPUT}")
 mkfs -t ext4 "${DVOL_DEVICE}"
 echo "${DVOL_DEVICE}" /mnt/docker ext4 defaults,nofail 0 0 >> /etc/fstab
 mkdir /mnt/docker

--- a/packages/standard/cloud-variables.stub
+++ b/packages/standard/cloud-variables.stub
@@ -1,0 +1,9 @@
+# shellcheck shell=sh
+# Declares the variables written into /root/cloud-variables by CloudFormation
+# UserData at instance boot, so ShellCheck can resolve them statically.
+# This file is NOT used at runtime; the real values come from CFN.
+: "${DVOL:=}"           # encrypted EBS volume serial
+: "${S3:=}"             # backup bucket for this instance
+: "${KMS:=}"            # KMS key ID for SSE
+: "${RECOVERYS3:=}"     # source bucket when restoring from another stack
+: "${RECOVERY_NEWRDS:=}" # replacement RDS hostname when restoring

--- a/packages/standard/scripts/backup.sh
+++ b/packages/standard/scripts/backup.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
+# shellcheck source=packages/standard/cloud-variables.stub
 source /root/cloud-variables
 PASSPHRASE=$(aws s3 cp "s3://${S3}/Backup/passphrase.txt" - --sse aws:kms --sse-kms-key-id "${KMS}")
 export PASSPHRASE
-duplicity --full-if-older-than 7D --include "$(docker volume inspect standard_sitevolume | jq -r ".[0].Mountpoint")" --exclude '**' / "boto3+s3://${S3}/Backup"
+VOLUME_INFO=$(docker volume inspect standard_sitevolume)
+MOUNTPOINT=$(jq -r ".[0].Mountpoint" <<< "${VOLUME_INFO}")
+duplicity --full-if-older-than 7D --include "${MOUNTPOINT}" --exclude '**' / "boto3+s3://${S3}/Backup"
 duplicity remove-all-but-n-full 2 --force "boto3+s3://${S3}/Backup"

--- a/packages/standard/scripts/restore.sh
+++ b/packages/standard/scripts/restore.sh
@@ -16,6 +16,7 @@ while getopts "r:" opt; do
   esac
 done
 
+# shellcheck source=packages/standard/cloud-variables.stub
 source /root/cloud-variables
 
 case ${RECOVERYMODE} in


### PR DESCRIPTION
## Summary

Follow-up to #649. Resolves the remaining ShellCheck warnings in the three `packages/standard` scripts that source `/root/cloud-variables` at runtime: `ami-configure.sh`, `backup.sh`, and `restore.sh`.

`/root/cloud-variables` is written by CloudFormation UserData at instance boot and is not tracked in the repo, so ShellCheck reports SC1091 (not followable) and SC2154 (variables not assigned) for every variable read from it.

## Changes

- **New `packages/standard/cloud-variables.stub`** declaring the variables CFN injects (`DVOL`, `S3`, `KMS`, `RECOVERYS3`, `RECOVERY_NEWRDS`) with no-op default assignments. The stub is a static declaration only — it is never sourced at runtime; the real values still come from CFN.
- **`# shellcheck source=packages/standard/cloud-variables.stub`** directive added above each `source /root/cloud-variables` line. The path is resolved from the repo root, matching how CI invokes shellcheck. Clears SC1091 and all SC2154.
- **SC2312 hoists**: the remaining `return value masked in pipeline` warnings in `ami-configure.sh` and `backup.sh` are fixed by capturing the producing command's output into a variable, then feeding it to the consumer via herestring. No runtime behavior change.

No `# shellcheck disable` directives are added; the stub plus `source=` directive is the proper fix.

## Verification

```
$ shellcheck --check-sourced --external-sources \
    packages/standard/ami/ami-configure.sh \
    packages/standard/scripts/backup.sh \
    packages/standard/scripts/restore.sh
$ echo $?
0
```

`bash -n` passes on all three scripts.

## Test plan

- [x] `bash -n` clean on all three scripts
- [x] `shellcheck --check-sourced --external-sources` produces no output for the three files
- [ ] CI ShellCheck workflow passes on this PR