### PR TITLE
fix(release): widen dispatch branch + tag patterns for test mode

### DIFF
--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -74,14 +74,14 @@
             "pattern": "^\\d+\\.\\d+\\.\\d+$"
         },
         "branch": {
-            "description": "Release branch name. Per #664 spec: rel-<MAJOR><MINOR>0.",
+            "description": "Release branch name. Per #664 spec real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut.",
             "type": "string",
-            "pattern": "^rel-\\d+\\d0$"
+            "pattern": "^rel-[A-Za-z0-9]+$"
         },
         "tag": {
-            "description": "Release tag name. Per #664 spec: v<MAJOR>_<MINOR>_<PATCH>.",
+            "description": "Release tag name. Per #664 spec real releases use v<MAJOR>_<MINOR>_<PATCH>. Test runs append -test.<shortSha> (7 hex chars) so a test merge does not collide with a real release tag.",
             "type": "string",
-            "pattern": "^v\\d+_\\d+_\\d+$"
+            "pattern": "^v\\d+_\\d+_\\d+(-test\\.[0-9a-f]{7})?$"
         },
         "relCutData": {
             "type": "object",

--- a/tools/release/tests/Contracts/DispatchSchemaTest.php
+++ b/tools/release/tests/Contracts/DispatchSchemaTest.php
@@ -29,6 +29,7 @@ final class DispatchSchemaTest extends TestCase
         yield 'openemr-rel-cut'        => ['good-rel-cut.json'];
         yield 'openemr-rel-update'     => ['good-rel-update.json'];
         yield 'openemr-tag'            => ['good-tag.json'];
+        yield 'openemr-tag (test)'     => ['good-tag-test.json'];
         yield 'openemr-docs-binaries'  => ['good-docs-binaries.json'];
     }
 

--- a/tools/release/tests/fixtures/dispatch/good-tag-test.json
+++ b/tools/release/tests/fixtures/dispatch/good-tag-test.json
@@ -1,0 +1,12 @@
+{
+    "event": "openemr-tag",
+    "repo": "openemr/openemr",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:30:00Z",
+    "data": {
+        "tag": "v8_1_0-test.abcdef0",
+        "branch": "rel-test",
+        "version": "8.1.0"
+    }
+}


### PR DESCRIPTION
The conductor in openemr/openemr#12061 widened the dispatch payload `branch` pattern to `^rel-[A-Za-z0-9]+$` so a sandbox branch like `rel-test` can drive end-to-end testing without a real release-cut. openemr/openemr#12063 then widened the `tag` pattern to allow an optional `-test.{shortSha}` suffix that the conductor produces when a test-mode prep PR merges (e.g. `v8_1_2-test.419858f`).

Both widenings landed in the `openemr/openemr` vendored copy of `dispatch.schema.json` but never propagated to the canonical schema here, which is what `website-openemr` (and eventually `website-openemr-files`) re-vendor. Result: every `repository_dispatch` this session sent to `website-openemr`'s `release-docs` consumer failed schema validation on `/data/branch` and `/data/tag`.

Bringing the canonical schema in line; adds a `good-tag-test.json` fixture covering the new shape. The companion vendored-copy update lands in `openemr/website-openemr`.

Refs #664. Follow-up to openemr/openemr#12061 / openemr/openemr#12063.