### PR TITLE
feat(openemr-cmd): add worktree start, stop, and exec subcommands

### DIFF
--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -541,7 +541,7 @@ cmd_worktree_list() {
     wt_require_cmd jq
     wt_init_state
 
-    local main_branch jq_output status compose_subdir slug ps_output
+    local main_branch jq_output status compose_subdir slug ps_running ps_all
     main_branch=$(git -C "${OPENEMR_ROOT}" symbolic-ref --short HEAD 2>/dev/null || echo "detached")
 
     printf "%-30s %-12s %-8s %-10s %s\n" "BRANCH" "ENV" "OFFSET" "STATUS" "DIRECTORY"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.27"
+VERSION="1.0.28"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -605,6 +605,56 @@ cmd_worktree_regen() {
     wt_info "Done."
 }
 
+# shellcheck disable=SC2004
+cmd_worktree_start() {
+    local branch=${1:-}
+    if [[ -z "${branch}" ]]; then wt_die "Usage: openemr-cmd worktree start <branch>"; fi
+    if ! [[ -f "${WT_STATE_FILE}" ]]; then wt_die "No worktrees found"; fi
+    wt_info "Starting stack for '${branch}'"
+    wt_compose_cmd "${branch}" start
+    local offset
+    offset=$(wt_state_get "${branch}" offset)
+    echo "OpenEMR running at http://localhost:$((8300 + ${offset}))"
+}
+
+cmd_worktree_stop() {
+    local branch=${1:-}
+    if [[ -z "${branch}" ]]; then wt_die "Usage: openemr-cmd worktree stop <branch>"; fi
+    if ! [[ -f "${WT_STATE_FILE}" ]]; then wt_die "No worktrees found"; fi
+    wt_info "Stopping stack for '${branch}'"
+    wt_compose_cmd "${branch}" stop
+}
+
+# Runs an openemr-cmd command against the openemr container of a worktree's
+# compose project. Resolves the container by compose project/service label,
+# then re-invokes this script with -d <container_id> <args...>.
+cmd_worktree_exec() {
+    local branch=${1:-}
+    if [[ -z "${branch}" ]]; then
+        wt_die "Usage: openemr-cmd worktree exec <branch> <openemr-cmd-command> [args...]"
+    fi
+    shift
+    if [[ $# -eq 0 ]]; then
+        wt_die "Usage: openemr-cmd worktree exec <branch> <openemr-cmd-command> [args...]"
+    fi
+    if ! [[ -f "${WT_STATE_FILE}" ]]; then wt_die "No worktrees found"; fi
+    local dir
+    dir=$(wt_state_get "${branch}" dir)
+    if [[ -z "${dir}" ]]; then wt_die "No worktree found for branch '${branch}'"; fi
+    wt_validate_dir "${dir}"
+
+    local slug container_id
+    slug=$(wt_slug "${branch}")
+    container_id=$(docker ps \
+        --filter "label=com.docker.compose.project=openemr-${slug}" \
+        --filter "label=com.docker.compose.service=openemr" \
+        --format "{{.ID}}" | head -n 1)
+    if [[ -z "${container_id}" ]]; then
+        wt_die "OpenEMR container is not running for worktree '${branch}'. Run 'openemr-cmd worktree up ${branch}' or 'openemr-cmd worktree start ${branch}' first."
+    fi
+    exec "$0" -d "${container_id}" "$@"
+}
+
 cmd_worktree() {
     local action=${1:-}
     case "${action}" in
@@ -612,16 +662,22 @@ cmd_worktree() {
         remove) cmd_worktree_remove "${@:2}" ;;
         up)     cmd_worktree_up     "${@:2}" ;;
         down)   cmd_worktree_down   "${@:2}" ;;
+        start)  cmd_worktree_start  "${@:2}" ;;
+        stop)   cmd_worktree_stop   "${@:2}" ;;
+        exec)   cmd_worktree_exec   "${@:2}" ;;
         list)   cmd_worktree_list            ;;
         regen)  cmd_worktree_regen  "${@:2}" ;;
         *)
-            echo "Usage: openemr-cmd worktree <add|remove|up|down|list|regen> [options]"
+            echo "Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen> [options]"
             echo ""
             echo "  add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]"
             echo "                            Create worktree (-b creates new branch, default env: easy)"
             echo "  remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)"
             echo "  up <branch>               Start Docker stack for worktree"
             echo "  down <branch> [--keep-volumes]  Stop Docker stack for worktree (volumes deleted by default)"
+            echo "  start <branch>            Start stopped containers for worktree (preserves data)"
+            echo "  stop <branch>             Stop running containers for worktree (preserves data)"
+            echo "  exec <branch> <cmd> [args...]   Run an openemr-cmd command against the worktree's openemr container"
             echo "  list                      List all worktrees and status"
             echo "  regen <branch>            Regenerate override/env files"
             echo "  wt                        Alias for worktree"
@@ -1017,6 +1073,9 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo "  worktree remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)"
     echo "  worktree up <branch>               Start Docker stack for a worktree"
     echo "  worktree down <branch> [--keep-volumes]  Stop Docker stack (volumes deleted by default)"
+    echo "  worktree start <branch>            Start stopped containers for worktree (preserves data)"
+    echo "  worktree stop <branch>             Stop running containers for worktree (preserves data)"
+    echo "  worktree exec <branch> <cmd> [args...]   Run an openemr-cmd command against the worktree's openemr container"
     echo "  worktree list                      List all worktrees and their running status"
     echo "  worktree regen <branch>            Regenerate override/env files for a worktree"
     echo "  wt                                 Alias for worktree"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -562,7 +562,7 @@ cmd_worktree_list() {
     check_docker_compose_install
     jq_output=$(jq -r 'to_entries[] | [.key, (.value.offset|tostring), .value.dir, .value.env] | @tsv' "${WT_STATE_FILE}")
     while IFS=$'\t' read -r branch offset dir env; do
-        status="stopped"
+        status="none"
         compose_subdir=$(wt_compose_subdir "${env}")
         slug=$(wt_slug "${branch}")
         local validate_result=0
@@ -574,14 +574,24 @@ cmd_worktree_list() {
         elif [[ "${validate_result}" -ne 0 ]]; then
             status="invalid"
         else
-            ps_output=$("${DOCKER_COMPOSE_CMD[@]}" \
+            ps_running=$("${DOCKER_COMPOSE_CMD[@]}" \
                 --env-file "${dir}/${compose_subdir}/.env" \
                 -p "openemr-${slug}" \
                 -f "${dir}/${compose_subdir}/docker-compose.yml" \
                 -f "${dir}/${compose_subdir}/docker-compose.override.yml" \
                 ps --services --filter "status=running" 2>/dev/null) || true
-            if echo "${ps_output}" | grep -q openemr; then
+            if echo "${ps_running}" | grep -q openemr; then
                 status="running"
+            else
+                ps_all=$("${DOCKER_COMPOSE_CMD[@]}" \
+                    --env-file "${dir}/${compose_subdir}/.env" \
+                    -p "openemr-${slug}" \
+                    -f "${dir}/${compose_subdir}/docker-compose.yml" \
+                    -f "${dir}/${compose_subdir}/docker-compose.override.yml" \
+                    ps -aq 2>/dev/null) || true
+                if [[ -n "${ps_all}" ]]; then
+                    status="stopped"
+                fi
             fi
         fi
         printf "%-30s %-12s %-8s %-10s %s\n" "${branch}" "${env}" "${offset}" "${status}" "${dir}"


### PR DESCRIPTION
## Summary
- Adds `worktree start <branch>` and `worktree stop <branch>` — thin wrappers around `docker compose start`/`stop` so a worktree's containers can be paused and resumed without recreating them or losing data.
- Adds `worktree exec <branch> <openemr-cmd-command> [args...]` — resolves the worktree's openemr container by compose project/service labels and re-invokes `openemr-cmd -d <container_id> ...`, so any standard openemr-cmd command (e.g. `drid`, `shell`, `pl`) can be targeted at a specific worktree without manually looking up the container.
- Bumps `VERSION` to `1.0.28` and updates both the `worktree` subcommand usage block and the top-level `-h` help.

## Test plan
- [ ] `openemr-cmd worktree` prints usage including the new `start|stop|exec` actions
- [ ] `openemr-cmd -h` lists the new worktree commands under `worktree-management`
- [ ] `openemr-cmd worktree up <branch>` then `worktree stop <branch>` → containers stopped, volumes intact
- [ ] `openemr-cmd worktree start <branch>` after a `stop` → containers come back without recreation
- [ ] `openemr-cmd worktree exec <branch> drid` runs the dev-reset-install-demodata flow against the correct worktree's openemr container
- [ ] `openemr-cmd worktree exec <branch> shell` opens a shell in the right worktree container
- [ ] `worktree exec` against a worktree whose openemr container is not running prints a clear error pointing at `worktree up` / `worktree start`
- [ ] Missing-branch / missing-arg invocations of `start`, `stop`, and `exec` print usage messages and exit non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)