### PR TITLE
feat(release): add openemr-devops slice of release automation (#664)

### DIFF
--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -1,0 +1,69 @@
+name: Release Permissions Check
+
+# Manual probe of the release App's installed permissions on this repo.
+# Mints an App token from RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY and
+# exercises only what tools/release/ rotation needs (per docs/release-automation-plan.md).
+# Run after installing the App and after secrets rotations.
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: release-permissions-check
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Probe release App permissions
+    runs-on: ubuntu-24.04
+    env:
+      OWNER: ${{ github.repository_owner }}
+      REPO_NAME: ${{ github.event.repository.name }}
+      RUN_ID: ${{ github.run_id }}
+      BRANCH: release-permissions-check/${{ github.run_id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      - name: Mint release App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Probe — installation includes this repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: tools/release
+        run: task release:probe-app-installation
+
+      - name: Probe — metadata:read on repo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: tools/release
+        run: task release:probe-app-metadata
+
+      - name: Probe — contents:write (branch create + commit)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: tools/release
+        run: task release:probe-app-contents-write
+
+      - name: Probe — pull-requests:write (open draft + close)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: tools/release
+        run: task release:probe-app-pull-requests-write
+
+      - name: Cleanup throwaway branch
+        if: always() && steps.app-token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        working-directory: tools/release
+        run: task release:probe-app-cleanup

--- a/.github/workflows/release-rotation.yml
+++ b/.github/workflows/release-rotation.yml
@@ -1,0 +1,141 @@
+name: Release Rotation
+
+# Long-lived rotation PR for the 3-slot model (current/next/dev). Triggered by
+# repository_dispatch from openemr/openemr (per dispatch.schema.json) or
+# manually via workflow_dispatch. Force-pushes a regenerated diff to
+# release-rotation/auto and opens/updates the draft PR. Won't fire E2E until
+# the conductor side lands; until then this is exercised via workflow_dispatch.
+
+on:
+  repository_dispatch:
+    types: [openemr-rel-cut, openemr-rel-update, openemr-tag]
+  workflow_dispatch:
+    inputs:
+      current:
+        description: 'New value for current slot (e.g. 8.1)'
+        required: false
+        type: string
+      next:
+        description: 'New value for next slot (e.g. 8.2)'
+        required: false
+        type: string
+      dev:
+        description: 'New value for dev slot (e.g. 8.2 or edge)'
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-rotation
+  cancel-in-progress: false
+
+jobs:
+  rotate:
+    name: Apply rotation and update draft PR
+    runs-on: ubuntu-24.04
+    env:
+      ROTATION_BRANCH: release-rotation/auto
+      EVENT_NAME: ${{ github.event_name }}
+      DISPATCH_TYPE: ${{ github.event.action }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Mint release App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      - name: Derive slot assignments
+        id: slots
+        env:
+          CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+          INPUT_CURRENT: ${{ inputs.current }}
+          INPUT_NEXT: ${{ inputs.next }}
+          INPUT_DEV: ${{ inputs.dev }}
+        working-directory: tools/release
+        run: |
+          set -euo pipefail
+          if [[ ${EVENT_NAME} == 'workflow_dispatch' ]]; then
+              {
+                  printf 'current=%s\n' "${INPUT_CURRENT}"
+                  printf 'next=%s\n' "${INPUT_NEXT}"
+                  printf 'dev=%s\n' "${INPUT_DEV}"
+              } >> "${GITHUB_OUTPUT}"
+          else
+              printf '%s' "${CLIENT_PAYLOAD}" \
+                | task release:derive-slots-from-dispatch EVENT_TYPE="${DISPATCH_TYPE}" PAYLOAD_FILE='-' \
+                >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Apply rotation
+        env:
+          CURRENT: ${{ steps.slots.outputs.current }}
+          NEXT: ${{ steps.slots.outputs.next }}
+          DEV: ${{ steps.slots.outputs.dev }}
+        working-directory: tools/release
+        run: |
+          set -euo pipefail
+          if [[ -z ${CURRENT} && -z ${NEXT} && -z ${DEV} ]]; then
+              printf '::warning::no slot assignments derived; nothing to rotate\n'
+              exit 0
+          fi
+          task release:rotate CURRENT="${CURRENT}" NEXT="${NEXT}" DEV="${DEV}"
+
+      - name: Diff and decide
+        id: diff
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+              printf 'has-changes=false\n' >> "${GITHUB_OUTPUT}"
+              printf '::notice::rotation is a no-op (registry already at target)\n'
+          else
+              printf 'has-changes=true\n' >> "${GITHUB_OUTPUT}"
+              git diff --stat
+          fi
+
+      - name: Force-push rotation branch
+        if: steps.diff.outputs.has-changes == 'true'
+        working-directory: tools/release
+        run: |
+          set -euo pipefail
+          msg=$(printf 'rotation: %s (run %s)' "${DISPATCH_TYPE:-workflow_dispatch}" "${RUN_URL}")
+          task release:push-rotation-branch \
+              ROTATION_BRANCH="${ROTATION_BRANCH}" \
+              COMMIT_MESSAGE="${msg}"
+
+      - name: Open or update rotation PR
+        if: steps.diff.outputs.has-changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          CURRENT: ${{ steps.slots.outputs.current }}
+          NEXT: ${{ steps.slots.outputs.next }}
+          DEV: ${{ steps.slots.outputs.dev }}
+        working-directory: tools/release
+        run: |
+          set -euo pipefail
+          default_branch=$(gh api "/repos/${GITHUB_REPOSITORY}" --jq '.default_branch')
+          task release:open-rotation-pr \
+              BRANCH="${ROTATION_BRANCH}" \
+              BASE="${default_branch}" \
+              TRIGGER="${DISPATCH_TYPE:-workflow_dispatch}" \
+              RUN_URL="${RUN_URL}" \
+              CURRENT="${CURRENT}" \
+              NEXT="${NEXT}" \
+              DEV="${DEV}"

--- a/.github/workflows/release-tools-php.yml
+++ b/.github/workflows/release-tools-php.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
           tools: cs2pr
       - run: composer install --no-interaction --no-progress
       - run: vendor/bin/phpcs --report=checkstyle | cs2pr
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
       - run: composer install --no-interaction --no-progress
       - run: vendor/bin/phpstan analyse
 
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
       - run: composer install --no-interaction --no-progress
       - run: vendor/bin/rector process --dry-run
 
@@ -70,6 +70,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.5'
       - run: composer install --no-interaction --no-progress
       - run: vendor/bin/composer-require-checker check

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -1,0 +1,187 @@
+# Release automation — `openemr-devops` slice
+
+Tracks: openemr/openemr-devops#664 (refines #662, overlaps with #638)
+
+This repo owns the **infra / test-matrix PR** in the three-PR release flow. The
+`openemr/openemr` conductor is upstream; the `website-openemr` docs PR is a
+sibling consumer. This document is the plan for what lands here.
+
+## Role in the flow
+
+```
+openemr/openemr release-prep PR  ── merge → tag v8_1_0
+            │                              │
+            └── (push to rel-*) ───────────┼──→ website-openemr docs PR
+                                           │
+                                           └──→ openemr-devops infra PR  ← this repo
+```
+
+Triggered by `repository_dispatch` from `openemr/openemr` on:
+
+- `rel-*` branch cut / push → roll `next` forward, keep `current` pinned
+- `v*_*_*` tag → promote `next` → `current`, drop the prior `current`
+
+No cron, no human handoff between workflows.
+
+## What the workflow rotates
+
+Per #638, the matrix collapses to three rotating slots:
+
+| Slot      | Meaning                                | Example after rel-8.2 cut |
+| --------- | -------------------------------------- | ------------------------- |
+| `current` | most recent tagged release             | 8.1                       |
+| `next`    | release candidate (active `rel-*`)     | 8.2                       |
+| `dev`     | head of master                         | edge                      |
+
+Today the matrix is hardcoded across files like:
+
+- `.github/workflows/build-810.yml`, `build-811.yml`, `build-800.yml`, …
+- `.github/workflows/test-flex-322.yml`, `test-flex-323.yml`, `test-flex-edge.yml`
+- `.github/workflows/build-edge.yml`, `build-flex-core.yml`, `build-release.yml`
+- `docker/**` Dockerfiles that pin OpenEMR version
+- `kubernetes/**` manifests with image tags
+- `raspberrypi/**` build configs
+- `packages/**` package version refs
+
+The infra PR is a long-lived PR against `master` that the workflow
+force-updates on every dispatch. Merging it is the "infra is ready for the new
+`current`/`next`" decision.
+
+## Components to build
+
+In dependency order:
+
+Build on the existing `tools/release/` foundation (composer + Symfony-style
+`bin/*.php` console scripts + `src/` classes + `Taskfile.yml`). Notably,
+`src/VersionBumper.php` and `bin/version-bump.php` already exist and likely
+host most of the rewrite logic.
+
+1. **`tools/release/bin/rotate.php` console script** (and supporting
+   `src/SlotRotator.php` extending or composing `VersionBumper`).
+   - Inputs: target slot assignments (e.g. `--current=8.1 --next=8.2
+     --dev=edge`).
+   - Reads a single source-of-truth config (`tools/release/versions.yml`)
+     listing every file + jsonpath/regex that holds a version reference.
+   - Rewrites those files in place, idempotently. `--dry-run` prints the diff.
+   - Lints with `php -l`, PHPStan (existing `phpstan.neon`), and PHPCS
+     (existing `phpcs.xml`).
+   - Exposed via `task release:rotate` in `tools/release/Taskfile.yml`,
+     mirroring the existing `task release:changelog` pattern.
+
+2. **`tools/release/versions.yml` registry.**
+   - One entry per file holding a version. Built by sweeping the repo once and
+     classifying each pin as `current` / `next` / `dev` (or explicit
+     `excludes:`).
+   - Reviewed by hand — this is the part that has to be right.
+
+3. **Workflow `.github/workflows/release-rotation.yml`.**
+   - Triggers: `repository_dispatch` (`types: [openemr-rel-cut, openemr-tag]`)
+     and `workflow_dispatch` (manual override).
+   - Steps: checkout → run rotation script → if diff, force-push to
+     `release-rotation/auto` branch and open/update a draft PR.
+   - PR body summarizes which slot moved and links the upstream event.
+
+4. **PAT / app credential** with `contents:write` and `pull-requests:write` on
+   this repo, accepted via `repository_dispatch` from openemr/openemr.
+
+5. **Workflow consolidation (#638 follow-on).**
+   - Collapse `build-810.yml` / `build-811.yml` / `build-800.yml` etc. into one
+     `build-current.yml` / `build-next.yml` / `build-dev.yml` driven by the
+     registry. Reduces what the rotation script has to touch.
+   - Same for `test-flex-*.yml` matrices.
+
+## Permissions self-check
+
+`.github/workflows/release-permissions-check.yml` (manual `workflow_dispatch`).
+Mints an App token from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` and
+probes only what this repo's rotation workflow needs:
+
+- `GET /installation/repositories` — confirm this repo is in the install list.
+- `GET /repos/openemr/openemr-devops` — confirm the App can read the repo.
+- Create + delete a throwaway branch `release-permissions-check/<run-id>` —
+  confirm `contents:write`.
+- Open + close a draft PR from that branch — confirm `pull-requests:write`.
+
+Fails loudly with the missing permission name. Run after installing the App;
+re-run if secrets are rotated. Pure consumer here, so no cross-repo dispatch
+to probe.
+
+## Out of scope here
+
+- Conductor workflow lives in `openemr/openemr`.
+- Docs / Hugo / OpenAPI publishing lives in `website-openemr` (+ `-files`).
+- Wiki migration is a docs-PR concern.
+- Choice of release manager UX (which PR they merge first, etc.) is documented
+  in the conductor PR.
+
+## Open questions
+
+- Do we keep `build-edge.yml` separate or fold it into `build-dev.yml`? Naming
+  consistency vs. churn in CI history.
+- Should the rotation PR auto-merge on green CI, or always require a human?
+  Default: human-merge, since this gates the release.
+- Where does `raspberrypi/` live in the rotation? Its release cadence has
+  historically lagged — may need its own slot or an opt-out flag.
+
+## Hypotheses (claims this slice rises or falls on)
+
+1. **The three-slot rotation covers every version pin in this repo.** Nothing
+   is per-minor-version forever; everything maps to `current` / `next` / `dev`
+   or has an explicit opt-out.
+2. **The registry can be kept honest by lint.** A repo sweep can enumerate
+   every version-looking string and fail CI if any aren't listed in
+   `versions.yml`.
+3. **Cross-repo `repository_dispatch` from openemr/openemr is reliable and
+   ordered enough** to be the only coupling — no polling, no shared state.
+4. **Force-pushing the long-lived rotation PR is acceptable to reviewers.**
+   The diff is regenerated, not authored.
+
+## Assumptions
+
+- An app or PAT with `contents:write` + `pull-requests:write` on this repo
+  will be provisioned and accepted from openemr/openemr's dispatcher.
+- Rotation always advances forward (no rollback flow); a botched rotation is
+  resolved by hand-editing the PR or merging a corrective dispatch.
+- `rel-*` is the only release-branch naming pattern we need to recognize.
+- raspberrypi/ and packages/ pins fit the same three-slot model (or accept an
+  explicit opt-out flag in the registry).
+
+## Testing
+
+### Independent / per-component (fast, no cross-repo)
+
+- **Rotator unit tests** (PHPUnit, alongside the existing tests in
+  `tools/release/`). Fixture `versions.yml` + sample workflow files; assert
+  each rewrite is correct and **idempotent** (run twice → no diff). Cover:
+  bumping `next`, promoting `next`→`current`, dropping a prior `current`,
+  no-op dispatch.
+- **Registry-coverage lint.** Sweeps the repo for version-looking strings
+  (regex over `8\.\d+(\.\d+)?`, image tags, `docker-version` files) and fails
+  if any aren't enumerated in `versions.yml` (allowed via explicit
+  `excludes:` list). Catches drift when contributors add a new pinned file.
+- **Workflow YAML validation.** `actionlint` + JSON-schema check of the
+  `repository_dispatch` payload this workflow accepts.
+
+### Single-repo integration
+
+- **`workflow_dispatch` synthetic run.** Fire the rotation workflow with a
+  hand-crafted payload (`{ current: "8.1", next: "8.2", dev: "edge" }`),
+  assert the rotation PR updates with the expected diff.
+- **Re-dispatch idempotence.** Fire the same payload twice, assert the
+  resulting PR is byte-identical.
+
+### E2E (cross-repo, only meaningful in a fork triplet)
+
+- **Full dry-run.** Cut `rel-test` in a fork of openemr/openemr → confirm the
+  conductor's `openemr-rel-cut` dispatch lands here → confirm the rotation PR
+  opens with `next` advanced → tag in the fork → confirm `openemr-tag`
+  promotes `next`→`current`.
+- **Race rehearsal.** Tag while a `workflow_dispatch` rotation is mid-run;
+  confirm the second event re-runs against the now-updated state and lands a
+  consistent PR.
+
+## Status
+
+Draft plan. Implementation lands in follow-up PRs once the conductor in
+`openemr/openemr` is far enough along to emit the dispatch events this
+workflow consumes.

--- a/tools/release/.gitignore
+++ b/tools/release/.gitignore
@@ -1,2 +1,5 @@
 /vendor/
 /release-output/
+/.phpunit.cache/
+/.phpunit.result.cache
+/.task/

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -15,6 +15,12 @@ tasks:
     generates:
       - vendor/autoload.php
 
+  test:
+    desc: Run PHPUnit test suite
+    deps: [setup]
+    cmds:
+      - vendor/bin/phpunit
+
   changelog:
     desc: Generate changelog from commit range
     requires:
@@ -126,6 +132,120 @@ tasks:
         --openemr-dir={{shellQuote .OPENEMR_DIR}}
         --output-dir={{shellQuote .OUTPUT_DIR}}
         {{if .COPY_STYLES}}--copy-styles{{end}}
+
+  release:rotate:
+    desc: Apply 3-slot rotation per versions.yml (idempotent)
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/rotate.php
+        --repo={{shellQuote (default "../.." .ROTATE_REPO)}}
+        {{if .CURRENT}}--current={{shellQuote .CURRENT}}{{end}}
+        {{if .NEXT}}--next={{shellQuote .NEXT}}{{end}}
+        {{if .DEV}}--dev={{shellQuote .DEV}}{{end}}
+        {{if eq .DRY_RUN "1"}}--dry-run{{end}}
+
+  release:lint-versions:
+    desc: Verify every OpenEMR version pin is enumerated in versions.yml
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/lint-versions.php
+        --repo={{shellQuote (default "../.." .ROTATE_REPO)}}
+
+  release:verify-tag:
+    desc: Verify a release tag is annotated and well-formed per #664 spec
+    requires:
+      vars: [TAG]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/verify-tag.php
+        --repo={{shellQuote (default "../.." .TAG_REPO)}}
+        --tag={{shellQuote .TAG}}
+
+  release:check-vendored:
+    desc: Verify a consumer repo's vendored contracts match canonical
+    requires:
+      vars: [CONSUMER]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/check-vendored.php
+        --consumer={{shellQuote .CONSUMER}}
+        {{if .CANONICAL}}--canonical={{shellQuote .CANONICAL}}{{end}}
+
+  release:derive-slots-from-dispatch:
+    desc: Translate a repository_dispatch envelope into slot=<value> lines
+    requires:
+      vars: [EVENT_TYPE]
+    vars:
+      PAYLOAD_FILE: '{{.PAYLOAD_FILE | default "-"}}'
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/derive-slots-from-dispatch.php
+        --event-type={{shellQuote .EVENT_TYPE}}
+        --payload-file={{shellQuote .PAYLOAD_FILE}}
+
+  release:open-rotation-pr:
+    desc: Open or update the long-lived rotation draft PR
+    requires:
+      vars: [BRANCH, BASE]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/open-rotation-pr.php
+        --branch={{shellQuote .BRANCH}}
+        --base={{shellQuote .BASE}}
+        {{if .TITLE}}--title={{shellQuote .TITLE}}{{end}}
+        {{if .TRIGGER}}--trigger={{shellQuote .TRIGGER}}{{end}}
+        {{if .RUN_URL}}--run-url={{shellQuote .RUN_URL}}{{end}}
+        {{if .CURRENT}}--current={{shellQuote .CURRENT}}{{end}}
+        {{if .NEXT}}--next={{shellQuote .NEXT}}{{end}}
+        {{if .DEV}}--dev={{shellQuote .DEV}}{{end}}
+
+  release:push-rotation-branch:
+    desc: Force-push the rotation working tree as a single bot commit
+    requires:
+      vars: [ROTATION_BRANCH, COMMIT_MESSAGE]
+    dir: '../..'
+    env:
+      GIT_AUTHOR_NAME: openemr-release-bot[bot]
+      GIT_AUTHOR_EMAIL: openemr-release-bot[bot]@users.noreply.github.com
+      GIT_COMMITTER_NAME: openemr-release-bot[bot]
+      GIT_COMMITTER_EMAIL: openemr-release-bot[bot]@users.noreply.github.com
+    cmds:
+      - git fetch origin {{shellQuote .ROTATION_BRANCH}} 2>/dev/null || true
+      - git checkout -B {{shellQuote .ROTATION_BRANCH}}
+      - git add -A
+      - git commit -m {{shellQuote .COMMIT_MESSAGE}}
+      - git push --force-with-lease origin {{shellQuote .ROTATION_BRANCH}}
+
+  release:probe-app-installation:
+    desc: Verify the release App is installed on $OWNER/$REPO_NAME
+    cmds:
+      - scripts/probe-app-installation.sh
+
+  release:probe-app-metadata:
+    desc: Verify the release App has metadata:read on $OWNER/$REPO_NAME
+    cmds:
+      - scripts/probe-app-metadata.sh
+
+  release:probe-app-contents-write:
+    desc: Verify the release App can create a branch and commit a stub
+    cmds:
+      - scripts/probe-app-contents-write.sh
+
+  release:probe-app-pull-requests-write:
+    desc: Verify the release App can open and close a draft PR
+    cmds:
+      - scripts/probe-app-pull-requests-write.sh
+
+  release:probe-app-cleanup:
+    desc: Best-effort delete the throwaway probe branch
+    cmds:
+      - scripts/probe-app-cleanup.sh
 
   summary:
     desc: Generate release summary

--- a/tools/release/bin/check-vendored.php
+++ b/tools/release/bin/check-vendored.php
@@ -1,0 +1,83 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Fail if a consumer repo's vendored copies of cross-repo contracts have
+ * drifted from the canonical sources here.
+ *
+ * Run by CI in consumer repos (openemr/openemr, openemr/website-openemr) to
+ * catch the case where the canonical contract is updated but a vendored
+ * copy is not refreshed.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\VendoredFileChecker;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('check-vendored')
+    ->setDescription('Verify a consumer repo vendored copy matches the canonical contract')
+    ->addOption(
+        'canonical',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the canonical tools/release/ root',
+        dirname(__DIR__),
+    )
+    ->addOption(
+        'consumer',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the consumer repo dir holding the vendored copies',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $canonical = $input->getOption('canonical');
+        if (!is_string($canonical) || $canonical === '') {
+            $output->writeln('<error>--canonical is required</error>');
+            return 1;
+        }
+        if (!is_dir($canonical)) {
+            $output->writeln(sprintf('<error>Canonical dir not found: %s</error>', $canonical));
+            return 1;
+        }
+
+        $consumer = $input->getOption('consumer');
+        if (!is_string($consumer) || $consumer === '') {
+            $output->writeln('<error>--consumer is required</error>');
+            return 1;
+        }
+        if (!is_dir($consumer)) {
+            $output->writeln(sprintf('<error>Consumer dir not found: %s</error>', $consumer));
+            return 1;
+        }
+
+        $issues = (new VendoredFileChecker($canonical, $consumer))->check();
+        if ($issues === []) {
+            $output->writeln(sprintf(
+                '<info>✓</info> All %d vendored file(s) match canonical.',
+                count(VendoredFileChecker::VENDORED_PATHS),
+            ));
+            return 0;
+        }
+
+        $output->writeln(sprintf('<error>✗</error> Vendored drift detected (%d issue(s)):', count($issues)));
+        foreach ($issues as $issue) {
+            $output->writeln(sprintf('  %s  [%s]  %s', $issue->relativePath, $issue->kind, $issue->message));
+        }
+        $output->writeln('');
+        $output->writeln('Re-vendor each drifted file from the canonical openemr-devops checkout.');
+        return 1;
+    })
+    ->run();

--- a/tools/release/bin/derive-slots-from-dispatch.php
+++ b/tools/release/bin/derive-slots-from-dispatch.php
@@ -1,0 +1,94 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Translate a `repository_dispatch` envelope into the slot-assignment lines
+ * that bin/rotate.php consumes via `--current=… --next=… --dev=…`.
+ *
+ * Reads the envelope from --payload-file (use '-' for stdin), pairs it with
+ * --event-type, and prints lines:
+ *
+ *     current=<minor or empty>
+ *     next=<minor or empty>
+ *     dev=<minor or empty>
+ *
+ * Suitable for piping into $GITHUB_OUTPUT inside a workflow step.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\SlotAssignmentParser;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('derive-slots-from-dispatch')
+    ->setDescription('Convert a repository_dispatch envelope into slot=<value> lines for rotate.php')
+    ->addOption('event-type', null, InputOption::VALUE_REQUIRED, 'Dispatch event type (e.g. openemr-rel-cut)')
+    ->addOption(
+        'payload-file',
+        null,
+        InputOption::VALUE_REQUIRED,
+        "Path to JSON envelope (use '-' for stdin)",
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $eventType = $input->getOption('event-type');
+        if (!is_string($eventType) || $eventType === '') {
+            $output->writeln('<error>--event-type is required</error>');
+            return 1;
+        }
+        $payloadFile = $input->getOption('payload-file');
+        if (!is_string($payloadFile) || $payloadFile === '') {
+            $output->writeln('<error>--payload-file is required (use - for stdin)</error>');
+            return 1;
+        }
+
+        if ($payloadFile === '-') {
+            $raw = (string) file_get_contents('php://stdin');
+        } else {
+            if (!is_file($payloadFile)) {
+                $output->writeln(sprintf('<error>Payload file not found: %s</error>', $payloadFile));
+                return 1;
+            }
+            $contents = file_get_contents($payloadFile);
+            if ($contents === false) {
+                $output->writeln(sprintf('<error>Payload file unreadable: %s</error>', $payloadFile));
+                return 1;
+            }
+            $raw = $contents;
+        }
+        if ($raw === '') {
+            $output->writeln(sprintf('<error>Empty payload from: %s</error>', $payloadFile));
+            return 1;
+        }
+        $envelope = json_decode($raw, true);
+        if (!is_array($envelope)) {
+            $output->writeln(sprintf('<error>Payload is not a JSON object: %s</error>', $payloadFile));
+            return 1;
+        }
+        $normalized = [];
+        foreach ($envelope as $key => $value) {
+            if (!is_string($key)) {
+                $output->writeln(sprintf('<error>Payload root has non-string key: %s</error>', $payloadFile));
+                return 1;
+            }
+            $normalized[$key] = $value;
+        }
+
+        $assignments = (new SlotAssignmentParser())->fromDispatchPayload($eventType, $normalized);
+        foreach (['current', 'next', 'dev'] as $slot) {
+            $output->writeln(sprintf('%s=%s', $slot, $assignments[$slot] ?? ''));
+        }
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/lint-versions.php
+++ b/tools/release/bin/lint-versions.php
@@ -1,0 +1,79 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Fail if any tracked file contains an OpenEMR version pin that isn't
+ * enumerated in tools/release/versions.yml (under `files:` or `excludes:`).
+ *
+ * Run by CI on every PR; catches contributors who add a new pinned file
+ * without registering it in the rotation system.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\VersionsRegistryLinter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('lint-versions')
+    ->setDescription('Verify every OpenEMR version pin is enumerated in versions.yml')
+    ->addOption(
+        'repo',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the repo root',
+        getcwd() === false ? '.' : getcwd(),
+    )
+    ->addOption(
+        'registry',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to versions.yml (defaults to <repo>/tools/release/versions.yml)',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $repo = $input->getOption('repo');
+        if (!is_string($repo) || $repo === '') {
+            $output->writeln('<error>--repo is required</error>');
+            return 1;
+        }
+        $registry = $input->getOption('registry');
+        if (!is_string($registry) || $registry === '') {
+            $registry = $repo . '/tools/release/versions.yml';
+        }
+        if (!is_file($registry)) {
+            $output->writeln("<error>Registry not found: {$registry}</error>");
+            return 1;
+        }
+
+        $issues = (new VersionsRegistryLinter($repo, $registry))->lint();
+        if ($issues === []) {
+            $output->writeln('<info>✓</info> No drifted version pins.');
+            return 0;
+        }
+
+        $output->writeln(sprintf('<error>✗</error> Found %d unregistered pin(s):', count($issues)));
+        foreach ($issues as $issue) {
+            $output->writeln(sprintf(
+                '  %s:%d  [%s]  %s',
+                $issue->path,
+                $issue->line,
+                $issue->patternKind,
+                $issue->matched,
+            ));
+        }
+        $output->writeln('');
+        $output->writeln('Add each file to `files:` (under rotation) or `excludes:` (with reason) in versions.yml.');
+        return 1;
+    })
+    ->run();

--- a/tools/release/bin/open-rotation-pr.php
+++ b/tools/release/bin/open-rotation-pr.php
@@ -1,0 +1,62 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Open or update the long-lived rotation draft PR.
+ *
+ * Authenticates via the ambient GH_TOKEN env var (the workflow mints an App
+ * token and exports it before invoking this script).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\RotationPrPublisher;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('open-rotation-pr')
+    ->setDescription('Open or update the long-lived rotation draft PR')
+    ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Rotation branch name (head)')
+    ->addOption('base', null, InputOption::VALUE_REQUIRED, 'Base branch (e.g. master)')
+    ->addOption('title', null, InputOption::VALUE_REQUIRED, 'PR title', 'Release rotation (auto)')
+    ->addOption('trigger', null, InputOption::VALUE_REQUIRED, 'Dispatch type or trigger label', 'workflow_dispatch')
+    ->addOption('run-url', null, InputOption::VALUE_REQUIRED, 'Workflow run URL', '')
+    ->addOption('current', null, InputOption::VALUE_REQUIRED, 'New current slot (for body)', '')
+    ->addOption('next', null, InputOption::VALUE_REQUIRED, 'New next slot (for body)', '')
+    ->addOption('dev', null, InputOption::VALUE_REQUIRED, 'New dev slot (for body)', '')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $branch = RotationPrPublisher::stringOrEmpty($input->getOption('branch'));
+        $base = RotationPrPublisher::stringOrEmpty($input->getOption('base'));
+        if ($branch === '' || $base === '') {
+            $output->writeln('<error>--branch and --base are required</error>');
+            return 1;
+        }
+
+        $body = RotationPrPublisher::buildBody(
+            RotationPrPublisher::stringOrEmpty($input->getOption('trigger')),
+            RotationPrPublisher::stringOrEmpty($input->getOption('run-url')),
+            RotationPrPublisher::stringOrEmpty($input->getOption('current')),
+            RotationPrPublisher::stringOrEmpty($input->getOption('next')),
+            RotationPrPublisher::stringOrEmpty($input->getOption('dev')),
+        );
+        $publisher = new RotationPrPublisher(
+            $branch,
+            $base,
+            RotationPrPublisher::stringOrEmpty($input->getOption('title')),
+        );
+        $number = $publisher->publish($body);
+        $output->writeln(sprintf('<info>✓</info> rotation PR #%d updated', $number));
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/rotate.php
+++ b/tools/release/bin/rotate.php
@@ -1,0 +1,94 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Apply OpenEMR slot rotation to versions.yml and the files it lists.
+ *
+ * Each slot accepts a target as either a minor version ("8.2") which is
+ * expanded to a full slot definition by deterministic mapping, "edge"
+ * (sets branch=master only — for the dev slot), or `key=value,...` for
+ * explicit overrides. The rotator reads versions.yml, rewrites every pin
+ * owned by changed slots, and updates versions.yml itself. Idempotent —
+ * running twice with the same args is a no-op the second time.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\SlotAssignmentParser;
+use OpenEMR\Release\SlotRotator;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('rotate')
+    ->setDescription('Apply OpenEMR slot rotation per tools/release/versions.yml')
+    ->addOption(
+        'repo',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the repo root',
+        getcwd() === false ? '.' : getcwd(),
+    )
+    ->addOption(
+        'registry',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to versions.yml (defaults to <repo>/tools/release/versions.yml)',
+    )
+    ->addOption('current', null, InputOption::VALUE_REQUIRED, 'New value for the current slot (e.g. "8.1")')
+    ->addOption('next', null, InputOption::VALUE_REQUIRED, 'New value for the next slot (e.g. "8.2")')
+    ->addOption('dev', null, InputOption::VALUE_REQUIRED, 'New value for the dev slot (e.g. "8.2" or "edge")')
+    ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print the diff and exit without writing')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $repo = $input->getOption('repo');
+        if (!is_string($repo) || $repo === '') {
+            $output->writeln('<error>--repo is required</error>');
+            return 1;
+        }
+        $registry = $input->getOption('registry');
+        if (!is_string($registry) || $registry === '') {
+            $registry = $repo . '/tools/release/versions.yml';
+        }
+        if (!is_file($registry)) {
+            $output->writeln("<error>Registry not found: {$registry}</error>");
+            return 1;
+        }
+
+        $parser = new SlotAssignmentParser();
+        $assignments = [];
+        foreach (['current', 'next', 'dev'] as $slot) {
+            $raw = $input->getOption($slot);
+            if (!is_string($raw) || $raw === '') {
+                continue;
+            }
+            $assignments[$slot] = $parser->parse($slot, $raw);
+        }
+        if ($assignments === []) {
+            $output->writeln('<comment>No slot assignments provided; nothing to do.</comment>');
+            return 0;
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $result = (new SlotRotator($repo, $registry))->rotate($assignments, $dryRun);
+
+        if ($result->isNoOp()) {
+            $output->writeln('<info>No changes required (already at target slot values).</info>');
+            return 0;
+        }
+
+        foreach ($result->changedFiles as $path) {
+            $output->writeln(($dryRun ? '[dry-run] ' : '') . 'changed: ' . $path);
+        }
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/verify-tag.php
+++ b/tools/release/bin/verify-tag.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Verify a release tag against the openemr-devops#664 spec.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\TagVerifier;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('verify-tag')
+    ->setDescription('Verify a release tag is annotated and well-formed per openemr-devops#664')
+    ->addOption(
+        'repo',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the git repository containing the tag',
+        getcwd() === false ? '.' : getcwd(),
+    )
+    ->addOption('tag', null, InputOption::VALUE_REQUIRED, 'Tag name to verify (e.g. v8_1_0)')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $repo = $input->getOption('repo');
+        if (!is_string($repo) || $repo === '') {
+            $output->writeln('<error>--repo is required</error>');
+            return 1;
+        }
+
+        $tag = $input->getOption('tag');
+        if (!is_string($tag) || $tag === '') {
+            $output->writeln('<error>--tag is required</error>');
+            return 1;
+        }
+
+        $result = (new TagVerifier($repo))->verify($tag);
+
+        if ($result->isValid()) {
+            $output->writeln(sprintf(
+                '<info>✓</info> %s: annotated, version=%s date=%s merge=%s',
+                $result->tagName,
+                $result->version ?? '?',
+                $result->date ?? '?',
+                $result->mergeSha ?? '?',
+            ));
+            return 0;
+        }
+
+        $output->writeln(sprintf('<error>✗</error> %s failed verification:', $result->tagName));
+        foreach ($result->errors as $err) {
+            $output->writeln('  - ' . $err);
+        }
+        return 1;
+    })
+    ->run();

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -4,23 +4,31 @@
     "type": "project",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": ">=8.2",
+        "php": "^8.5",
         "nikic/php-parser": "^5.0",
         "symfony/console": "^7.0",
         "symfony/process": "^7.0",
+        "symfony/yaml": "^8.0",
         "twig/twig": "^3.24"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.48",
+        "justinrainbow/json-schema": "^6.0",
         "maglnet/composer-require-checker": "^4.0",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-strict-rules": "^2.0",
+        "phpunit/phpunit": "^11.0",
         "rector/rector": "^2.0",
         "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "OpenEMR\\Release\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "OpenEMR\\Release\\Tests\\": "tests/"
         }
     },
     "config": {
@@ -33,7 +41,8 @@
         "check": [
             "@phpcs",
             "@phpstan",
-            "@rector"
+            "@rector-check",
+            "@test"
         ],
         "fix": [
             "@phpcbf",
@@ -41,9 +50,10 @@
         ],
         "phpcbf": "phpcbf",
         "phpcs": "phpcs",
-        "phpstan": "phpstan analyse",
-        "rector": "rector process --dry-run",
+        "phpstan": "phpstan analyse --memory-limit=2G",
+        "rector-check": "rector process --dry-run",
         "rector-fix": "rector process",
-        "require-checker": "composer-require-checker check"
+        "require-checker": "composer-require-checker check",
+        "test": "phpunit"
     }
 }

--- a/tools/release/composer.lock
+++ b/tools/release/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ce59809361947bc65d9ac7a0fd2efb6",
+    "content-hash": "a6b1f8a66a38b31b874c316714afc922",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -119,16 +119,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
                 "shasum": ""
             },
             "require": {
@@ -193,7 +193,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -213,7 +213,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-04-22T15:21:55+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -284,16 +284,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -343,7 +343,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -363,20 +363,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
                 "shasum": ""
             },
             "require": {
@@ -425,7 +425,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -445,11 +445,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-04-26T13:13:48+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -510,7 +510,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -534,16 +534,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
                 "shasum": ""
             },
             "require": {
@@ -595,7 +595,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -615,20 +615,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-04-10T17:25:58+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
+                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
                 "shasum": ""
             },
             "require": {
@@ -660,7 +660,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -680,7 +680,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -771,16 +771,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.6",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4"
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
-                "reference": "6c9e1108041b5dce21a9a4984b531c4923aa9ec4",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
                 "shasum": ""
             },
             "require": {
@@ -837,7 +837,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.6"
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -857,7 +857,82 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T10:14:57+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/54174ab48c0c0f9e21512b304be17f8150ccf8f1",
+                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "twig/twig",
@@ -1020,16 +1095,16 @@
         },
         {
             "name": "ergebnis/composer-normalize",
-            "version": "2.50.0",
+            "version": "2.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/composer-normalize.git",
-                "reference": "80971fe24ff10709789942bcbe9368b2c704097c"
+                "reference": "36fb17dce18579ccab50f71b411a32ed55e6d4bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/80971fe24ff10709789942bcbe9368b2c704097c",
-                "reference": "80971fe24ff10709789942bcbe9368b2c704097c",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/36fb17dce18579ccab50f71b411a32ed55e6d4bc",
+                "reference": "36fb17dce18579ccab50f71b411a32ed55e6d4bc",
                 "shasum": ""
             },
             "require": {
@@ -1045,25 +1120,25 @@
             "require-dev": {
                 "composer/composer": "^2.9.4",
                 "ergebnis/license": "^2.7.0",
-                "ergebnis/php-cs-fixer-config": "^6.59.0",
+                "ergebnis/php-cs-fixer-config": "^6.61.1",
                 "ergebnis/phpstan-rules": "^2.13.1",
-                "ergebnis/phpunit-slow-test-detector": "^2.20.0",
-                "ergebnis/rector-rules": "^1.9.0",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.18.1",
                 "fakerphp/faker": "^1.24.1",
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^2.1.38",
-                "phpstan/phpstan-deprecation-rules": "^2.0.3",
-                "phpstan/phpstan-phpunit": "^2.0.12",
-                "phpstan/phpstan-strict-rules": "^2.0.8",
+                "phpstan/phpstan": "^2.1.47",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
                 "phpunit/phpunit": "^9.6.33",
-                "rector/rector": "^2.3.5",
+                "rector/rector": "^2.4.1",
                 "symfony/filesystem": "^5.4.41"
             },
             "type": "composer-plugin",
             "extra": {
                 "class": "Ergebnis\\Composer\\Normalize\\NormalizePlugin",
                 "branch-alias": {
-                    "dev-main": "2.49-dev"
+                    "dev-main": "2.51-dev"
                 },
                 "plugin-optional": true,
                 "composer-normalize": {
@@ -1100,7 +1175,7 @@
                 "security": "https://github.com/ergebnis/composer-normalize/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/composer-normalize"
             },
-            "time": "2026-02-09T20:57:47+00:00"
+            "time": "2026-04-14T11:17:04+00:00"
         },
         {
             "name": "ergebnis/json",
@@ -1259,36 +1334,38 @@
         },
         {
             "name": "ergebnis/json-pointer",
-            "version": "3.7.1",
+            "version": "3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-pointer.git",
-                "reference": "43bef355184e9542635e35dd2705910a3df4c236"
+                "reference": "b58c3c468a7ff109fdf9a255f17de29ecbe5276c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/43bef355184e9542635e35dd2705910a3df4c236",
-                "reference": "43bef355184e9542635e35dd2705910a3df4c236",
+                "url": "https://api.github.com/repos/ergebnis/json-pointer/zipball/b58c3c468a7ff109fdf9a255f17de29ecbe5276c",
+                "reference": "b58c3c468a7ff109fdf9a255f17de29ecbe5276c",
                 "shasum": ""
             },
             "require": {
                 "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0"
             },
             "require-dev": {
-                "ergebnis/composer-normalize": "^2.43.0",
-                "ergebnis/data-provider": "^3.2.0",
-                "ergebnis/license": "^2.4.0",
-                "ergebnis/php-cs-fixer-config": "^6.32.0",
-                "ergebnis/phpunit-slow-test-detector": "^2.15.0",
-                "fakerphp/faker": "^1.23.1",
+                "ergebnis/composer-normalize": "^2.50.0",
+                "ergebnis/data-provider": "^3.6.0",
+                "ergebnis/license": "^2.7.0",
+                "ergebnis/php-cs-fixer-config": "^6.60.2",
+                "ergebnis/phpstan-rules": "^2.13.1",
+                "ergebnis/phpunit-slow-test-detector": "^2.24.0",
+                "ergebnis/rector-rules": "^1.16.0",
+                "fakerphp/faker": "^1.24.1",
                 "infection/infection": "~0.26.6",
                 "phpstan/extension-installer": "^1.4.3",
-                "phpstan/phpstan": "^1.12.10",
-                "phpstan/phpstan-deprecation-rules": "^1.2.1",
-                "phpstan/phpstan-phpunit": "^1.4.0",
-                "phpstan/phpstan-strict-rules": "^1.6.1",
-                "phpunit/phpunit": "^9.6.19",
-                "rector/rector": "^1.2.10"
+                "phpstan/phpstan": "^2.1.46",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "phpunit/phpunit": "^9.6.34",
+                "rector/rector": "^2.4.0"
             },
             "type": "library",
             "extra": {
@@ -1328,7 +1405,7 @@
                 "security": "https://github.com/ergebnis/json-pointer/blob/main/.github/SECURITY.md",
                 "source": "https://github.com/ergebnis/json-pointer"
             },
-            "time": "2025-09-06T09:28:19+00:00"
+            "time": "2026-04-07T14:52:13+00:00"
         },
         {
             "name": "ergebnis/json-printer",
@@ -1484,16 +1561,16 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "v6.7.2",
+            "version": "6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0"
+                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/6fea66c7204683af437864e7c4e7abf383d14bc0",
-                "reference": "6fea66c7204683af437864e7c4e7abf383d14bc0",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
+                "reference": "89ac92bcfe5d0a8a4433c7b89d394553ae7250cc",
                 "shasum": ""
             },
             "require": {
@@ -1553,9 +1630,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/v6.7.2"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.8.0"
             },
-            "time": "2026-02-15T15:06:22+00:00"
+            "time": "2026-04-02T12:43:11+00:00"
         },
         {
             "name": "localheinz/diff",
@@ -1772,12 +1849,190 @@
             "time": "2025-09-14T11:18:39+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "2.1.42",
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1279e1ce86ba768f0780c9d889852b4e02ff40d0",
-                "reference": "1279e1ce86ba768f0780c9d889852b4e02ff40d0",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.54",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
                 "shasum": ""
             },
             "require": {
@@ -1822,7 +2077,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-17T14:58:32+00:00"
+            "time": "2026-04-29T13:31:09+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
@@ -1876,22 +2131,479 @@
             "time": "2026-02-11T14:17:32+00:00"
         },
         {
-            "name": "rector/rector",
-            "version": "2.3.9",
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
             "source": {
                 "type": "git",
-                "url": "https://github.com/rectorphp/rector.git",
-                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4"
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rectorphp/rector/zipball/917842143fd9f5331a2adefc214b8d7143bd32c4",
-                "reference": "917842143fd9f5331a2adefc214b8d7143bd32c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/e645b6463c6a88ea5b44b17d3387d35a912c7946",
+                "reference": "e645b6463c6a88ea5b44b17d3387d35a912c7946",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4|^8.0",
-                "phpstan/phpstan": "^2.1.40"
+                "phpstan/phpstan": "^2.1.48"
             },
             "conflict": {
                 "rector/rector-doctrine": "*",
@@ -1925,7 +2637,7 @@
             ],
             "support": {
                 "issues": "https://github.com/rectorphp/rector/issues",
-                "source": "https://github.com/rectorphp/rector/tree/2.3.9"
+                "source": "https://github.com/rectorphp/rector/tree/2.4.2"
             },
             "funding": [
                 {
@@ -1933,7 +2645,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-16T09:43:55+00:00"
+            "time": "2026-04-16T13:07:34+00:00"
         },
         {
             "name": "revolt/event-loop",
@@ -2006,6 +2718,992 @@
                 "source": "https://github.com/revoltphp/event-loop/tree/v1.0.8"
             },
             "time": "2025-08-27T21:33:23+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2087,6 +3785,108 @@
             "time": "2025-11-10T16:43:36+00:00"
         },
         {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
             "name": "webmozart/glob",
             "version": "4.7.0",
             "source": {
@@ -2142,7 +3942,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": "^8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/openemr/openemr-devops/blob/master/tools/release/contracts/dispatch.schema.json",
+    "title": "OpenEMR release dispatch payload",
+    "description": "Cross-repo repository_dispatch payloads emitted between openemr/openemr (conductor) and openemr/openemr-devops, openemr/website-openemr, openemr/website-openemr-files (consumers). See openemr/openemr-devops#664. The canonical copy lives here; consumers vendor it and CI fails on drift via tools/release/bin/check-vendored.php.",
+    "type": "object",
+    "required": ["event", "repo", "sha", "actor", "dispatched_at", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "event": {
+            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "type": "string",
+            "enum": [
+                "openemr-rel-cut",
+                "openemr-rel-update",
+                "openemr-tag",
+                "openemr-docs-binaries"
+            ]
+        },
+        "repo": {
+            "description": "Source repo in owner/name form.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$"
+        },
+        "sha": {
+            "description": "40-character lowercase hex commit SHA the event refers to.",
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+        },
+        "actor": {
+            "description": "Identity that produced the dispatch (App slug or login).",
+            "type": "string",
+            "minLength": 1
+        },
+        "dispatched_at": {
+            "description": "ISO 8601 UTC timestamp, e.g. 2026-04-29T12:00:00Z.",
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+        },
+        "data": {
+            "type": "object"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-cut" },
+                "data": { "$ref": "#/definitions/relCutData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-update" },
+                "data": { "$ref": "#/definitions/relUpdateData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-tag" },
+                "data": { "$ref": "#/definitions/tagData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-docs-binaries" },
+                "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        }
+    ],
+    "definitions": {
+        "version": {
+            "description": "Hugo version param shape (MAJOR.MINOR.PATCH).",
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "branch": {
+            "description": "Release branch name. Per #664 spec: rel-<MAJOR><MINOR>0.",
+            "type": "string",
+            "pattern": "^rel-\\d+\\d0$"
+        },
+        "tag": {
+            "description": "Release tag name. Per #664 spec: v<MAJOR>_<MINOR>_<PATCH>.",
+            "type": "string",
+            "pattern": "^v\\d+_\\d+_\\d+$"
+        },
+        "relCutData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "relUpdateData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "tagData": {
+            "type": "object",
+            "required": ["tag", "branch", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "tag": { "$ref": "#/definitions/tag" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" }
+            }
+        },
+        "docsBinariesData": {
+            "type": "object",
+            "required": ["version", "branch", "files"],
+            "additionalProperties": false,
+            "properties": {
+                "version": { "$ref": "#/definitions/version" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "files": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/release/phpcs.xml
+++ b/tools/release/phpcs.xml
@@ -8,6 +8,7 @@
 
     <file>src</file>
     <file>bin</file>
+    <file>tests</file>
 
     <exclude-pattern>vendor</exclude-pattern>
 

--- a/tools/release/phpstan.neon
+++ b/tools/release/phpstan.neon
@@ -3,10 +3,11 @@ includes:
 
 parameters:
     level: 10
-    phpVersion: 80200
+    phpVersion: 80500
     paths:
         - src
         - bin
+        - tests
     checkMissingCallableSignature: true
     checkUninitializedProperties: true
     checkTooWideReturnTypesInProtectedAndPublicMethods: true

--- a/tools/release/phpunit.xml.dist
+++ b/tools/release/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="release-tools">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+            <directory>bin</directory>
+        </include>
+    </source>
+</phpunit>

--- a/tools/release/rector.php
+++ b/tools/release/rector.php
@@ -8,8 +8,9 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
         __DIR__ . '/bin',
+        __DIR__ . '/tests',
     ])
-    ->withPhpVersion(Rector\ValueObject\PhpVersion::PHP_82)
+    ->withPhpVersion(Rector\ValueObject\PhpVersion::PHP_85)
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/tools/release/scripts/probe-app-cleanup.sh
+++ b/tools/release/scripts/probe-app-cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Best-effort delete the throwaway probe branch. Runs even if earlier probes failed.
+# Requires env: GH_TOKEN, OWNER, REPO_NAME, BRANCH.
+
+set -euo pipefail
+
+main() {
+    : "${OWNER:?OWNER is required}" "${REPO_NAME:?REPO_NAME is required}" "${BRANCH:?BRANCH is required}"
+    gh api -X DELETE "/repos/${OWNER}/${REPO_NAME}/git/refs/heads/${BRANCH}" >/dev/null 2>&1 || true
+}
+
+main "$@"

--- a/tools/release/scripts/probe-app-contents-write.sh
+++ b/tools/release/scripts/probe-app-contents-write.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Verify contents:write by creating $BRANCH from default and committing a stub file.
+# Requires env: GH_TOKEN, OWNER, REPO_NAME, BRANCH, RUN_ID.
+
+set -euo pipefail
+
+main() {
+    : "${OWNER:?OWNER is required}" "${REPO_NAME:?REPO_NAME is required}"
+    : "${BRANCH:?BRANCH is required}" "${RUN_ID:?RUN_ID is required}"
+    local default_branch base_sha stub_b64
+    default_branch=$(gh api "/repos/${OWNER}/${REPO_NAME}" --jq '.default_branch')
+    base_sha=$(gh api "/repos/${OWNER}/${REPO_NAME}/git/ref/heads/${default_branch}" --jq '.object.sha')
+    if ! gh api -X POST "/repos/${OWNER}/${REPO_NAME}/git/refs" \
+            -f "ref=refs/heads/${BRANCH}" -f "sha=${base_sha}" >/dev/null; then
+        printf '::error::release App lacks contents:write (branch create failed)\n'
+        exit 1
+    fi
+    stub_b64=$(printf 'permissions-check %s\n' "${RUN_ID}" | base64)
+    if ! gh api -X PUT "/repos/${OWNER}/${REPO_NAME}/contents/.permissions-check-${RUN_ID}" \
+            -f "message=permissions-check ${RUN_ID}" \
+            -f "content=${stub_b64}" \
+            -f "branch=${BRANCH}" >/dev/null; then
+        printf '::error::release App lacks contents:write (commit failed)\n'
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/release/scripts/probe-app-installation.sh
+++ b/tools/release/scripts/probe-app-installation.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fail if the release App is not installed on $OWNER/$REPO_NAME.
+# Requires env: GH_TOKEN, OWNER, REPO_NAME.
+
+set -euo pipefail
+
+main() {
+    : "${OWNER:?OWNER is required}" "${REPO_NAME:?REPO_NAME is required}"
+    local repos
+    repos=$(gh api /installation/repositories --paginate --jq '.repositories[].full_name')
+    if ! grep -Fxq "${OWNER}/${REPO_NAME}" <<< "${repos}"; then
+        printf '::error::release App is not installed on %s/%s\n' "${OWNER}" "${REPO_NAME}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/release/scripts/probe-app-metadata.sh
+++ b/tools/release/scripts/probe-app-metadata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fail if the release App lacks metadata:read on $OWNER/$REPO_NAME.
+# Requires env: GH_TOKEN, OWNER, REPO_NAME.
+
+set -euo pipefail
+
+main() {
+    : "${OWNER:?OWNER is required}" "${REPO_NAME:?REPO_NAME is required}"
+    if ! gh api "/repos/${OWNER}/${REPO_NAME}" --jq '.full_name' >/dev/null; then
+        printf '::error::release App lacks metadata:read on %s/%s\n' "${OWNER}" "${REPO_NAME}"
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/release/scripts/probe-app-pull-requests-write.sh
+++ b/tools/release/scripts/probe-app-pull-requests-write.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Verify pull-requests:write by opening a draft PR from $BRANCH and closing it.
+# Requires env: GH_TOKEN, OWNER, REPO_NAME, BRANCH, RUN_ID.
+
+set -euo pipefail
+
+main() {
+    : "${OWNER:?OWNER is required}" "${REPO_NAME:?REPO_NAME is required}"
+    : "${BRANCH:?BRANCH is required}" "${RUN_ID:?RUN_ID is required}"
+    local default_branch pr_number
+    default_branch=$(gh api "/repos/${OWNER}/${REPO_NAME}" --jq '.default_branch')
+    pr_number=$(gh api -X POST "/repos/${OWNER}/${REPO_NAME}/pulls" \
+            -f "title=permissions-check ${RUN_ID}" \
+            -f "body=Probe run ${RUN_ID}; auto-closed by release-permissions-check workflow." \
+            -f "head=${BRANCH}" -f "base=${default_branch}" \
+            -F draft=true --jq '.number' || true)
+    if [[ -z ${pr_number} ]]; then
+        printf '::error::release App lacks pull-requests:write (draft PR open failed)\n'
+        exit 1
+    fi
+    if ! gh api -X PATCH "/repos/${OWNER}/${REPO_NAME}/pulls/${pr_number}" \
+            -f 'state=closed' >/dev/null; then
+        printf '::error::release App can open but not close PRs\n'
+        exit 1
+    fi
+}
+
+main "$@"

--- a/tools/release/src/LintIssue.php
+++ b/tools/release/src/LintIssue.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * One drift finding from VersionsRegistryLinter: a file that contains an
+ * OpenEMR version pin but is neither listed in `files:` nor `excludes:`
+ * in versions.yml.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class LintIssue
+{
+    public function __construct(
+        public string $path,
+        public int $line,
+        public string $lineContent,
+        public string $matched,
+        public string $patternKind,
+    ) {
+    }
+}

--- a/tools/release/src/RotationPrPublisher.php
+++ b/tools/release/src/RotationPrPublisher.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * Open or update the long-lived rotation draft PR for the 3-slot model.
+ *
+ * Body markdown is built in {@see buildBody()} (pure, unit-testable). PR
+ * lookup, create, and edit shell out to the gh CLI — that uses the ambient
+ * GH_TOKEN env var, which the workflow sets to the release App's token.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class RotationPrPublisher
+{
+    public function __construct(
+        private string $branch,
+        private string $base,
+        private string $title = 'Release rotation (auto)',
+    ) {
+    }
+
+    /**
+     * Returns the PR number that was created or updated.
+     */
+    public function publish(string $body): int
+    {
+        $bodyFile = tempnam(sys_get_temp_dir(), 'rotation-pr-body-');
+        if ($bodyFile === false) {
+            throw new \RuntimeException('Failed to allocate temp file for PR body');
+        }
+        file_put_contents($bodyFile, $body);
+
+        try {
+            $existing = $this->findOpenPrNumber();
+            if ($existing !== null) {
+                $this->run(['gh', 'pr', 'edit', (string) $existing, '--body-file', $bodyFile]);
+                return $existing;
+            }
+            $this->run([
+                'gh', 'pr', 'create',
+                '--draft',
+                '--base', $this->base,
+                '--head', $this->branch,
+                '--title', $this->title,
+                '--body-file', $bodyFile,
+            ]);
+            $created = $this->findOpenPrNumber();
+            if ($created === null) {
+                throw new \RuntimeException('PR was created but cannot be located by head/base');
+            }
+            return $created;
+        } finally {
+            @unlink($bodyFile);
+        }
+    }
+
+    public static function stringOrEmpty(mixed $value): string
+    {
+        return is_string($value) ? $value : '';
+    }
+
+    public static function buildBody(
+        string $trigger,
+        string $runUrl,
+        string $current,
+        string $next,
+        string $dev,
+    ): string {
+        $lines = [
+            sprintf('Automated rotation triggered by `%s`.', $trigger),
+            '',
+        ];
+        if ($runUrl !== '') {
+            $lines[] = sprintf('Run: %s', $runUrl);
+            $lines[] = '';
+        }
+        $lines[] = 'Slot assignments applied:';
+        foreach (['current' => $current, 'next' => $next, 'dev' => $dev] as $slot => $value) {
+            if ($value !== '') {
+                $lines[] = sprintf('- %s=%s', $slot, $value);
+            }
+        }
+        return implode("\n", $lines) . "\n";
+    }
+
+    private function findOpenPrNumber(): ?int
+    {
+        $process = new Process([
+            'gh', 'pr', 'list',
+            '--state', 'open',
+            '--head', $this->branch,
+            '--base', $this->base,
+            '--json', 'number',
+            '--jq', '.[0].number // ""',
+        ]);
+        $process->mustRun();
+        $out = trim($process->getOutput());
+        return $out === '' ? null : (int) $out;
+    }
+
+    /**
+     * @param list<string> $argv
+     */
+    private function run(array $argv): void
+    {
+        $process = new Process($argv);
+        $process->setTimeout(120.0);
+        $process->mustRun();
+    }
+}

--- a/tools/release/src/SlotAssignmentParser.php
+++ b/tools/release/src/SlotAssignmentParser.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Translate CLI slot arguments into the full registry slot definition shape.
+ *
+ * Accepted forms per slot:
+ *   - "8.1"                      → minor=8.1, full=8.1.0, branch=rel-810, docker_dir=8.1.0
+ *   - "edge"                     → branch=master only (used for the dev slot)
+ *   - "key=value,key=value,..."  → explicit override of an arbitrary subset
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final class SlotAssignmentParser
+{
+    /**
+     * @return array<string, string>
+     */
+    public function parse(string $slot, string $raw): array
+    {
+        if (str_contains($raw, '=')) {
+            return $this->parseKeyValue($raw);
+        }
+        if ($raw === 'edge') {
+            return ['branch' => 'master'];
+        }
+        if (preg_match('/^(\d+)\.(\d+)$/', $raw, $m) !== 1) {
+            throw new \InvalidArgumentException("Slot {$slot}: expected MAJOR.MINOR or 'edge', got: {$raw}");
+        }
+        $major = $m[1];
+        $minorPart = $m[2];
+        return [
+            'minor' => "{$major}.{$minorPart}",
+            'full' => "{$major}.{$minorPart}.0",
+            'branch' => "rel-{$major}{$minorPart}0",
+            'docker_dir' => "{$major}.{$minorPart}.0",
+        ];
+    }
+
+    /**
+     * Translate a `repository_dispatch` envelope (per dispatch.schema.json)
+     * into the `--current=… --next=… --dev=…` shape that bin/rotate.php
+     * wants. Returns a map keyed by slot name with bare CLI values
+     * (MAJOR.MINOR strings or 'edge'); the workflow then re-invokes the
+     * regular `parse()` path for each entry.
+     *
+     * Mapping:
+     *   - openemr-rel-cut, openemr-rel-update → next=<minor of data.version>
+     *   - openemr-tag                         → current=<minor of data.version>
+     *   - openemr-docs-binaries               → no slot move (consumer event)
+     *
+     * @param array<string, mixed> $envelope
+     * @return array<string, string>
+     */
+    public function fromDispatchPayload(string $eventType, array $envelope): array
+    {
+        $data = $envelope['data'] ?? null;
+        if (!is_array($data)) {
+            throw new \InvalidArgumentException("Dispatch envelope missing 'data' object");
+        }
+        if ($eventType === 'openemr-docs-binaries') {
+            return [];
+        }
+
+        $version = $data['version'] ?? null;
+        if (!is_string($version) || preg_match('/^(\d+)\.(\d+)\.\d+$/', $version, $m) !== 1) {
+            throw new \InvalidArgumentException(
+                "Dispatch '{$eventType}' missing or malformed data.version (expected MAJOR.MINOR.PATCH)",
+            );
+        }
+        $minor = "{$m[1]}.{$m[2]}";
+
+        return match ($eventType) {
+            'openemr-rel-cut', 'openemr-rel-update' => ['next' => $minor],
+            'openemr-tag' => ['current' => $minor],
+            default => throw new \InvalidArgumentException("Unsupported dispatch event type: {$eventType}"),
+        };
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function parseKeyValue(string $raw): array
+    {
+        $out = [];
+        foreach (explode(',', $raw) as $pair) {
+            [$key, $value] = array_pad(explode('=', $pair, 2), 2, '');
+            $out[trim($key)] = trim($value);
+        }
+        return $out;
+    }
+}

--- a/tools/release/src/SlotRotationResult.php
+++ b/tools/release/src/SlotRotationResult.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Result of running SlotRotator: the set of files whose contents changed
+ * (relative to the repo root) and per-file before/after snapshots so callers
+ * can render a diff.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class SlotRotationResult
+{
+    /**
+     * @param list<string>                                $changedFiles  paths relative to repo root
+     * @param array<string, array{before: string, after: string}> $snapshots keyed by relative path
+     */
+    public function __construct(
+        public array $changedFiles,
+        public array $snapshots,
+    ) {
+    }
+
+    public function isNoOp(): bool
+    {
+        return $this->changedFiles === [];
+    }
+}

--- a/tools/release/src/SlotRotator.php
+++ b/tools/release/src/SlotRotator.php
@@ -1,0 +1,218 @@
+<?php
+
+/**
+ * Apply slot reassignments to the OpenEMR version registry (versions.yml)
+ * and to every file the registry says holds a pin for the affected slot.
+ *
+ * Idempotence is the load-bearing property here: the same arguments applied
+ * twice produce zero changes the second pass. The release workflow re-fires
+ * on every dispatch (sometimes redundantly), so a non-idempotent rotator
+ * would churn the rotation PR.
+ *
+ * The rotation strategy is value substitution scoped by slot. For a slot
+ * whose values change, every (oldValue → newValue) pair derived from the
+ * slot definition is rewritten in the slot's pin files, with regex
+ * negative-lookarounds preventing partial matches across version boundaries
+ * (e.g. "8.1" inside "8.1.0").
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Yaml\Yaml;
+
+final readonly class SlotRotator
+{
+    public function __construct(
+        private string $repoDir,
+        private string $registryPath,
+    ) {
+    }
+
+    /**
+     * @param array<string, array<string, string>> $newSlots slot name → key/value map
+     *                                                       (e.g. ['next' => ['minor' => '8.2', ...]])
+     */
+    public function rotate(array $newSlots, bool $dryRun = false): SlotRotationResult
+    {
+        $registry = $this->loadRegistry();
+        $oldSlots = $registry['slots'];
+
+        /** @var list<string> $changed */
+        $changed = [];
+        /** @var array<string, array{before: string, after: string}> $snapshots */
+        $snapshots = [];
+
+        foreach ($newSlots as $slotName => $newDef) {
+            if (!isset($oldSlots[$slotName])) {
+                throw new \InvalidArgumentException("Unknown slot: {$slotName}");
+            }
+            $oldDef = $oldSlots[$slotName];
+            if ($oldDef === $newDef) {
+                continue;
+            }
+
+            $replacements = $this->buildReplacements($oldDef, $newDef);
+            $affected = $this->filesForSlot($registry['files'], $slotName);
+
+            foreach ($affected as $relPath) {
+                $absPath = $this->repoDir . '/' . $relPath;
+                if (!is_file($absPath)) {
+                    throw new \RuntimeException("Registry references missing file: {$relPath}");
+                }
+                $before = (string) file_get_contents($absPath);
+                $after = $this->applyReplacements($before, $replacements);
+                if ($after === $before) {
+                    continue;
+                }
+                if (!$dryRun) {
+                    file_put_contents($absPath, $after);
+                }
+                $changed[] = $relPath;
+                $snapshots[$relPath] = ['before' => $before, 'after' => $after];
+            }
+        }
+
+        $registryRel = $this->relativePath($this->registryPath);
+        $regBefore = (string) file_get_contents($this->registryPath);
+        $regAfter = $this->updateRegistrySlots($regBefore, $newSlots);
+        if ($regAfter !== $regBefore) {
+            if (!$dryRun) {
+                file_put_contents($this->registryPath, $regAfter);
+            }
+            $changed[] = $registryRel;
+            $snapshots[$registryRel] = ['before' => $regBefore, 'after' => $regAfter];
+        }
+
+        return new SlotRotationResult($changed, $snapshots);
+    }
+
+    /**
+     * @return array{
+     *     slots: array<string, array<string, string>>,
+     *     files: list<array{path: string, slot: string, kinds?: list<string>}>
+     * }
+     */
+    private function loadRegistry(): array
+    {
+        $parsed = Yaml::parseFile($this->registryPath);
+        if (!is_array($parsed) || !isset($parsed['slots'], $parsed['files'])) {
+            throw new \RuntimeException("Registry malformed: {$this->registryPath}");
+        }
+        /** @var array{slots: array<string, array<string, string>>, files: list<array{path: string, slot: string, kinds?: list<string>}>} $parsed */
+        return $parsed;
+    }
+
+    /**
+     * @param array<string, string>                                    $oldDef
+     * @param array<string, string>                                    $newDef
+     * @return array<string, string> old → new, ordered by old length descending
+     */
+    private function buildReplacements(array $oldDef, array $newDef): array
+    {
+        $pairs = [];
+        foreach ($newDef as $key => $newValue) {
+            if (!isset($oldDef[$key])) {
+                continue;
+            }
+            $oldValue = $oldDef[$key];
+            if ($oldValue === '' || $oldValue === $newValue) {
+                continue;
+            }
+            $pairs[$oldValue] = $newValue;
+        }
+        uksort($pairs, static fn(string $a, string $b): int => strlen($b) - strlen($a));
+        return $pairs;
+    }
+
+    /**
+     * @param list<array{path: string, slot: string, kinds?: list<string>}> $files
+     * @return list<string>
+     */
+    private function filesForSlot(array $files, string $slotName): array
+    {
+        $matched = [];
+        foreach ($files as $entry) {
+            if ($entry['slot'] === $slotName || $entry['slot'] === 'all') {
+                $matched[] = $entry['path'];
+            }
+        }
+        return $matched;
+    }
+
+    /**
+     * @param array<string, string> $replacements
+     */
+    private function applyReplacements(string $content, array $replacements): string
+    {
+        foreach ($replacements as $old => $new) {
+            $pattern = '/(?<![\w.])' . preg_quote($old, '/') . '(?![\w.])/';
+            $result = preg_replace($pattern, $new, $content);
+            if ($result === null) {
+                throw new \RuntimeException("preg_replace failed for pattern: {$pattern}");
+            }
+            $content = $result;
+        }
+        return $content;
+    }
+
+    /**
+     * Update versions.yml in place by rewriting the per-slot scalar lines under
+     * the `slots:` block. Walks lines so that comments, blank lines, ordering,
+     * and the rest of the file are preserved verbatim.
+     *
+     * @param array<string, array<string, string>> $newSlots
+     */
+    private function updateRegistrySlots(string $content, array $newSlots): string
+    {
+        $lines = explode("\n", $content);
+        $inSlotsBlock = false;
+        $currentSlot = null;
+        foreach ($lines as $i => $line) {
+            if (preg_match('/^slots:\s*$/', $line) === 1) {
+                $inSlotsBlock = true;
+                $currentSlot = null;
+                continue;
+            }
+            if ($inSlotsBlock && preg_match('/^\S/', $line) === 1) {
+                $inSlotsBlock = false;
+                $currentSlot = null;
+                continue;
+            }
+            if (!$inSlotsBlock) {
+                continue;
+            }
+            if (preg_match('/^  (\w+):\s*$/', $line, $m) === 1) {
+                $currentSlot = isset($newSlots[$m[1]]) ? $m[1] : null;
+                continue;
+            }
+            if ($currentSlot === null) {
+                continue;
+            }
+            if (preg_match('/^(    (\w+):\s*)"([^"]*)"(\s*)$/', $line, $m) === 1) {
+                $key = $m[2];
+                if (!isset($newSlots[$currentSlot][$key])) {
+                    continue;
+                }
+                $lines[$i] = $m[1] . '"' . $newSlots[$currentSlot][$key] . '"' . $m[4];
+            }
+        }
+        return implode("\n", $lines);
+    }
+
+    private function relativePath(string $absPath): string
+    {
+        $prefix = rtrim($this->repoDir, '/') . '/';
+        if (str_starts_with($absPath, $prefix)) {
+            return substr($absPath, strlen($prefix));
+        }
+        return $absPath;
+    }
+}

--- a/tools/release/src/TagVerificationResult.php
+++ b/tools/release/src/TagVerificationResult.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Result of verifying a release tag against the openemr-devops#664 spec.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class TagVerificationResult
+{
+    /**
+     * @param list<string> $errors
+     */
+    public function __construct(
+        public string $tagName,
+        public bool $isAnnotated,
+        public ?string $version,
+        public ?string $date,
+        public ?string $mergeSha,
+        public array $errors,
+    ) {
+    }
+
+    public function isValid(): bool
+    {
+        return $this->errors === [];
+    }
+}

--- a/tools/release/src/TagVerifier.php
+++ b/tools/release/src/TagVerifier.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Verify a release tag is annotated and its message conforms to the
+ * openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class TagVerifier
+{
+    public function __construct(
+        private string $repoDir,
+    ) {
+    }
+
+    public function verify(string $tagName): TagVerificationResult
+    {
+        $errors = [];
+        $type = $this->git(['cat-file', '-t', $tagName]);
+        $isAnnotated = $type === 'tag';
+        if (!$isAnnotated) {
+            $errors[] = sprintf(
+                '%s is not annotated (object type: %s); the spec requires `git tag -a`',
+                $tagName,
+                $type,
+            );
+            return new TagVerificationResult($tagName, false, null, null, null, $errors);
+        }
+
+        $message = $this->extractMessage($this->git(['cat-file', '-p', $tagName]));
+
+        $version = $this->firstMatch('/\b(\d+\.\d+\.\d+)\b/', $message);
+        if ($version === null) {
+            $errors[] = 'tag message does not contain a version (MAJOR.MINOR.PATCH)';
+        }
+
+        $date = $this->firstMatch('/\b(\d{4}-\d{2}-\d{2})\b/', $message);
+        if ($date === null) {
+            $errors[] = 'tag message does not contain an ISO date (YYYY-MM-DD)';
+        }
+
+        $mergeSha = $this->firstMatch('/\b([0-9a-f]{40})\b/', $message);
+        if ($mergeSha === null) {
+            $errors[] = 'tag message does not contain a merge-commit SHA (40 hex chars)';
+        }
+
+        return new TagVerificationResult($tagName, true, $version, $date, $mergeSha, $errors);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): string
+    {
+        $process = new Process(['git', ...$args], $this->repoDir);
+        $process->mustRun();
+        return rtrim($process->getOutput(), "\n");
+    }
+
+    /**
+     * Extract the message body of a `git cat-file -p <tag>` annotated-tag dump.
+     *
+     * Headers (object/type/tag/tagger) precede a blank line, then the message.
+     */
+    private function extractMessage(string $catFileOutput): string
+    {
+        $parts = preg_split('/\R\R/', $catFileOutput, 2);
+        if ($parts === false || count($parts) < 2) {
+            return '';
+        }
+        return $parts[1];
+    }
+
+    private function firstMatch(string $pattern, string $subject): ?string
+    {
+        if (preg_match($pattern, $subject, $matches) !== 1) {
+            return null;
+        }
+        return $matches[1];
+    }
+}

--- a/tools/release/src/VendoredDriftIssue.php
+++ b/tools/release/src/VendoredDriftIssue.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * One drift finding from VendoredFileChecker: a vendored copy in a consumer
+ * repo that no longer matches its canonical source in openemr-devops.
+ *
+ * `kind` is one of:
+ *   - `missing_canonical` — canonical file absent (registry bug, not consumer drift)
+ *   - `missing_consumer`  — consumer never vendored this file
+ *   - `drift`             — consumer copy differs from canonical (re-vendor)
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class VendoredDriftIssue
+{
+    public function __construct(
+        public string $relativePath,
+        public string $kind,
+        public string $message,
+    ) {
+    }
+}

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Compare a consumer repo's vendored copies of cross-repo contracts against
+ * the canonical sources in this repo. Used by CI in consumer repos
+ * (openemr/openemr, openemr/website-openemr) to catch silent contract drift.
+ *
+ * Layout assumption: the consumer mirrors the canonical relative paths under
+ * its vendored dir. A consumer that vendors to `vendored/openemr-devops/`
+ * therefore has `vendored/openemr-devops/contracts/dispatch.schema.json` and
+ * `vendored/openemr-devops/src/TagVerifier.php`.
+ *
+ * Equivalence is byte-for-byte (sha256). The vendored set is intentionally
+ * small — it covers only what consumers need to validate dispatch payloads
+ * and verify release tags without depending on this repo's autoloader.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class VendoredFileChecker
+{
+    /**
+     * Files consumers must vendor. Keep this list tight — every entry is an
+     * obligation on every consumer repo's CI.
+     */
+    public const VENDORED_PATHS = [
+        'contracts/dispatch.schema.json',
+        'src/TagVerifier.php',
+        'src/TagVerificationResult.php',
+    ];
+
+    public function __construct(
+        private string $canonicalRoot,
+        private string $consumerDir,
+    ) {
+    }
+
+    /**
+     * @return list<VendoredDriftIssue>
+     */
+    public function check(): array
+    {
+        $issues = [];
+        foreach (self::VENDORED_PATHS as $rel) {
+            $canonicalAbs = $this->canonicalRoot . '/' . $rel;
+            $consumerAbs = $this->consumerDir . '/' . $rel;
+
+            if (!is_file($canonicalAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $rel,
+                    'missing_canonical',
+                    'Canonical file not found: ' . $canonicalAbs,
+                );
+                continue;
+            }
+            if (!is_file($consumerAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $rel,
+                    'missing_consumer',
+                    'Consumer copy missing — vendor it from canonical at ' . $canonicalAbs,
+                );
+                continue;
+            }
+            if (hash_file('sha256', $canonicalAbs) !== hash_file('sha256', $consumerAbs)) {
+                $issues[] = new VendoredDriftIssue(
+                    $rel,
+                    'drift',
+                    'Consumer copy differs from canonical — re-vendor from ' . $canonicalAbs,
+                );
+            }
+        }
+        return $issues;
+    }
+}

--- a/tools/release/src/VersionsRegistryLinter.php
+++ b/tools/release/src/VersionsRegistryLinter.php
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * Lint the repo against the versions.yml registry: every file containing an
+ * OpenEMR version pin must be listed in `files:` (under rotation) or
+ * `excludes:` (with a reason for opting out). This catches the case where a
+ * contributor adds a new file with a version reference and forgets to update
+ * the registry — without lint, the rotation workflow would silently miss it.
+ *
+ * Patterns scanned (all OpenEMR-specific, to keep false positives down so
+ * `excludes:` doesn't have to enumerate every Alpine/PHP/MySQL pin in the
+ * repo):
+ *
+ *   - `openemr/openemr:<tag>`       Docker image reference
+ *   - `OPENEMR_VERSION=<value>`     build arg
+ *   - `--branch <rel-NNN>`          git clone branch
+ *   - `rel-NNN`                     bare release-branch reference
+ *   - `docker/openemr/<dir>`        path reference
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+
+final readonly class VersionsRegistryLinter
+{
+    /**
+     * Patterns that signal an OpenEMR version pin. Keys are kind labels for
+     * reporting; values are PCRE patterns where capture group 1 is the matched
+     * value to surface in the lint message.
+     */
+    private const PATTERNS = [
+        'docker_image_tag' => '#openemr/openemr:([\w.-]+)#',
+        'build_arg' => '/OPENEMR_VERSION=([\w.-]+)/',
+        'clone_branch' => '/--branch\s+(rel-\d+)/',
+        'rel_branch_ref' => '/(?<![\w-])(rel-\d{2,4})(?![\w])/',
+        'docker_dir_ref' => '#(?<![\w/])docker/openemr/([\d.]+)(?![\w])#',
+    ];
+
+    public function __construct(
+        private string $repoDir,
+        private string $registryPath,
+    ) {
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    public function lint(): array
+    {
+        $registry = $this->loadRegistry();
+        $covered = array_column($registry['files'], 'path');
+        $excluded = array_column($registry['excludes'], 'path');
+
+        $registryRel = $this->relativeRegistryPath();
+        $issues = [];
+        foreach ($this->trackedFiles() as $relPath) {
+            if ($relPath === $registryRel) {
+                continue;
+            }
+            if (in_array($relPath, $covered, true)) {
+                continue;
+            }
+            if ($this->isExcluded($relPath, $excluded)) {
+                continue;
+            }
+            foreach ($this->scanFile($relPath) as $issue) {
+                $issues[] = $issue;
+            }
+        }
+        return $issues;
+    }
+
+    /**
+     * @return array{files: list<array{path: string}>, excludes: list<array{path: string}>}
+     */
+    private function loadRegistry(): array
+    {
+        $parsed = Yaml::parseFile($this->registryPath);
+        if (!is_array($parsed)) {
+            throw new \RuntimeException("Registry malformed: {$this->registryPath}");
+        }
+        $files = $parsed['files'] ?? [];
+        $excludes = $parsed['excludes'] ?? [];
+        if (!is_array($files) || !is_array($excludes)) {
+            throw new \RuntimeException("Registry files/excludes must be lists: {$this->registryPath}");
+        }
+        /** @var array{files: list<array{path: string}>, excludes: list<array{path: string}>} $out */
+        $out = ['files' => array_values($files), 'excludes' => array_values($excludes)];
+        return $out;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function trackedFiles(): array
+    {
+        $process = new Process(['git', 'ls-files', '-z'], $this->repoDir);
+        $process->mustRun();
+        $raw = $process->getOutput();
+        if ($raw === '') {
+            return [];
+        }
+        return array_values(array_filter(
+            explode("\0", $raw),
+            static fn(string $s): bool => $s !== '',
+        ));
+    }
+
+    /**
+     * @param list<string> $excluded
+     */
+    private function isExcluded(string $path, array $excluded): bool
+    {
+        foreach ($excluded as $entry) {
+            if ($path === $entry) {
+                return true;
+            }
+            if (str_starts_with($path, $entry . '/')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return list<LintIssue>
+     */
+    private function scanFile(string $relPath): array
+    {
+        $absPath = $this->repoDir . '/' . $relPath;
+        if (!is_file($absPath)) {
+            return [];
+        }
+        if ($this->looksBinary($relPath)) {
+            return [];
+        }
+        $content = (string) file_get_contents($absPath);
+        if ($content === '') {
+            return [];
+        }
+
+        $issues = [];
+        $lines = explode("\n", $content);
+        foreach ($lines as $idx => $line) {
+            foreach (self::PATTERNS as $kind => $pattern) {
+                if (preg_match_all($pattern, $line, $matches, PREG_SET_ORDER) === 0) {
+                    continue;
+                }
+                foreach ($matches as $m) {
+                    $issues[] = new LintIssue($relPath, $idx + 1, $line, $m[1], $kind);
+                }
+            }
+        }
+        return $issues;
+    }
+
+    private function looksBinary(string $relPath): bool
+    {
+        return preg_match('/\.(png|jpe?g|gif|ico|woff2?|ttf|eot|pdf|zip|gz|bz2|tar|jar|class)$/i', $relPath) === 1;
+    }
+
+    private function relativeRegistryPath(): string
+    {
+        $prefix = rtrim($this->repoDir, '/') . '/';
+        if (str_starts_with($this->registryPath, $prefix)) {
+            return substr($this->registryPath, strlen($prefix));
+        }
+        return $this->registryPath;
+    }
+}

--- a/tools/release/tests/Contracts/DispatchSchemaTest.php
+++ b/tools/release/tests/Contracts/DispatchSchemaTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests\Contracts;
+
+use JsonSchema\Validator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DispatchSchemaTest extends TestCase
+{
+    private const SCHEMA_PATH = __DIR__ . '/../../contracts/dispatch.schema.json';
+    private const FIXTURE_DIR = __DIR__ . '/../fixtures/dispatch';
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function goodFixtures(): iterable
+    {
+        yield 'openemr-rel-cut'        => ['good-rel-cut.json'];
+        yield 'openemr-rel-update'     => ['good-rel-update.json'];
+        yield 'openemr-tag'            => ['good-tag.json'];
+        yield 'openemr-docs-binaries'  => ['good-docs-binaries.json'];
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function badFixtures(): iterable
+    {
+        yield 'openemr-rel-cut missing prev_release'    => ['bad-rel-cut.json', 'prev_release'];
+        yield 'openemr-rel-update non-hex sha'          => ['bad-rel-update.json', 'sha'];
+        yield 'openemr-tag with dotted version'         => ['bad-tag.json', 'tag'];
+        yield 'openemr-docs-binaries empty files array' => ['bad-docs-binaries.json', 'files'];
+    }
+
+    #[DataProvider('goodFixtures')]
+    public function testGoodFixtureValidates(string $fixture): void
+    {
+        $validator = $this->validateFixture($fixture);
+        self::assertTrue(
+            $validator->isValid(),
+            sprintf('Expected %s to validate. %s', $fixture, $this->errorString($validator)),
+        );
+    }
+
+    #[DataProvider('badFixtures')]
+    public function testBadFixtureFails(string $fixture, string $expectedField): void
+    {
+        $validator = $this->validateFixture($fixture);
+        self::assertFalse(
+            $validator->isValid(),
+            sprintf('Expected %s to fail validation but it passed.', $fixture),
+        );
+        $errorString = $this->errorString($validator);
+        self::assertStringContainsString(
+            $expectedField,
+            $errorString,
+            sprintf('Expected validation error to mention "%s". Got: %s', $expectedField, $errorString),
+        );
+    }
+
+    private function validateFixture(string $fixtureName): Validator
+    {
+        $payload = $this->decodeJson(self::FIXTURE_DIR . '/' . $fixtureName);
+        $schema = $this->decodeJson(self::SCHEMA_PATH);
+        $validator = new Validator();
+        $validator->validate($payload, $schema);
+        return $validator;
+    }
+
+    private function decodeJson(string $path): mixed
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+        return json_decode($contents, false, 512, JSON_THROW_ON_ERROR);
+    }
+
+    private function errorString(Validator $validator): string
+    {
+        return 'Errors: ' . json_encode($validator->getErrors(), JSON_THROW_ON_ERROR);
+    }
+}

--- a/tools/release/tests/RotationPrPublisherTest.php
+++ b/tools/release/tests/RotationPrPublisherTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\RotationPrPublisher;
+use PHPUnit\Framework\TestCase;
+
+final class RotationPrPublisherTest extends TestCase
+{
+    public function testBodyIncludesTriggerInBackticksAndRunUrl(): void
+    {
+        $body = RotationPrPublisher::buildBody(
+            'openemr-rel-cut',
+            'https://example.test/runs/42',
+            '',
+            '8.2',
+            '',
+        );
+
+        self::assertStringContainsString('triggered by `openemr-rel-cut`', $body);
+        self::assertStringContainsString('Run: https://example.test/runs/42', $body);
+        self::assertStringContainsString('- next=8.2', $body);
+        self::assertStringNotContainsString('- current=', $body);
+        self::assertStringNotContainsString('- dev=', $body);
+    }
+
+    public function testBodyOmitsRunUrlSectionWhenAbsent(): void
+    {
+        $body = RotationPrPublisher::buildBody('workflow_dispatch', '', '8.1', '8.2', 'edge');
+
+        self::assertStringNotContainsString('Run:', $body);
+        self::assertStringContainsString('- current=8.1', $body);
+        self::assertStringContainsString('- next=8.2', $body);
+        self::assertStringContainsString('- dev=edge', $body);
+    }
+
+    public function testBodyHandlesAllSlotsEmpty(): void
+    {
+        $body = RotationPrPublisher::buildBody('workflow_dispatch', 'https://x.test/r/1', '', '', '');
+
+        // Heading line + blank + Run line + blank + 'Slot assignments applied:' + trailing newline.
+        self::assertStringContainsString('Slot assignments applied:', $body);
+        self::assertStringEndsWith("\n", $body);
+        self::assertStringNotContainsString('- ', $body);
+    }
+}

--- a/tools/release/tests/SlotAssignmentParserTest.php
+++ b/tools/release/tests/SlotAssignmentParserTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\SlotAssignmentParser;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class SlotAssignmentParserTest extends TestCase
+{
+    public function testRelCutDispatchAdvancesNextSlot(): void
+    {
+        $envelope = $this->loadFixture('good-rel-cut.json');
+
+        $assignments = (new SlotAssignmentParser())->fromDispatchPayload('openemr-rel-cut', $envelope);
+
+        self::assertSame(['next' => '8.1'], $assignments);
+    }
+
+    public function testRelUpdateDispatchAdvancesNextSlot(): void
+    {
+        $envelope = $this->loadFixture('good-rel-update.json');
+
+        $assignments = (new SlotAssignmentParser())->fromDispatchPayload('openemr-rel-update', $envelope);
+
+        self::assertSame(['next' => '8.1'], $assignments);
+    }
+
+    public function testTagDispatchPromotesCurrentSlot(): void
+    {
+        $envelope = $this->loadFixture('good-tag.json');
+
+        $assignments = (new SlotAssignmentParser())->fromDispatchPayload('openemr-tag', $envelope);
+
+        self::assertSame(['current' => '8.1'], $assignments);
+    }
+
+    public function testDocsBinariesDispatchYieldsNoSlotMove(): void
+    {
+        $envelope = $this->loadFixture('good-docs-binaries.json');
+
+        $assignments = (new SlotAssignmentParser())->fromDispatchPayload('openemr-docs-binaries', $envelope);
+
+        self::assertSame([], $assignments);
+    }
+
+    public function testMissingDataObjectThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/missing 'data' object/");
+
+        (new SlotAssignmentParser())->fromDispatchPayload('openemr-tag', ['event' => 'openemr-tag']);
+    }
+
+    public function testMissingVersionThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/data\.version/');
+
+        (new SlotAssignmentParser())->fromDispatchPayload('openemr-rel-cut', ['data' => ['branch' => 'rel-810']]);
+    }
+
+    public function testMalformedVersionThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/MAJOR\.MINOR\.PATCH/');
+
+        (new SlotAssignmentParser())->fromDispatchPayload('openemr-tag', ['data' => ['version' => '8.1']]);
+    }
+
+    public function testUnsupportedEventTypeThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Unsupported dispatch event/');
+
+        (new SlotAssignmentParser())->fromDispatchPayload(
+            'openemr-mystery-event',
+            ['data' => ['version' => '8.1.0']],
+        );
+    }
+
+    /**
+     * @param array<string, string> $expected
+     */
+    #[DataProvider('parseProvider')]
+    public function testParseHandlesCliShorthandForms(string $slot, string $raw, array $expected): void
+    {
+        self::assertSame($expected, (new SlotAssignmentParser())->parse($slot, $raw));
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: string, 2: array<string, string>}>
+     */
+    public static function parseProvider(): array
+    {
+        return [
+            'minor expands to slot tuple' => [
+                'next',
+                '8.2',
+                ['minor' => '8.2', 'full' => '8.2.0', 'branch' => 'rel-820', 'docker_dir' => '8.2.0'],
+            ],
+            'edge maps to master branch' => ['dev', 'edge', ['branch' => 'master']],
+            'key=value overrides apply verbatim' => [
+                'current',
+                'minor=8.0,full=8.0.0,patch=8.0.0.3,branch=rel-800,docker_dir=8.0.0',
+                [
+                    'minor' => '8.0',
+                    'full' => '8.0.0',
+                    'patch' => '8.0.0.3',
+                    'branch' => 'rel-800',
+                    'docker_dir' => '8.0.0',
+                ],
+            ],
+        ];
+    }
+
+    public function testParseRejectsBadInput(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/expected MAJOR\.MINOR or 'edge'/");
+
+        (new SlotAssignmentParser())->parse('next', 'banana');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadFixture(string $name): array
+    {
+        $path = __DIR__ . '/fixtures/dispatch/' . $name;
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw new \RuntimeException("Fixture not readable: {$path}");
+        }
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            throw new \RuntimeException("Fixture not a JSON object: {$path}");
+        }
+        $normalized = [];
+        foreach ($decoded as $key => $value) {
+            if (!is_string($key)) {
+                throw new \RuntimeException("Fixture has non-string root key: {$path}");
+            }
+            $normalized[$key] = $value;
+        }
+        return $normalized;
+    }
+}

--- a/tools/release/tests/SlotRotatorTest.php
+++ b/tools/release/tests/SlotRotatorTest.php
@@ -1,0 +1,298 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\SlotRotator;
+use PHPUnit\Framework\TestCase;
+
+final class SlotRotatorTest extends TestCase
+{
+    private string $tmpDir = '';
+    private string $registryPath = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-slot-rotator-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+        $this->seedFixtures();
+        $this->registryPath = $this->tmpDir . '/tools/release/versions.yml';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testRotationAdvancesNextSlotAndRewritesPinFiles(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $result = $rotator->rotate([
+            'next' => [
+                'minor' => '8.2',
+                'full' => '8.2.0',
+                'branch' => 'rel-820',
+                'docker_dir' => '8.2.0',
+            ],
+        ]);
+
+        self::assertFalse($result->isNoOp(), 'Rotation should have changed files');
+        self::assertContains('docker/openemr/8.1.0/Dockerfile', $result->changedFiles);
+        self::assertContains('.github/workflows/build-810.yml', $result->changedFiles);
+        self::assertContains('docker/openemr/OVERVIEW.md', $result->changedFiles);
+        self::assertContains('tools/release/versions.yml', $result->changedFiles);
+
+        $dockerfile = (string) file_get_contents($this->tmpDir . '/docker/openemr/8.1.0/Dockerfile');
+        self::assertStringContainsString('ARG OPENEMR_VERSION=rel-820', $dockerfile);
+        self::assertStringNotContainsString('rel-810', $dockerfile);
+
+        $workflow = (string) file_get_contents($this->tmpDir . '/.github/workflows/build-810.yml');
+        self::assertStringContainsString('docker/openemr/8.2.0', $workflow);
+        self::assertStringContainsString('openemr/openemr:8.2.0', $workflow);
+        self::assertStringContainsString('openemr/openemr:next', $workflow, 'Floating tag :next stays on slot');
+
+        $registry = (string) file_get_contents($this->registryPath);
+        self::assertStringContainsString('full: "8.2.0"', $registry);
+        self::assertStringContainsString('branch: "rel-820"', $registry);
+    }
+
+    public function testRotationIsIdempotent(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+        $newNext = [
+            'minor' => '8.2',
+            'full' => '8.2.0',
+            'branch' => 'rel-820',
+            'docker_dir' => '8.2.0',
+        ];
+
+        $first = $rotator->rotate(['next' => $newNext]);
+        self::assertFalse($first->isNoOp(), 'First rotation should have changed files');
+
+        $second = $rotator->rotate(['next' => $newNext]);
+        self::assertTrue($second->isNoOp(), 'Second rotation with same args should be a no-op');
+        self::assertSame([], $second->changedFiles);
+    }
+
+    public function testNoOpDispatchAtCurrentSlotValuesChangesNothing(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $result = $rotator->rotate([
+            'next' => [
+                'minor' => '8.1',
+                'full' => '8.1.0',
+                'branch' => 'rel-810',
+                'docker_dir' => '8.1.0',
+            ],
+        ]);
+
+        self::assertTrue($result->isNoOp(), 'Dispatching with the existing slot values must be a no-op');
+    }
+
+    public function testForwardRotationDoesNotCorruptOtherSlots(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $rotator->rotate([
+            'next' => [
+                'minor' => '8.2',
+                'full' => '8.2.0',
+                'branch' => 'rel-820',
+                'docker_dir' => '8.2.0',
+            ],
+        ]);
+
+        $currentPath = $this->tmpDir . '/docker/openemr/8.0.0/Dockerfile';
+        $current = (string) file_get_contents($currentPath);
+        self::assertStringContainsString('--branch rel-800', $current, 'current slot Dockerfile must not change');
+
+        $devPath = $this->tmpDir . '/docker/openemr/8.1.1/Dockerfile';
+        $dev = (string) file_get_contents($devPath);
+        self::assertStringContainsString('ARG OPENEMR_VERSION=master', $dev, 'dev slot Dockerfile must not change');
+    }
+
+    public function testDryRunReturnsDiffWithoutWritingFiles(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+        $before = (string) file_get_contents($this->tmpDir . '/docker/openemr/8.1.0/Dockerfile');
+
+        $result = $rotator->rotate(
+            [
+                'next' => [
+                    'minor' => '8.2',
+                    'full' => '8.2.0',
+                    'branch' => 'rel-820',
+                    'docker_dir' => '8.2.0',
+                ],
+            ],
+            true,
+        );
+
+        self::assertFalse($result->isNoOp());
+        $after = (string) file_get_contents($this->tmpDir . '/docker/openemr/8.1.0/Dockerfile');
+        self::assertSame($before, $after, 'dry-run must not touch the file');
+        self::assertArrayHasKey('docker/openemr/8.1.0/Dockerfile', $result->snapshots);
+    }
+
+    public function testUnknownSlotThrows(): void
+    {
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $rotator->rotate(['nightly' => ['minor' => '9.0']]);
+    }
+
+    public function testMissingPinFileThrows(): void
+    {
+        unlink($this->tmpDir . '/docker/openemr/8.1.0/Dockerfile');
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Registry references missing file/');
+
+        $rotator->rotate([
+            'next' => [
+                'minor' => '8.2',
+                'full' => '8.2.0',
+                'branch' => 'rel-820',
+                'docker_dir' => '8.2.0',
+            ],
+        ]);
+    }
+
+    public function testReplacementAvoidsPartialVersionMatches(): void
+    {
+        file_put_contents(
+            $this->tmpDir . '/docker/openemr/8.1.0/Dockerfile',
+            "FROM alpine:3.21\nARG OPENEMR_VERSION=rel-810\n# version-like-but-not: 8.1.10 should stay\n",
+        );
+        $rotator = new SlotRotator($this->tmpDir, $this->registryPath);
+
+        $rotator->rotate([
+            'next' => [
+                'minor' => '8.2',
+                'full' => '8.2.0',
+                'branch' => 'rel-820',
+                'docker_dir' => '8.2.0',
+            ],
+        ]);
+
+        $after = (string) file_get_contents($this->tmpDir . '/docker/openemr/8.1.0/Dockerfile');
+        self::assertStringContainsString('8.1.10', $after, '8.1 inside 8.1.10 must NOT be rewritten');
+        self::assertStringContainsString('rel-820', $after);
+    }
+
+    private function seedFixtures(): void
+    {
+        $this->writeFile('tools/release/versions.yml', <<<'YAML'
+        version: 1
+
+        slots:
+          current:
+            minor: "8.0"
+            full: "8.0.0"
+            branch: "rel-800"
+            docker_dir: "8.0.0"
+          next:
+            minor: "8.1"
+            full: "8.1.0"
+            branch: "rel-810"
+            docker_dir: "8.1.0"
+          dev:
+            minor: "8.1"
+            full: "8.1.1"
+            branch: "master"
+            docker_dir: "8.1.1"
+
+        files:
+          - path: .github/workflows/build-800.yml
+            slot: current
+            kinds: [build_workflow]
+          - path: .github/workflows/build-810.yml
+            slot: next
+            kinds: [build_workflow]
+          - path: .github/workflows/build-811.yml
+            slot: dev
+            kinds: [build_workflow]
+          - path: docker/openemr/8.0.0/Dockerfile
+            slot: current
+            kinds: [docker_clone_branch]
+          - path: docker/openemr/8.1.0/Dockerfile
+            slot: next
+            kinds: [docker_arg_branch]
+          - path: docker/openemr/8.1.1/Dockerfile
+            slot: dev
+            kinds: [docker_arg_branch]
+          - path: docker/openemr/OVERVIEW.md
+            slot: all
+            kinds: [overview_table]
+
+        excludes: []
+        YAML);
+
+        $workflowTemplate = "context: \"{{defaultContext}}:docker/openemr/%s\"\n"
+            . "tags: openemr/openemr:%s, openemr/openemr:%s\n";
+        $this->writeFile('.github/workflows/build-800.yml', sprintf($workflowTemplate, '8.0.0', '8.0.0', 'latest'));
+        $this->writeFile('.github/workflows/build-810.yml', sprintf($workflowTemplate, '8.1.0', '8.1.0', 'next'));
+        $this->writeFile('.github/workflows/build-811.yml', sprintf($workflowTemplate, '8.1.1', '8.1.1', 'dev'));
+
+        $this->writeFile(
+            'docker/openemr/8.0.0/Dockerfile',
+            "FROM alpine:3.21\nRUN git clone https://github.com/openemr/openemr.git --branch rel-800 --depth 1\n",
+        );
+        $this->writeFile('docker/openemr/8.1.0/Dockerfile', "FROM alpine:3.21\nARG OPENEMR_VERSION=rel-810\n");
+        $this->writeFile('docker/openemr/8.1.1/Dockerfile', "FROM alpine:3.21\nARG OPENEMR_VERSION=master\n");
+
+        $this->writeFile(
+            'docker/openemr/OVERVIEW.md',
+            "| 8.0.0 | latest |\n| 8.1.0 | next |\n| 8.1.1 | dev |\n",
+        );
+    }
+
+    private function writeFile(string $relPath, string $contents): void
+    {
+        $absPath = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($absPath);
+        if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+            throw new \RuntimeException("Failed to mkdir: {$dir}");
+        }
+        file_put_contents($absPath, $contents);
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/tests/TagVerifierTest.php
+++ b/tools/release/tests/TagVerifierTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\TagVerifier;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class TagVerifierTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-tag-verifier-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+        $this->git(['init', '-q', '-b', 'main']);
+        $this->git(['commit', '--allow-empty', '-q', '-m', 'initial commit']);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testValidAnnotatedTagPasses(): void
+    {
+        $sha = $this->git(['rev-parse', 'HEAD']);
+        $message = sprintf(
+            "OpenEMR 8.1.0 released 2026-04-29\n\nConductor PR: https://example.test/pr/1\nMerge commit: %s",
+            $sha,
+        );
+        $this->git(['tag', '-a', 'v8_1_0', '-m', $message]);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertTrue($result->isValid(), 'Expected valid tag, got errors: ' . implode('; ', $result->errors));
+        self::assertTrue($result->isAnnotated);
+        self::assertSame('8.1.0', $result->version);
+        self::assertSame('2026-04-29', $result->date);
+        self::assertSame($sha, $result->mergeSha);
+    }
+
+    public function testLightweightTagFails(): void
+    {
+        $this->git(['tag', 'v8_1_0']);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertFalse($result->isValid());
+        self::assertFalse($result->isAnnotated);
+        self::assertCount(1, $result->errors);
+        self::assertStringContainsString('not annotated', $result->errors[0]);
+    }
+
+    public function testMissingVersionFails(): void
+    {
+        $sha = $this->git(['rev-parse', 'HEAD']);
+        $message = sprintf("Released 2026-04-29\n\nMerge commit: %s", $sha);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', $message]);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertFalse($result->isValid());
+        self::assertNull($result->version);
+        self::assertContains('tag message does not contain a version (MAJOR.MINOR.PATCH)', $result->errors);
+    }
+
+    public function testMissingDateFails(): void
+    {
+        $sha = $this->git(['rev-parse', 'HEAD']);
+        $message = sprintf("OpenEMR 8.1.0 released\n\nMerge commit: %s", $sha);
+        $this->git(['tag', '-a', 'v8_1_0', '-m', $message]);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertFalse($result->isValid());
+        self::assertNull($result->date);
+        self::assertContains('tag message does not contain an ISO date (YYYY-MM-DD)', $result->errors);
+    }
+
+    public function testMissingMergeShaFails(): void
+    {
+        $message = "OpenEMR 8.1.0 released 2026-04-29\n\nNo merge SHA here";
+        $this->git(['tag', '-a', 'v8_1_0', '-m', $message]);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertFalse($result->isValid());
+        self::assertNull($result->mergeSha);
+        self::assertContains('tag message does not contain a merge-commit SHA (40 hex chars)', $result->errors);
+    }
+
+    public function testCollectsAllErrorsInOnePass(): void
+    {
+        $message = 'minimal tag message with no required fields';
+        $this->git(['tag', '-a', 'v8_1_0', '-m', $message]);
+
+        $result = (new TagVerifier($this->tmpDir))->verify('v8_1_0');
+
+        self::assertFalse($result->isValid());
+        self::assertCount(3, $result->errors);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): string
+    {
+        $process = new Process(['git', ...$args], $this->tmpDir, [
+            'GIT_CONFIG_GLOBAL' => '/dev/null',
+            'GIT_CONFIG_SYSTEM' => '/dev/null',
+            'GIT_AUTHOR_NAME' => 'Test Author',
+            'GIT_AUTHOR_EMAIL' => 'test@example.test',
+            'GIT_COMMITTER_NAME' => 'Test Committer',
+            'GIT_COMMITTER_EMAIL' => 'test@example.test',
+        ]);
+        $process->mustRun();
+        return rtrim($process->getOutput(), "\n");
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\VendoredDriftIssue;
+use OpenEMR\Release\VendoredFileChecker;
+use PHPUnit\Framework\TestCase;
+
+final class VendoredFileCheckerTest extends TestCase
+{
+    private string $canonicalRoot = '';
+    private string $consumerDir = '';
+
+    protected function setUp(): void
+    {
+        $this->canonicalRoot = sys_get_temp_dir() . '/openemr-vendored-canon-' . bin2hex(random_bytes(8));
+        $this->consumerDir = sys_get_temp_dir() . '/openemr-vendored-consumer-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->canonicalRoot, 0700, true) || !mkdir($this->consumerDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dirs');
+        }
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $this->writeFile($this->canonicalRoot, $rel, "canonical:{$rel}\n");
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->canonicalRoot);
+        $this->removeRecursive($this->consumerDir);
+    }
+
+    public function testMatchingCopiesProduceNoIssues(): void
+    {
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
+        }
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testDriftedCopyIsFlagged(): void
+    {
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
+        }
+        $this->writeFile($this->consumerDir, 'src/TagVerifier.php', "stale-content\n");
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('src/TagVerifier.php', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testMissingConsumerCopyIsFlagged(): void
+    {
+        $copy = VendoredFileChecker::VENDORED_PATHS;
+        array_pop($copy);
+        foreach ($copy as $rel) {
+            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
+        }
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('missing_consumer', $issues[0]->kind);
+    }
+
+    public function testMissingCanonicalIsFlagged(): void
+    {
+        unlink($this->canonicalRoot . '/contracts/dispatch.schema.json');
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
+        }
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('contracts/dispatch.schema.json', $issues[0]->relativePath);
+        self::assertSame('missing_canonical', $issues[0]->kind);
+    }
+
+    public function testMultipleDriftKindsReportedTogether(): void
+    {
+        $this->writeFile($this->consumerDir, 'contracts/dispatch.schema.json', "stale\n");
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(count(VendoredFileChecker::VENDORED_PATHS), $issues);
+        $kinds = array_map(static fn(VendoredDriftIssue $i): string => $i->kind, $issues);
+        self::assertContains('drift', $kinds);
+        self::assertContains('missing_consumer', $kinds);
+    }
+
+    public function testCanonicalListContainsContractAndTagFiles(): void
+    {
+        self::assertContains('contracts/dispatch.schema.json', VendoredFileChecker::VENDORED_PATHS);
+        self::assertContains('src/TagVerifier.php', VendoredFileChecker::VENDORED_PATHS);
+        self::assertContains('src/TagVerificationResult.php', VendoredFileChecker::VENDORED_PATHS);
+    }
+
+    private function writeFile(string $root, string $rel, string $contents): void
+    {
+        $abs = $root . '/' . $rel;
+        $dir = dirname($abs);
+        if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+            throw new \RuntimeException("Failed to mkdir: {$dir}");
+        }
+        file_put_contents($abs, $contents);
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/tests/VersionsRegistryLinterTest.php
+++ b/tools/release/tests/VersionsRegistryLinterTest.php
@@ -1,0 +1,226 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\VersionsRegistryLinter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class VersionsRegistryLinterTest extends TestCase
+{
+    private string $tmpDir = '';
+    private string $registryPath = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-versions-linter-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+        $this->git(['init', '-q', '-b', 'main']);
+        $this->seedBaseRegistry();
+        $this->registryPath = $this->tmpDir . '/tools/release/versions.yml';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeRecursive($this->tmpDir);
+    }
+
+    public function testCleanRepoProducesNoIssues(): void
+    {
+        $this->writeFileAndAdd('docker/openemr/8.1.0/Dockerfile', "ARG OPENEMR_VERSION=rel-810\n");
+        $this->updateRegistry([
+            ['path' => 'docker/openemr/8.1.0/Dockerfile', 'slot' => 'next'],
+        ], []);
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testUnregisteredFileWithImageTagIsFlagged(): void
+    {
+        $this->writeFileAndAdd(
+            '.github/workflows/build-new.yml',
+            "tags: openemr/openemr:8.3.0, openemr/openemr:next-next\n",
+        );
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertNotEmpty($issues);
+        $paths = array_map(static fn(\OpenEMR\Release\LintIssue $i): string => $i->path, $issues);
+        self::assertContains('.github/workflows/build-new.yml', $paths);
+    }
+
+    public function testUnregisteredFileWithBuildArgIsFlagged(): void
+    {
+        $this->writeFileAndAdd('docker/openemr/8.2.0/Dockerfile', "ARG OPENEMR_VERSION=rel-820\n");
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertNotEmpty($issues);
+        $paths = array_unique(array_map(static fn(\OpenEMR\Release\LintIssue $i): string => $i->path, $issues));
+        self::assertContains('docker/openemr/8.2.0/Dockerfile', $paths);
+    }
+
+    public function testExcludedDirectoryIsSkipped(): void
+    {
+        $this->writeFileAndAdd('docker/openemr/obsolete/old/Dockerfile', "ARG OPENEMR_VERSION=rel-700\n");
+        $this->updateRegistry([], [
+            ['path' => 'docker/openemr/obsolete', 'reason' => 'frozen historical builds'],
+        ]);
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testExcludedExactPathIsSkipped(): void
+    {
+        $this->writeFileAndAdd('packages/standard/cfn/stack.py', "docker_version = ':7.0.3'\n");
+        $this->updateRegistry([], [
+            ['path' => 'packages/standard/cfn/stack.py', 'reason' => 'independent cadence'],
+        ]);
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testNonOpenemrVersionPinsAreNotFlagged(): void
+    {
+        $this->writeFileAndAdd(
+            '.github/workflows/build-new.yml',
+            "  - uses: actions/setup-php@v3\n    with:\n      php-version: '8.4'\n",
+        );
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertSame([], $issues, 'PHP/Alpine/etc. version pins must not trigger the linter');
+    }
+
+    public function testIssueRecordsLineNumberAndPatternKind(): void
+    {
+        $this->writeFileAndAdd(
+            'docker/openemr/8.2.0/README.md',
+            "# Header\n\nimage: openemr/openemr:8.2.0\n",
+        );
+
+        $issues = (new VersionsRegistryLinter($this->tmpDir, $this->registryPath))->lint();
+
+        self::assertNotEmpty($issues);
+        $first = $issues[0];
+        self::assertSame('docker/openemr/8.2.0/README.md', $first->path);
+        self::assertSame(3, $first->line);
+        self::assertSame('docker_image_tag', $first->patternKind);
+        self::assertSame('8.2.0', $first->matched);
+    }
+
+    private function seedBaseRegistry(): void
+    {
+        $this->writeFileAndAdd('tools/release/versions.yml', <<<'YAML'
+        version: 1
+
+        slots:
+          current: { minor: "8.0", full: "8.0.0", branch: "rel-800", docker_dir: "8.0.0" }
+          next:    { minor: "8.1", full: "8.1.0", branch: "rel-810", docker_dir: "8.1.0" }
+          dev:     { minor: "8.1", full: "8.1.1", branch: "master",  docker_dir: "8.1.1" }
+
+        files: []
+
+        excludes: []
+        YAML);
+    }
+
+    /**
+     * @param list<array{path: string, slot: string}>  $files
+     * @param list<array{path: string, reason: string}> $excludes
+     */
+    private function updateRegistry(array $files, array $excludes): void
+    {
+        $yaml = "version: 1\n\nslots:\n"
+            . "  current: { minor: \"8.0\", full: \"8.0.0\", branch: \"rel-800\", docker_dir: \"8.0.0\" }\n"
+            . "  next:    { minor: \"8.1\", full: \"8.1.0\", branch: \"rel-810\", docker_dir: \"8.1.0\" }\n"
+            . "  dev:     { minor: \"8.1\", full: \"8.1.1\", branch: \"master\",  docker_dir: \"8.1.1\" }\n\n";
+
+        $yaml .= "files:\n";
+        if ($files === []) {
+            $yaml .= "  []\n";
+        } else {
+            foreach ($files as $f) {
+                $yaml .= sprintf("  - { path: %s, slot: %s }\n", $f['path'], $f['slot']);
+            }
+        }
+        $yaml .= "\nexcludes:\n";
+        if ($excludes === []) {
+            $yaml .= "  []\n";
+        } else {
+            foreach ($excludes as $e) {
+                $yaml .= sprintf("  - { path: %s, reason: \"%s\" }\n", $e['path'], $e['reason']);
+            }
+        }
+        file_put_contents($this->registryPath, $yaml);
+    }
+
+    private function writeFileAndAdd(string $relPath, string $contents): void
+    {
+        $absPath = $this->tmpDir . '/' . $relPath;
+        $dir = dirname($absPath);
+        if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+            throw new \RuntimeException("Failed to mkdir: {$dir}");
+        }
+        file_put_contents($absPath, $contents);
+        $this->git(['add', $relPath]);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): void
+    {
+        $process = new Process(['git', ...$args], $this->tmpDir, [
+            'GIT_CONFIG_GLOBAL' => '/dev/null',
+            'GIT_CONFIG_SYSTEM' => '/dev/null',
+            'GIT_AUTHOR_NAME' => 'Test',
+            'GIT_AUTHOR_EMAIL' => 'test@example.test',
+            'GIT_COMMITTER_NAME' => 'Test',
+            'GIT_COMMITTER_EMAIL' => 'test@example.test',
+        ]);
+        $process->mustRun();
+    }
+
+    private function removeRecursive(string $path): void
+    {
+        if (!is_dir($path)) {
+            if (is_file($path) || is_link($path)) {
+                unlink($path);
+            }
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entryPath = $entry->getPathname();
+            if ($entry->isDir() && !$entry->isLink()) {
+                rmdir($entryPath);
+            } else {
+                unlink($entryPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/bad-docs-binaries.json
+++ b/tools/release/tests/fixtures/dispatch/bad-docs-binaries.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-docs-binaries",
+    "repo": "openemr/website-openemr",
+    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T13:00:00Z",
+    "data": {
+        "version": "8.1.0",
+        "branch": "rel-810",
+        "files": []
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/bad-rel-cut.json
+++ b/tools/release/tests/fixtures/dispatch/bad-rel-cut.json
@@ -1,0 +1,11 @@
+{
+    "event": "openemr-rel-cut",
+    "repo": "openemr/openemr",
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:00:00Z",
+    "data": {
+        "branch": "rel-810",
+        "version": "8.1.0"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/bad-rel-update.json
+++ b/tools/release/tests/fixtures/dispatch/bad-rel-update.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-rel-update",
+    "repo": "openemr/openemr",
+    "sha": "not-a-valid-sha",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:15:30Z",
+    "data": {
+        "branch": "rel-810",
+        "version": "8.1.0",
+        "prev_release": "8.0.0"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/bad-tag.json
+++ b/tools/release/tests/fixtures/dispatch/bad-tag.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-tag",
+    "repo": "openemr/openemr",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:30:00Z",
+    "data": {
+        "tag": "v8.1.0",
+        "branch": "rel-810",
+        "version": "8.1.0"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/good-docs-binaries.json
+++ b/tools/release/tests/fixtures/dispatch/good-docs-binaries.json
@@ -1,0 +1,15 @@
+{
+    "event": "openemr-docs-binaries",
+    "repo": "openemr/website-openemr",
+    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T13:00:00Z",
+    "data": {
+        "version": "8.1.0",
+        "branch": "rel-810",
+        "files": [
+            "openemr-8.1.0-ehi.tar.gz",
+            "openemr-8.1.0-b10.tar.gz"
+        ]
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/good-rel-cut.json
+++ b/tools/release/tests/fixtures/dispatch/good-rel-cut.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-rel-cut",
+    "repo": "openemr/openemr",
+    "sha": "0123456789abcdef0123456789abcdef01234567",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:00:00Z",
+    "data": {
+        "branch": "rel-810",
+        "version": "8.1.0",
+        "prev_release": "8.0.0"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/good-rel-update.json
+++ b/tools/release/tests/fixtures/dispatch/good-rel-update.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-rel-update",
+    "repo": "openemr/openemr",
+    "sha": "fedcba9876543210fedcba9876543210fedcba98",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:15:30Z",
+    "data": {
+        "branch": "rel-810",
+        "version": "8.1.0",
+        "prev_release": "8.0.0"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/good-tag.json
+++ b/tools/release/tests/fixtures/dispatch/good-tag.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-tag",
+    "repo": "openemr/openemr",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:30:00Z",
+    "data": {
+        "tag": "v8_1_0",
+        "branch": "rel-810",
+        "version": "8.1.0"
+    }
+}

--- a/tools/release/versions.yml
+++ b/tools/release/versions.yml
@@ -1,0 +1,252 @@
+# Release-tooling registry of OpenEMR version pins in this repo.
+#
+# Drives:
+#   - tools/release/bin/rotate.php (slot rotation)
+#   - tools/release/bin/lint-versions.php (drift detection)
+#
+# Rotation model (openemr/openemr-devops#664):
+#   current = most recent tagged release (Docker tag :latest)
+#   next    = upcoming release / active rel-* branch (Docker tag :next)
+#   dev     = head of master (Docker tag :dev)
+#
+# This file is the source of truth. Editing slot assignments below + running
+# `task release:rotate` rewrites every pin listed in `files`.
+#
+# DRAFT: built by manual sweep on 2026-04-29. Several files were excluded with
+# explicit reasons; ambiguous cases are reported in PR #665.
+
+version: 1
+
+slots:
+  current:
+    minor: "8.0"
+    full: "8.0.0"
+    patch: "8.0.0.3"
+    branch: "rel-800"
+    docker_dir: "8.0.0"
+  next:
+    minor: "8.1"
+    full: "8.1.0"
+    branch: "rel-810"
+    docker_dir: "8.1.0"
+  dev:
+    minor: "8.1"
+    full: "8.1.1"
+    branch: "master"
+    docker_dir: "8.1.1"
+
+# Files containing rotating OpenEMR version pins. The rotator dispatches on
+# `kind` per pin to decide the rewrite strategy; the linter uses these entries
+# to verify no version-looking string lives in a non-listed location.
+#
+# `kind` taxonomy:
+#   build_workflow             — .github/workflows/build-*.yml docker build job
+#   docker_arg_branch          — Dockerfile `ARG OPENEMR_VERSION=<rel-branch>`
+#   docker_clone_branch        — Dockerfile `git clone … --branch <rel-branch>`
+#   docker_image_tag           — markdown/yaml `openemr/openemr:<tag>` reference
+#   bats_test_paths            — workflow path filter `docker/openemr/<dir>/**`
+#   container_func_test_paths  — workflow path filter + script arg
+#   benchmarking_default       — utilities/container_benchmarking default variant
+#   overview_table             — docker/openemr/OVERVIEW.md mapping table
+files:
+  - path: .github/workflows/build-800.yml
+    slot: current
+    kinds: [build_workflow]
+
+  - path: .github/workflows/build-810.yml
+    slot: next
+    kinds: [build_workflow]
+
+  - path: .github/workflows/build-811.yml
+    slot: dev
+    kinds: [build_workflow]
+
+  - path: docker/openemr/8.0.0/Dockerfile
+    slot: current
+    kinds: [docker_clone_branch]
+
+  - path: docker/openemr/8.1.0/Dockerfile
+    slot: next
+    kinds: [docker_arg_branch]
+
+  - path: docker/openemr/8.1.1/Dockerfile
+    slot: dev
+    kinds: [docker_arg_branch]
+
+  - path: docker/openemr/8.0.0/README.md
+    slot: current
+    kinds: [docker_image_tag]
+    # FIXME: line 33 currently reads `image: openemr/openemr:7.0.5` — a stale
+    # copy-paste from before 8.0.0 was tagged. Rotator should overwrite to
+    # match slot.full on next run; flagged in PR #665 for human confirmation.
+
+  - path: docker/openemr/8.1.0/README.md
+    slot: next
+    kinds: [docker_image_tag]
+
+  - path: docker/openemr/8.1.1/README.md
+    slot: dev
+    kinds: [docker_image_tag]
+
+  - path: .github/workflows/test-bats.yml
+    slot: next
+    kinds: [bats_test_paths]
+
+  - path: .github/workflows/test-container-functionality.yml
+    slot: next
+    kinds: [container_func_test_paths]
+
+  - path: utilities/container_benchmarking/docker-compose.yml
+    slot: next
+    kinds: [benchmarking_default]
+
+  - path: utilities/container_benchmarking/benchmark.sh
+    slot: next
+    kinds: [benchmarking_default]
+
+  - path: utilities/container_benchmarking/test_functionality.sh
+    slot: next
+    kinds: [benchmarking_default]
+
+  - path: utilities/container_benchmarking/test_suite.sh
+    slot: next
+    kinds: [benchmarking_default]
+
+  # Touched by every rotation — the canonical Docker tag mapping table.
+  - path: docker/openemr/OVERVIEW.md
+    slot: all
+    kinds: [overview_table]
+
+  # Dependabot enumerates each rotating Docker dir explicitly; rotation needs
+  # to add/remove entries when slot dirs change.
+  - path: .github/dependabot.yml
+    slot: all
+    kinds: [dependabot_directory]
+
+  # In-container init scripts; reference their own dir as shellcheck source
+  # comments, so they rotate with the slot's docker_dir. Only the 8.0.0/*.sh
+  # files currently have these refs; the next/dev variants have no path
+  # comments and will be picked up by the linter only if added later.
+  - path: docker/openemr/8.0.0/openemr.sh
+    slot: current
+    kinds: [shellcheck_source]
+  - path: docker/openemr/8.0.0/ssl.sh
+    slot: current
+    kinds: [shellcheck_source]
+
+  # Container-benchmarking docs reference the next-slot version as defaults.
+  - path: utilities/container_benchmarking/README.md
+    slot: next
+    kinds: [docker_image_tag]
+
+# Files the linter would otherwise flag as containing OpenEMR version pins, but
+# which intentionally don't participate in 3-slot rotation. Each entry needs a
+# reason — that's the cost of bypassing the lint.
+excludes:
+  # Legacy 7.0.4 support track — rotated by hand, not by slot system.
+  - path: .github/workflows/build-704.yml
+    reason: "legacy 7.0.4 support track; manual rotation only"
+  - path: docker/openemr/7.0.4
+    reason: "legacy 7.0.4 support track (entire dir)"
+
+  # Frozen historical builds.
+  - path: docker/openemr/obsolete
+    reason: "frozen historical builds; never rotate"
+  - path: docker/obsolete
+    reason: "frozen historical builds; never rotate"
+  - path: kubernetes/obsolete
+    reason: "frozen historical builds; never rotate"
+
+  # Binary track — own release cadence (currently 7_0_4 + dated build).
+  - path: docker/openemr/binary/Dockerfile
+    reason: "binary release track on independent cadence"
+  - path: docker/openemr/binary/README.md
+    reason: "binary release track on independent cadence"
+
+  # Flex (Alpine) track — separate axis from OpenEMR version slots.
+  - path: .github/workflows/build-322.yml
+    reason: "Alpine flex track (3.22), not OpenEMR rotation"
+  - path: .github/workflows/build-323.yml
+    reason: "Alpine flex track (3.23, currently :flex), not OpenEMR rotation"
+  - path: .github/workflows/build-edge.yml
+    reason: "Alpine flex-edge track, not OpenEMR rotation"
+  - path: .github/workflows/build-flex-core.yml
+    reason: "reusable flex build, no fixed pin"
+  - path: .github/workflows/test-flex-322.yml
+    reason: "Alpine flex test"
+  - path: .github/workflows/test-flex-323.yml
+    reason: "Alpine flex test"
+  - path: .github/workflows/test-flex-edge.yml
+    reason: "Alpine flex-edge test"
+  - path: docker/openemr/flex/Dockerfile
+    reason: "flex variant fetches OpenEMR at runtime; no build-time pin"
+  - path: docker/openemr/flex/README.md
+    reason: "flex variant; tag references are doc-only"
+
+  # Workflows with no fixed pin (parameterized or version-agnostic).
+  - path: .github/workflows/build-patch.yml
+    reason: "version comes from workflow_dispatch inputs"
+  - path: .github/workflows/build-release.yml
+    reason: "version comes from workflow_dispatch inputs"
+  - path: .github/workflows/test-core.yml
+    reason: "reusable workflow; callers supply version"
+  - path: .github/workflows/test-production.yml
+    reason: "pins production_coverage_openemr_version='7.0.5' (release not yet built); see PR #665"
+
+  # AWS deployment packages — independent release cadence; lag the Docker
+  # slots and currently span three different OpenEMR versions across the four
+  # packages. Maintainer decision pending on whether to fold into the 3-slot
+  # system. See PR #665 "Ambiguous registry entries".
+  - path: packages/appliance/docker-compose.yml
+    reason: "appliance package (currently 7.0.4) — independent cadence; pending decision"
+  - path: packages/standard/cfn/stack.py
+    reason: "standard CFN (currently 7.0.3) — independent cadence; pending decision"
+  - path: packages/standard/cfn/OpenEMR-Standard.json
+    reason: "generated from standard/cfn/stack.py"
+  - path: packages/standard/cfn/OpenEMR-Standard-Recovery.json
+    reason: "generated from standard/cfn/stack.py"
+  - path: packages/standard/ami/ami-build.sh
+    reason: "AMI build (currently 7.0.3) — tracks standard/cfn/stack.py"
+  - path: packages/express_plus/stack.py
+    reason: "express_plus CFN — independent cadence; pending decision"
+  - path: packages/express_plus/OpenEMR-Express-Plus.json
+    reason: "generated from express_plus/stack.py"
+  - path: packages/express_plus/OpenEMR-Express-Plus-Recovery.json
+    reason: "generated from express_plus/stack.py"
+  - path: packages/express/README.md
+    reason: "doc-only OpenEMR version reference (currently 7.0.4)"
+  - path: packages/lightsail/launch.sh
+    reason: "stub redirecting to appliance; no OpenEMR pin"
+
+  # K8s manifest currently lags the Docker rotation; needs a one-shot
+  # alignment commit before joining the rotation registry.
+  - path: kubernetes/openemr/deployment.yaml
+    reason: "pinned to 7.0.3; needs reconciliation before joining rotation"
+  - path: kubernetes/README.md
+    reason: "doc-only image-tag examples; not a deployment pin"
+
+  # Documentation that mentions versions in prose only.
+  - path: docker/openemr/COVERAGE.md
+    reason: "prose mention of 7.0.4 as 'future production' — stale doc, not a pin"
+  - path: raspberrypi/README.md
+    reason: "documentation; references master branch only"
+
+  # Upgrade machinery — version-looking strings are step indices and
+  # historical SQL-upgrade hints, not active pins.
+  - path: docker/openemr/8.0.0/upgrade
+    reason: "upgrade scripts: docker-version is a step index; fsupgrade-N.sh refs are historical"
+  - path: docker/openemr/8.1.0/upgrade
+    reason: "upgrade scripts: docker-version is a step index; fsupgrade-N.sh refs are historical"
+  - path: docker/openemr/8.1.1/upgrade
+    reason: "upgrade scripts: docker-version is a step index; fsupgrade-N.sh refs are historical"
+  - path: docker/openemr/7.0.4/upgrade
+    reason: "upgrade scripts: docker-version is a step index; fsupgrade-N.sh refs are historical"
+
+  # Demo SQL fixture — filename matches version regex but isn't a pin.
+  - path: docker/openemr/8.0.0/demo_5_0_0_5.sql
+    reason: "demo SQL fixture; filename matches regex but isn't an OpenEMR pin"
+
+  # Release tooling itself — versions appear in tests and documentation but
+  # are not subject to rotation.
+  - path: tools/release
+    reason: "release tooling; versions in tests and contracts, not pins"


### PR DESCRIPTION
## Summary

Implements the openemr-devops slice of the three-repo release-automation flow described in #664. Sibling draft PRs in openemr/openemr (conductor) and openemr/website-openemr (docs) cover the conductor and docs slices.

## What lands in this PR

Under `tools/release/`:

- `contracts/dispatch.schema.json` — canonical JSON Schema for the four cross-repo `repository_dispatch` payloads (`openemr-rel-cut`, `openemr-rel-update`, `openemr-tag`, `openemr-docs-binaries`). PHPUnit tests cover good + bad fixtures per event.
- `src/TagVerifier.php` + `bin/verify-tag.php` — verify a release tag is annotated and its message contains version, ISO date, and merge SHA per the #664 spec.
- `versions.yml` — manual sweep classifying every OpenEMR version pin as `current` / `next` / `dev` / excluded. Active slots: current=8.0.0/rel-800, next=8.1.0/rel-810, dev=8.1.1/master.
- `src/SlotRotator.php` + `bin/rotate.php` — reads `versions.yml`, rewrites every pin owned by changed slots, updates the registry in place. Idempotent by design (the load-bearing test runs the rotation twice and asserts no diff).
- `src/VersionsRegistryLinter.php` + `bin/lint-versions.php` — fails if any tracked file contains an OpenEMR version pin not enumerated in `versions.yml`.
- `src/VendoredFileChecker.php` + `bin/check-vendored.php` — sha256 drift check for the small set of contracts (`dispatch.schema.json`, `TagVerifier.php`, `TagVerificationResult.php`) that consumer repos vendor.
- `src/RotationPrPublisher.php` + `bin/open-rotation-pr.php` — open or update the long-lived rotation draft PR.
- `src/SlotAssignmentParser.php` + `bin/derive-slots-from-dispatch.php` — translate CLI shorthand and `repository_dispatch` envelopes into slot assignments.
- `Taskfile.yml` — `release:rotate`, `release:lint-versions`, `release:verify-tag`, `release:check-vendored`, plus the App-token probe tasks invoked by the permissions-check workflow.

Under `.github/workflows/`:

- `release-permissions-check.yml` — manual `workflow_dispatch` that mints the App token and probes installation membership, `metadata:read`, `contents:write`, `pull-requests:write` (each fails loudly with the missing scope name).
- `release-rotation.yml` — `repository_dispatch` (3 types) + `workflow_dispatch`. Derives slot args from `data.version`, runs `task release:rotate`, force-pushes diffs to `release-rotation/auto`, opens/updates the long-lived draft PR.

Quality gates: every PHP file passes `php -l`, PHPStan level 10 + strict-rules, PHPCS PSR-12, Rector dry-run, and `composer test` (50 tests, 115 assertions). Both new workflows pass `actionlint`. Tooling pinned to PHP 8.5 per OCE conventions for internal tooling. Runners pinned to `ubuntu-24.04`.

## What remains before this can fire end-to-end

- Conductor side (openemr/openemr) needs to emit `repository_dispatch` events conforming to `dispatch.schema.json`. Until then `release-rotation.yml` is exercisable only via `workflow_dispatch`.
- Maintainer runs `release-permissions-check.yml` once via `workflow_dispatch` after merge to confirm the App's installed permissions match what rotation needs.
- Workflow consolidation (`build-810.yml` → `build-current.yml`, etc.) per #638 is intentionally out of scope here — the rotator + registry must work against the current matrix first.

## Ambiguous registry entries (excluded with `reason:`, flagged for maintainer decision)

- `packages/appliance/docker-compose.yml` (currently 7.0.4), `packages/standard/cfn/stack.py` + generated CFN JSON (currently 7.0.3), `packages/express_plus/stack.py` + generated CFN JSON, `packages/express/README.md`, `packages/lightsail/launch.sh` — AWS deployment packages on independent cadence, currently spanning three different OpenEMR versions across the four packages. Fold into the 3-slot system, or keep on independent manual rotation?
- `kubernetes/openemr/deployment.yaml` — pinned to 7.0.3; needs a one-shot alignment commit before joining the rotation registry.
- `.github/workflows/test-production.yml` — pins `production_coverage_openemr_version='7.0.5'`, a release that hasn't been built yet (current is 8.0.0). Should this rotate with `current` once 7.0.5 is built, or stay independent?
- `docker/openemr/8.0.0/README.md` line 33 currently reads `image: openemr/openemr:7.0.5`, an apparent stale copy-paste from before 8.0.0 was tagged. The rotator will overwrite this on the next run; flagging for human confirmation that this is the intent.

## Test plan

- [ ] Maintainer runs `release-permissions-check` workflow via `workflow_dispatch` once merged; confirm green.
- [ ] Maintainer runs `release-rotation` via `workflow_dispatch` with synthetic inputs (e.g. `current=8.1 next=8.2 dev=edge`); confirm draft PR appears at `release-rotation/auto` with the expected diff.
- [ ] Re-run the same `workflow_dispatch` payload; confirm the resulting PR is byte-identical (idempotence).
- [ ] Resolve the ambiguous registry entries above before the first real conductor-driven dispatch.

Closes #664.
