### PR TITLE
fix(flex): use sql_upgrade.php CLI mode in upgradeOpenEMR

### DIFF
--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -207,26 +207,14 @@ demoData() {
 # ============================================================================
 
 # Upgrades OpenEMR database from a specified version to the current version.
-# This function runs OpenEMR's sql_upgrade.php script programmatically
-# by modifying it to run non-interactively.
+# Invokes sql_upgrade.php in CLI mode (added in openemr/openemr#11906).
 #
 # Parameters:
 #   $1: Original OpenEMR version (e.g., "5.0.0", "6.0.0")
 #
-# Process:
-#   1. Creates a temporary version of sql_upgrade.php
-#   2. Modifies it to run non-interactively (auto-submit form)
-#   3. Sets the source version
-#   4. Executes the upgrade script
-#   5. Cleans up temporary file
-#
 # Must call prepareVariables() before calling this function.
 upgradeOpenEMR() {
-    sed -e "s@!empty(\$_POST\['form_submit'\])@true@" < /var/www/localhost/htdocs/openemr/sql_upgrade.php > /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-    sed -i "s@\$form_old_version = \$_POST\['form_old_version'\];@\$form_old_version = '${1}';@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-    sed -i "1s@^@<?php \$_GET['site'] = 'default'; ?>@" /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-    php -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
-    rm -f /var/www/localhost/htdocs/openemr/sql_upgrade_temp.php
+    php -f /var/www/localhost/htdocs/openemr/sql_upgrade.php -- --from="${1}"
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

After openemr/openemr#11906 added native CLI support to `sql_upgrade.php`, the sed-based version-injection in `upgradeOpenEMR()` silently became a no-op, causing `dev-reset-install-demodata` (a.k.a. `openemr-cmd drid`) to leave the database at v5.0.0 with only the earliest upgrade scripts partially applied.

## Mechanism

1. `demoData()` calls `upgradeOpenEMR 5.0.0`.
2. The function tries to inject the version with `sed`, looking for `$form_old_version = $_POST['form_old_version'];`.
3. That pattern no longer exists in `sql_upgrade.php`. After openemr/openemr#11906, the assignment is `$form_old_version = $cliFromVersion ?? ($_POST['form_old_version'] ?? '')`.
4. The sed becomes a silent no-op. `$form_old_version` resolves to `''`.
5. The loop guard `strcmp(\$version, '') < 0` is false for every upgrade file, so `sql_upgrade.php` starts processing from `2_6_0-to-2_6_1_upgrade.sql` instead of from 5.0.0.
6. `2_6_0-to-2_6_1_upgrade.sql:40` has an unguarded `INSERT INTO categories_seq VALUES (0)` — adding a second row alongside the demo dump's `(26)`.
7. Later, `5_0_0-to-5_0_1_upgrade.sql:407` runs `UPDATE categories_seq SET id = (SELECT MAX(id) FROM categories)` without a `WHERE`. With two rows being set to the same id, the second hits a `Duplicate entry` PRIMARY KEY violation and the upgrade aborts.
8. Database is left at v5.0.0 / v_database=206, with all post-5.0.0 schema changes missing.

## User-visible symptoms after `openemr-cmd drid`

- Login page renders without theme styling.
- Patient dashboard fails with `SQL Statement failed on preparation: ... lists_medication ... reporting_source_record_id ...`.
- `UUID_Service` and `Email_Service` background services error.

## Fix

Use the supported `--from=VERSION` CLI argument added in openemr/openemr#11906. The loop guard at `sql_upgrade.php:379` is `!empty(\$_POST['form_submit']) || \$cliFromVersion !== null`, so passing `--from=` also satisfies the entry condition — no need to mutate the script source.

## Scope

Only `docker/openemr/flex/utilities/devtoolsLibrary.source` is touched. The 8.0.0 / 8.1.0 / 8.1.1 image variants ship paired with their corresponding openemr release, where the older sed pattern still matches; they are out of scope here.

## Test plan

- [x] `bash -n` on the patched file passes
- [x] Replaced the in-container `/root/devtoolsLibrary.source` via `docker cp` and re-ran `openemr-cmd drid`
- [x] Verified post-drid state: `version` = 8.1.1-dev / v_database=538 / v_acl=13, `lists_medication.reporting_source_record_id` present, `categories_seq` contains the expected single row
- [ ] Reviewer to spot-check on a non-arm64 host if convenient