### PR TITLE
fix(docker): set git safe.directory in DEVELOPER_TOOLS containers

### DIFF
--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -119,6 +119,26 @@ case "${PCOV_ON,,}" in
     *) PCOV_ON=false ;;
 esac
 
+# Disable git's CVE-2022-24765 ownership check for the bind-mounted
+# OpenEMR working tree. When the host UID does not match the container's
+# apache UID (common on macOS Docker Desktop, WSL2, GitHub Codespaces),
+# git refuses to operate without this. Without it, in-container git
+# tooling fails: npm postinstall hooks (husky, lint-staged), prek,
+# composer scripts that read commit metadata, and openemr-cmd commands
+# that shell out to git.
+#
+# Runs unconditionally on every container start, before any code path
+# that might invoke git. Scoped to DEVELOPER_TOOLS=yes only: production
+# images COPY the source rather than bind-mount it, so .git is owned by
+# the container's build user and the ownership check passes naturally.
+#
+# --replace-all (vs --add) so /etc/gitconfig stays stable across restarts;
+# specific path (vs '*') keeps the ownership check intact for any other
+# repos that might exist in the container.
+if [[ "${DEVELOPER_TOOLS}" = "yes" ]]; then
+    git config --system --replace-all safe.directory /var/www/localhost/htdocs/openemr
+fi
+
 auto_setup() {
     prepareVariables
 
@@ -648,15 +668,6 @@ if [[ "${NEED_COMPOSER_BUILD}" = "true" ]] || [[ "${NEED_NPM_BUILD}" = "true" ]]
 
         # install php dependencies
         if [[ "${DEVELOPER_TOOLS}" = "yes" ]]; then
-            # Disable git's CVE-2022-24765 ownership check inside the
-            # container. The bind-mounted repo is owned by the host user;
-            # when the host UID does not match the container's UID (common
-            # on macOS Docker Desktop, WSL2, and Codespaces), git refuses
-            # to operate without this. Set system-wide so both root (CLI
-            # shells) and apache (runtime processes, npm postinstall hooks
-            # like husky) see it. Idempotent; safe to re-run on every
-            # container start.
-            git config --system --add safe.directory '*'
             composer install
             # install support for the e2e testing
             apk update

--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -648,6 +648,15 @@ if [[ "${NEED_COMPOSER_BUILD}" = "true" ]] || [[ "${NEED_NPM_BUILD}" = "true" ]]
 
         # install php dependencies
         if [[ "${DEVELOPER_TOOLS}" = "yes" ]]; then
+            # Disable git's CVE-2022-24765 ownership check inside the
+            # container. The bind-mounted repo is owned by the host user;
+            # when the host UID does not match the container's UID (common
+            # on macOS Docker Desktop, WSL2, and Codespaces), git refuses
+            # to operate without this. Set system-wide so both root (CLI
+            # shells) and apache (runtime processes, npm postinstall hooks
+            # like husky) see it. Idempotent; safe to re-run on every
+            # container start.
+            git config --system --add safe.directory '*'
             composer install
             # install support for the e2e testing
             apk update


### PR DESCRIPTION
## Summary
- When the host UID differs from the container's apache UID 1000 (typical on macOS Docker Desktop, WSL2, GitHub Codespaces), git's CVE-2022-24765 ownership check refuses to operate on the bind-mounted repo. Any in-container git tooling breaks — npm husky postinstall, lint-staged, prek, composer scripts that read commit metadata.
- Set `safe.directory '*'` system-wide (`/etc/gitconfig`) so both root (CLI shells, `openemr-cmd exec`) and apache (runtime processes, npm postinstall hooks) see it without per-user configs.
- Gated on `DEVELOPER_TOOLS=yes` since this only matters for host-mounted dev repos. Idempotent; safe to re-run on every container start.

This is independent of the worktree `.git` bind-mount fix — it benefits primary-repo dev containers on non-Linux hosts too, regardless of whether worktrees are in use.

## Test plan
- [ ] Linux host with UID 1000: no behavior change (already worked)
- [ ] macOS Docker Desktop / WSL2 / Codespaces: `docker exec <openemr-container> git -C /var/www/localhost/htdocs/openemr status` succeeds where it previously errored with `fatal: detected dubious ownership`
- [ ] `/etc/gitconfig` inside the container contains a `safe.directory = *` line after first `composer install` runs
- [ ] `npm install` postinstall hooks (husky) succeed on non-Linux hosts
- [ ] Containers without `DEVELOPER_TOOLS=yes` are unaffected (the new line lives entirely inside that branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)