### PR TITLE
fix(release): align vendored-file checker with #664 spec

### DIFF
--- a/tools/release/phpcs.xml
+++ b/tools/release/phpcs.xml
@@ -10,7 +10,7 @@
     <file>bin</file>
     <file>tests</file>
 
-    <exclude-pattern>vendor</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 
     <rule ref="PSR12"/>
 

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -10,9 +10,16 @@
  * therefore has `vendored/openemr-devops/contracts/dispatch.schema.json` and
  * `vendored/openemr-devops/src/TagVerifier.php`.
  *
- * Equivalence is byte-for-byte (sha256). The vendored set is intentionally
- * small — it covers only what consumers need to validate dispatch payloads
- * and verify release tags without depending on this repo's autoloader.
+ * Equivalence is per-file-type, per the openemr-devops#664 spec:
+ *
+ *   - JSON: parse + canonical re-serialize (recursively sort object keys,
+ *     preserve list order, normalize whitespace), then string-compare.
+ *     A consumer can reformat or reorder object keys without tripping drift.
+ *   - PHP: strip the `namespace` declaration line, then string-compare.
+ *     A consumer can vendor under its own namespace (e.g.
+ *     `OpenEMR\ReleaseDocs\Release`) so long as everything else — class
+ *     structure, method signatures, behavior — is identical.
+ *   - Other: byte-for-byte sha256. Default for any file type added later.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -69,7 +76,7 @@ final readonly class VendoredFileChecker
                 );
                 continue;
             }
-            if (hash_file('sha256', $canonicalAbs) !== hash_file('sha256', $consumerAbs)) {
+            if (!$this->equivalent($rel, $canonicalAbs, $consumerAbs)) {
                 $issues[] = new VendoredDriftIssue(
                     $rel,
                     'drift',
@@ -78,5 +85,67 @@ final readonly class VendoredFileChecker
             }
         }
         return $issues;
+    }
+
+    private function equivalent(string $relativePath, string $canonicalAbs, string $consumerAbs): bool
+    {
+        $extension = pathinfo($relativePath, PATHINFO_EXTENSION);
+        return match ($extension) {
+            'json' => $this->canonicalJson($canonicalAbs) === $this->canonicalJson($consumerAbs),
+            'php' => $this->stripNamespace($this->readFile($canonicalAbs))
+                === $this->stripNamespace($this->readFile($consumerAbs)),
+            default => hash_file('sha256', $canonicalAbs) === hash_file('sha256', $consumerAbs),
+        };
+    }
+
+    private function canonicalJson(string $path): string
+    {
+        $decoded = json_decode($this->readFile($path), true, flags: JSON_THROW_ON_ERROR);
+        $this->sortObjectKeys($decoded);
+        return json_encode(
+            $decoded,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+        );
+    }
+
+    /**
+     * Recursively sort object (associative array) keys to make JSON
+     * comparison insensitive to key order. List order stays intact —
+     * arrays in JSON Schema (`enum`, `oneOf`, `required`) carry semantic
+     * meaning that reordering would silently change.
+     */
+    private function sortObjectKeys(mixed &$value): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+        if (!array_is_list($value)) {
+            ksort($value);
+        }
+        foreach ($value as &$child) {
+            $this->sortObjectKeys($child);
+        }
+    }
+
+    /**
+     * Strip the single `namespace …;` declaration line from a PHP source
+     * string. Removes the line itself but leaves surrounding whitespace
+     * intact — both canonical and consumer files have the same
+     * surrounding whitespace, so byte-comparing the post-strip strings
+     * is sufficient.
+     */
+    private function stripNamespace(string $contents): string
+    {
+        $stripped = preg_replace('/^namespace\s+[\w\\\\]+;\s*$/m', '', $contents);
+        return $stripped ?? $contents;
+    }
+
+    private function readFile(string $path): string
+    {
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            throw new \RuntimeException('Cannot read ' . $path);
+        }
+        return $contents;
     }
 }

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -100,7 +100,12 @@ final readonly class VendoredFileChecker
 
     private function canonicalJson(string $path): string
     {
-        $decoded = json_decode($this->readFile($path), true, flags: JSON_THROW_ON_ERROR);
+        $contents = $this->readFile($path);
+        try {
+            $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException('Invalid JSON in ' . $path . ': ' . $e->getMessage(), 0, $e);
+        }
         $this->sortObjectKeys($decoded);
         return json_encode(
             $decoded,

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -18,6 +18,34 @@ use PHPUnit\Framework\TestCase;
 
 final class VendoredFileCheckerTest extends TestCase
 {
+    private const CANONICAL_JSON = <<<'JSON'
+        {
+            "$schema": "https://example.test/schema",
+            "title": "test schema",
+            "required": ["event", "data"],
+            "properties": {
+                "event": { "type": "string" },
+                "data": { "type": "object" }
+            }
+        }
+        JSON;
+
+    private const CANONICAL_PHP_TEMPLATE = <<<'PHP'
+        <?php
+
+        declare(strict_types=1);
+
+        namespace %s;
+
+        final class TagVerifier
+        {
+            public function verify(string $tag): bool
+            {
+                return $tag !== '';
+            }
+        }
+        PHP;
+
     private string $canonicalRoot = '';
     private string $consumerDir = '';
 
@@ -28,9 +56,7 @@ final class VendoredFileCheckerTest extends TestCase
         if (!mkdir($this->canonicalRoot, 0700, true) || !mkdir($this->consumerDir, 0700, true)) {
             throw new \RuntimeException('Failed to create tmp dirs');
         }
-        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
-            $this->writeFile($this->canonicalRoot, $rel, "canonical:{$rel}\n");
-        }
+        $this->writeCanonicalFixtures($this->canonicalRoot);
     }
 
     protected function tearDown(): void
@@ -41,25 +67,99 @@ final class VendoredFileCheckerTest extends TestCase
 
     public function testMatchingCopiesProduceNoIssues(): void
     {
-        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
-            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
-        }
+        $this->writeCanonicalFixtures($this->consumerDir);
 
         $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
 
         self::assertSame([], $issues);
     }
 
-    public function testDriftedCopyIsFlagged(): void
+    public function testJsonReorderedKeysAreEquivalent(): void
     {
-        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
-            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
-        }
-        $this->writeFile($this->consumerDir, 'src/TagVerifier.php', "stale-content\n");
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $reordered = json_encode(
+            [
+                'properties' => [
+                    'data' => ['type' => 'object'],
+                    'event' => ['type' => 'string'],
+                ],
+                'required' => ['event', 'data'],
+                'title' => 'test schema',
+                '$schema' => 'https://example.test/schema',
+            ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $reordered);
 
         $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
 
-        self::assertCount(1, $issues);
+        self::assertSame([], $issues, 'JSON object key order must not affect equivalence');
+    }
+
+    public function testJsonReformattedWhitespaceIsEquivalent(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $minified = json_encode(
+            json_decode(self::CANONICAL_JSON, true, flags: JSON_THROW_ON_ERROR),
+            JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $minified);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues, 'JSON whitespace must not affect equivalence');
+    }
+
+    public function testJsonListReorderingIsFlagged(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $reorderedList = json_encode(
+            [
+                '$schema' => 'https://example.test/schema',
+                'title' => 'test schema',
+                'required' => ['data', 'event'],
+                'properties' => [
+                    'event' => ['type' => 'string'],
+                    'data' => ['type' => 'object'],
+                ],
+            ],
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+        );
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', $reorderedList);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues, 'JSON list element order is semantic and must trip drift');
+        self::assertSame('contracts/dispatch.schema.json', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testPhpWithDifferentNamespaceIsEquivalent(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        file_put_contents(
+            $this->consumerDir . '/src/TagVerifier.php',
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\ReleaseDocs\\Release'),
+        );
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertSame([], $issues, 'Different vendored namespace must not trip drift');
+    }
+
+    public function testPhpDriftBeyondNamespaceIsFlagged(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $modified = str_replace(
+            "return \$tag !== '';",
+            "return true;",
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release'),
+        );
+        file_put_contents($this->consumerDir . '/src/TagVerifier.php', $modified);
+
+        $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+
+        self::assertCount(1, $issues, 'Behavior change must trip drift even with matching namespace');
         self::assertSame('src/TagVerifier.php', $issues[0]->relativePath);
         self::assertSame('drift', $issues[0]->kind);
     }
@@ -68,9 +168,7 @@ final class VendoredFileCheckerTest extends TestCase
     {
         $copy = VendoredFileChecker::VENDORED_PATHS;
         array_pop($copy);
-        foreach ($copy as $rel) {
-            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
-        }
+        $this->writeCanonicalFixtures($this->consumerDir, $copy);
 
         $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
 
@@ -81,9 +179,7 @@ final class VendoredFileCheckerTest extends TestCase
     public function testMissingCanonicalIsFlagged(): void
     {
         unlink($this->canonicalRoot . '/contracts/dispatch.schema.json');
-        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
-            $this->writeFile($this->consumerDir, $rel, "canonical:{$rel}\n");
-        }
+        $this->writeCanonicalFixtures($this->consumerDir);
 
         $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
 
@@ -94,7 +190,11 @@ final class VendoredFileCheckerTest extends TestCase
 
     public function testMultipleDriftKindsReportedTogether(): void
     {
-        $this->writeFile($this->consumerDir, 'contracts/dispatch.schema.json', "stale\n");
+        $this->writeFile(
+            $this->consumerDir,
+            'contracts/dispatch.schema.json',
+            json_encode(['unrelated' => 'value'], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR),
+        );
 
         $issues = (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
 
@@ -109,6 +209,27 @@ final class VendoredFileCheckerTest extends TestCase
         self::assertContains('contracts/dispatch.schema.json', VendoredFileChecker::VENDORED_PATHS);
         self::assertContains('src/TagVerifier.php', VendoredFileChecker::VENDORED_PATHS);
         self::assertContains('src/TagVerificationResult.php', VendoredFileChecker::VENDORED_PATHS);
+    }
+
+    /**
+     * @param list<string>|null $only restrict which paths to write
+     */
+    private function writeCanonicalFixtures(string $root, ?array $only = null): void
+    {
+        $paths = $only ?? VendoredFileChecker::VENDORED_PATHS;
+        foreach ($paths as $rel) {
+            $this->writeFile($root, $rel, $this->canonicalContents($rel));
+        }
+    }
+
+    private function canonicalContents(string $relativePath): string
+    {
+        $extension = pathinfo($relativePath, PATHINFO_EXTENSION);
+        return match ($extension) {
+            'json' => self::CANONICAL_JSON,
+            'php' => sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release'),
+            default => "canonical:{$relativePath}\n",
+        };
     }
 
     private function writeFile(string $root, string $rel, string $contents): void

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -164,6 +164,17 @@ final class VendoredFileCheckerTest extends TestCase
         self::assertSame('drift', $issues[0]->kind);
     }
 
+    public function testInvalidJsonRaisesWithPathContext(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        file_put_contents($this->consumerDir . '/contracts/dispatch.schema.json', '{not json');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('contracts/dispatch.schema.json');
+
+        (new VendoredFileChecker($this->canonicalRoot, $this->consumerDir))->check();
+    }
+
     public function testMissingConsumerCopyIsFlagged(): void
     {
         $copy = VendoredFileChecker::VENDORED_PATHS;


### PR DESCRIPTION
## Summary

The vendored-file checker shipped in #665 compared all vendored copies byte-for-byte via sha256, which forced consumer repos (openemr/openemr, openemr/website-openemr) to use the canonical namespace verbatim and rejected any whitespace or key-order normalization in the vendored JSON schema. Issue #664's "Cross-repo contracts" section specifies the opposite — JSON parses + canonical re-serializes, PHP strips the namespace line, then strings compare. This PR aligns the implementation with that spec.

## Changes

`tools/release/src/VendoredFileChecker.php` dispatches comparison on file extension:

- **JSON** — parse, recursively sort object keys (preserving list order, since `enum` / `oneOf` / `required` carry semantic meaning), serialize with consistent flags, then string-compare. A consumer can reformat or reorder object keys without tripping drift.
- **PHP** — strip the single `namespace …;` line before comparison. Vendored copies under e.g. `OpenEMR\ReleaseDocs\Release` no longer trip drift; behavior changes still do.
- **Other** — byte-for-byte sha256. Default for anything added to `VENDORED_PATHS` later.

`tools/release/tests/VendoredFileCheckerTest.php` rewrites the fixture seeding to produce realistic JSON and PHP files, then covers:

- Canonical happy path (matching copies → no drift)
- JSON object-key reordering (no drift)
- JSON whitespace normalization, e.g. minified vs pretty (no drift)
- JSON list reordering (drift — list order is semantic)
- PHP with a different vendored namespace (no drift)
- PHP behavior change beyond namespace (drift)
- Existing missing/multiple-drift scenarios (preserved)

`tools/release/phpcs.xml` tightens `<exclude-pattern>vendor</exclude-pattern>` → `*/vendor/*`. The previous pattern was a substring match against absolute paths, so any worktree whose name contains `vendor` had every checked file silently excluded. Discovered while developing this PR — bundled because it's a one-liner.

## Test plan

- [x] `composer phpcs` — 34/34
- [x] `composer phpstan` — 34/34, level 10
- [x] `composer rector-check` — clean
- [x] `composer test` — 54 tests, 121 assertions
- [ ] CI green
- [ ] Consumer repos can vendor under their own namespace once they wire up `bin/check-vendored.php`

Refs #664.