### PR TITLE
style(upgrade): rewrite `for X in $(find ...)` as a glob loop (SC2044)

### DIFF
--- a/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-2.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="5.0.2"
 echo "Start: Upgrade to docker-version 2"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-3.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="6.0.0"
 echo "Start: Upgrade to docker-version 3"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-4.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="6.1.0"
 echo "Start: Upgrade to docker-version 4"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-5.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.0"
 echo "Start: Upgrade to docker-version 5"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-6.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.1"
 echo "Start: Upgrade to docker-version 6"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-7.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.2"
 echo "Start: Upgrade to docker-version 7"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/7.0.4/upgrade/fsupgrade-8.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.3"
 echo "Start: Upgrade to docker-version 8"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-8.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.3"
 echo "Start: Upgrade to docker-version 8"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-9.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.4"
 echo "Start: Upgrade to docker-version 9"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"


### PR DESCRIPTION
#### Short description of what this resolves:

Next slice of ShellCheck cleanup (follow-up to #459, #643, #649, #652). Clears all 18 SC2044 warnings across the `fsupgrade-{2..8}.sh` family, and brings the family's outer-loop structure into line with what #652 landed on `fsupgrade-1.sh`.

Every file has two loops of the form:

```sh
for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
```

Word-splitting the output of `find` is fragile — any whitespace or glob characters in a site directory name breaks the loop. Replace with a POSIX directory-glob:

```sh
for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
    dir="${dir%/}"
    sitename=${dir##*/}
    ...existing body unchanged...
done
```

- Trailing `/` on the glob restricts matches to directories (same as `-type d`).
- `dir="${dir%/}"` strips the trailing slash so `${dir}` inside the loop body behaves exactly as before — no follow-up changes needed.
- `${dir##*/}` replaces `$(basename "${dir}")` — no subshell, same result.

No `[ -d "${dir}" ] || continue` guard: the trailing-slash glob only expands to directories, so the guard is dead weight. (Matches the convention #652 landed on `fsupgrade-1.sh`.)

Same fix applied to the `dirdata` loop in each file. Loop bodies are otherwise untouched.

#### Changes proposed in this pull request:

- `docker/openemr/7.0.4/upgrade/fsupgrade-{2,3,4,5,6,7,8}.sh`
- `docker/openemr/8.0.0/upgrade/fsupgrade-{8,9}.sh`

SC2044 in `fsupgrade-1.sh` was already handled by #652.

`shellcheck --check-sourced --external-sources` is clean on all nine files.

#### AI disclosure:
- [x] Yes, I used AI to help with this PR