### PR TITLE
ci: rebuild flex 3.23 image nightly

### DIFF
--- a/.github/workflows/build-323.yml
+++ b/.github/workflows/build-323.yml
@@ -17,6 +17,8 @@ name: Flex 3.23 Dockers Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Adds a `schedule` trigger to `.github/workflows/build-323.yml` so the default `openemr/openemr:flex` tag refreshes nightly at 2 AM UTC, matching the existing pattern in `build-edge.yml`, `build-810.yml`, and `build-811.yml`.

Without this, fixes that land on `master` (devops or upstream openemr) can sit in the unpublished `openemr/openemr:flex` image for weeks until someone manually dispatches the workflow. The motivating example: #666 merged on 2026-05-01, but the published `flex` digest is still the 2026-04-07 build, so `openemr-cmd dev-reset-install-demodata` continues to fail in fresh containers.

When a future Alpine version takes over `is_default_flex: true`, this trigger should move with it.

Closes #686

## Test plan

- [ ] Verify actionlint passes
- [ ] After merge, confirm a scheduled run kicks off the next 2 AM UTC and publishes a fresh `openemr/openemr:flex` digest