### PR TITLE
style(shell): clear remaining ShellCheck warnings across 8.0.0 scripts

### DIFF
--- a/docker/openemr/8.0.0/env.stub
+++ b/docker/openemr/8.0.0/env.stub
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+# Stub file for ShellCheck SC2154 (vars referenced but not assigned).
+# These variables come from the Docker container environment, set by
+# docker-compose's `environment:` block or `-e` flags on `docker run`.
+# This file exists solely to tell ShellCheck the names are intentional;
+# it is not sourced at runtime.
+
+# openemr.sh
+: "${K8S:=}"
+: "${SWARM_MODE:=}"
+: "${MANUAL_SETUP:=}"
+: "${REDIS_SERVER:=}"
+: "${PHPREDIS_BUILD:=}"
+: "${PHP_VERSION_ABBR:=}"
+: "${REDIS_USERNAME:=}"
+: "${REDIS_PASSWORD:=}"
+: "${REDIS_X509:=}"
+: "${REDIS_TLS:=}"
+: "${XDEBUG_IDE_KEY:=}"
+: "${XDEBUG_ON:=}"
+
+# ssl.sh
+: "${DOMAIN:=}"
+: "${OPERATOR:=}"

--- a/docker/openemr/8.0.0/openemr.sh
+++ b/docker/openemr/8.0.0/openemr.sh
@@ -12,6 +12,18 @@ set -e
 # shellcheck source=SCRIPTDIR/utilities/devtoolsLibrary.source
 . /root/devtoolsLibrary.source
 
+# Environment variables used by this script are supplied by the Docker runtime
+# (docker-compose `environment:` or `-e` flags). The env.stub file declares
+# them for ShellCheck's benefit using `: "${VAR:=}"` assignments that leave
+# real runtime values untouched. The stub is not shipped into the container
+# image; the `if false` keeps the `.` statically visible to ShellCheck's
+# source-follower without ever running it — BusyBox ash treats `.` as a
+# special builtin and exits the shell on file-not-found even with `|| true`.
+if false; then
+    # shellcheck source=docker/openemr/8.0.0/env.stub
+    . /root/env.stub
+fi
+
 swarm_wait() {
     if [ ! -f /var/www/localhost/htdocs/openemr/sites/docker-completed ]; then
         # true
@@ -75,13 +87,23 @@ elif [ "${K8S}" = "worker" ]; then
 fi
 
 if [ "${SWARM_MODE}" = "yes" ]; then
-    # atomically test for leadership
+    # Atomically test for leadership. Multiple swarm containers race through this block,
+    # and exactly one must become the leader. A `[ -f file ]` check followed by a create
+    # has a TOCTOU race — every racer sees the file missing, every racer creates it, every
+    # racer declares itself leader. Instead, `set -o noclobber` makes the redirect below
+    # use `open(O_CREAT|O_EXCL)`: the kernel serializes the creation, exactly one redirect
+    # succeeds, and every other container's redirect fails with EEXIST and falls into the
+    # `|| AUTHORITY=no` branch. One winner by construction.
     set -o noclobber
-    { > /var/www/localhost/htdocs/openemr/sites/docker-leader ; } &> /dev/null || AUTHORITY=no
+    : > /var/www/localhost/htdocs/openemr/sites/docker-leader 2>/dev/null || AUTHORITY=no
     set +o noclobber
 
     if [ "${AUTHORITY}" = "no" ] &&
        [ ! -f /var/www/localhost/htdocs/openemr/sites/docker-completed ]; then
+        # swarm_wait is a retry predicate: its failure is the loop termination
+        # signal, not a script-fatal condition. Disabling set -e in the while
+        # condition is intentional.
+        # shellcheck disable=SC2310
         while swarm_wait; do
             echo "Waiting for the docker-leader to finish configuration before proceeding."
             sleep 10;
@@ -224,6 +246,10 @@ if [ "${AUTHORITY}" = "yes" ]; then
        [ "${MANUAL_SETUP}" != "yes" ]; then
 
         echo "Running quick setup!"
+        # auto_setup is a retry predicate: the loop drives it to success and
+        # the ! inverts its exit for the exit condition. Disabling set -e in
+        # both the ! and while contexts is intentional.
+        # shellcheck disable=SC2310
         while ! auto_setup; do
             echo "Couldn't set up. Any of these reasons could be what's wrong:"
             echo " - You didn't spin up a MySQL container or connect your OpenEMR container to a mysql instance"
@@ -253,7 +279,7 @@ if
             fi
             c=$(( c + 1 ))
         done
-        echo -n "${DOCKER_VERSION_ROOT}" > /var/www/localhost/htdocs/openemr/sites/default/docker-version
+        printf '%s' "${DOCKER_VERSION_ROOT}" > /var/www/localhost/htdocs/openemr/sites/default/docker-version
         echo "Completed upgrade"
     fi
 fi
@@ -284,7 +310,8 @@ if [ "${REDIS_SERVER}" != "" ] &&
       phpize83
       # note for php 8.3, needed to change from './configure --enable-redis-igbinary' to:
       ./configure --with-php-config=/usr/bin/php-config83 --enable-redis-igbinary
-      make -j "$(nproc --all)"
+      jobs=$(nproc --all)
+      make -j "${jobs}"
       make install
       echo "extension=redis" > "/etc/php${PHP_VERSION_ABBR}/conf.d/20_redis.ini"
       rm -fr /tmpredis/phpredis

--- a/docker/openemr/8.0.0/ssl.sh
+++ b/docker/openemr/8.0.0/ssl.sh
@@ -8,6 +8,18 @@
 #
 set -e
 
+# Environment variables used by this script are supplied by the Docker runtime
+# (docker-compose `environment:` or `-e` flags). The env.stub file declares
+# them for ShellCheck's benefit using `: "${VAR:=}"` assignments that leave
+# real runtime values untouched. The stub is not shipped into the container
+# image; the `if false` keeps the `.` statically visible to ShellCheck's
+# source-follower without ever running it — BusyBox ash treats `.` as a
+# special builtin and exits the shell on file-not-found even with `|| true`.
+if false; then
+    # shellcheck source=docker/openemr/8.0.0/env.stub
+    . /root/env.stub
+fi
+
  if ! [ -f /etc/ssl/private/selfsigned.key.pem ]; then
     openssl req -x509 -newkey rsa:4096 \
     -keyout /etc/ssl/private/selfsigned.key.pem \

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-2.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="5.0.2"
 echo "Start: Upgrade to docker-version 2"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-3.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="6.0.0"
 echo "Start: Upgrade to docker-version 3"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-4.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="6.1.0"
 echo "Start: Upgrade to docker-version 4"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-5.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.0"
 echo "Start: Upgrade to docker-version 5"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-6.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.1"
 echo "Start: Upgrade to docker-version 6"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"

--- a/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
+++ b/docker/openemr/8.0.0/upgrade/fsupgrade-7.sh
@@ -6,8 +6,9 @@ priorOpenemrVersion="7.0.2"
 echo "Start: Upgrade to docker-version 7"
 
 # Perform codebase upgrade on each directory in sites/
-for dir in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dir}")
+for dir in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dir="${dir%/}"
+    sitename=${dir##*/}
 
     # Ensure have all directories
     echo "Start: Ensure have all directories in ${sitename}"
@@ -39,8 +40,9 @@ chown -R apache:root /var/www/localhost/htdocs/openemr/sites/
 echo "Completed: Fix permissions"
 
 # Perform database upgrade on each directory in sites/
-for dirdata in $(find /var/www/localhost/htdocs/openemr/sites/* -maxdepth 0 -type d ); do
-    sitename=$(basename "${dirdata}")
+for dirdata in /var/www/localhost/htdocs/openemr/sites/*/; do
+    dirdata="${dirdata%/}"
+    sitename=${dirdata##*/}
 
     # Upgrade database
     echo "Start: Upgrade database for ${sitename} from ${priorOpenemrVersion}"


### PR DESCRIPTION
## Summary

Finishes the ShellCheck cleanup started in #652–#655. Applies the same patterns that landed in the 7.0.4 image to the 8.0.0 image, plus the glob-loop rewrite to `fsupgrade-{2..7}.sh`.

After this, every file covered by `.github/workflows/shellcheck.yml` produces zero findings locally.

### Changes

- `docker/openemr/8.0.0/env.stub` — new stub file declaring runtime env vars supplied by docker-compose, for SC2154 silencing. Pattern established in #653/#655.
- `docker/openemr/8.0.0/openemr.sh` and `docker/openemr/8.0.0/ssl.sh`:
  - Add the env.stub source wrapped in `if false; then … fi` so ShellCheck follows it statically but the `.` command never runs at container startup. BusyBox ash (Alpine's `/bin/sh`) exits on special-builtin failure even with `|| true`, which is what broke the container in #655's first attempt.
  - `{ > file ; } &> /dev/null` → POSIX `: > file 2>/dev/null` (SC2188, SC3020) with an expanded comment explaining why `set -o noclobber` + O_CREAT|O_EXCL is the right TOCTOU-safe leader-election primitive.
  - `echo -n` → `printf '%s'` (SC3037).
  - Hoist `$(nproc --all)` to `jobs=` so ShellCheck can see its exit status (SC2312).
  - Inline `# shellcheck disable=SC2310` with an explanatory comment at each retry-predicate `while` (`swarm_wait`, `! auto_setup`).
- `docker/openemr/8.0.0/upgrade/fsupgrade-{2..7}.sh` — rewrite `for X in $(find sites/* -maxdepth 0 -type d)` as `for X in sites/*/; do X="${X%/}"; sitename=${X##*/}` (SC2044, drops the `basename` subshell). Matches #654.

### Clears

SC2044 (13), SC2154 (15), SC2188 (1), SC2310 (3), SC2312 (1), SC3020 (1), SC3037 (1).

## Test plan

- [x] `shellcheck --check-sourced --external-sources` over the full set of 113 files matched by the workflow returns no findings
- [x] `bash -n` on each modified script passes
- [ ] CI green: ShellCheck + Production Docker (7.0.4/8.0.0/8.1.0/8.1.1/binary/flex)