### PR TITLE
feat(release): add ship-release workflow to merge three release PRs in order

### DIFF
--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -76,11 +76,10 @@ jobs:
           TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
           STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          task release:ship \
-              VERSION="${VERSION}" \
-              REL_BRANCH="${REL_BRANCH}" \
-              TIMEOUT_SECONDS="${TIMEOUT_SECONDS}" \
-              STATUS_TARGET_URL="${STATUS_TARGET_URL}" \
-              DRY_RUN="${DRY_RUN}"
+        run: >-
+          task release:ship
+          VERSION="${VERSION}"
+          REL_BRANCH="${REL_BRANCH}"
+          TIMEOUT_SECONDS="${TIMEOUT_SECONDS}"
+          STATUS_TARGET_URL="${STATUS_TARGET_URL}"
+          DRY_RUN="${DRY_RUN}"

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -1,0 +1,84 @@
+name: Ship Release
+
+# Manually-triggered orchestration for the three-PR release flow (#705):
+# merges infra → conductor → docs in strict order, skipping any already merged
+# (so the same trigger handles partial-merge recovery), and refusing to merge
+# anything if any unmerged PR is not ready. Mints one App token with PR-write
+# on all three repos and posts a release/ship-approved commit status on each
+# PR head before merging it (so branch protection can require it later).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 8.1.0) — picks website-openemr branch release-docs/<version>'
+        required: true
+        type: string
+      rel_branch:
+        description: 'Release branch (e.g. rel-810) — picks openemr/openemr branch release-prep/<rel_branch>'
+        required: true
+        type: string
+      dry_run:
+        description: 'Check readiness only — do not merge or post statuses'
+        required: false
+        type: boolean
+        default: false
+      timeout_seconds:
+        description: 'Max seconds to wait for docs PR to update after conductor merge'
+        required: false
+        type: string
+        default: '600'
+
+permissions: {}
+
+concurrency:
+  group: ship-release
+  cancel-in-progress: false
+
+jobs:
+  ship:
+    name: Merge release PRs in order
+    runs-on: ubuntu-24.04
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Mint release App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: openemr
+          repositories: |
+            openemr
+            openemr-devops
+            website-openemr
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      - name: Ship release
+        working-directory: tools/release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+          REL_BRANCH: ${{ inputs.rel_branch }}
+          TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          STATUS_TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          task release:ship \
+              VERSION="${VERSION}" \
+              REL_BRANCH="${REL_BRANCH}" \
+              TIMEOUT_SECONDS="${TIMEOUT_SECONDS}" \
+              STATUS_TARGET_URL="${STATUS_TARGET_URL}" \
+              DRY_RUN="${DRY_RUN}"

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -56,6 +56,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -60,10 +60,11 @@ The current shape is the cost of **PHPStan level 10 + strict tests + structured 
 ## Running checks locally
 
 ```sh
-composer test           # PHPUnit
-composer phpstan        # level 10 + strict-rules
-composer phpcs          # PSR12 + line-length
-composer rector-check   # dry-run modernization checks
-composer check          # all four
-composer fix            # phpcbf + rector-fix
+composer test            # PHPUnit
+composer phpstan         # level 10 + strict-rules
+composer phpcs           # PSR12 + line-length
+composer rector-check    # dry-run modernization checks
+composer require-checker # composer.json declares every used symbol
+composer check           # all five
+composer fix             # phpcbf + rector-fix
 ```

--- a/tools/release/README.md
+++ b/tools/release/README.md
@@ -1,0 +1,69 @@
+# `tools/release/`
+
+PHP foundation for OpenEMR's release tooling. Used by the workflows in
+`.github/workflows/release-*.yml` and `ship-release.yml`, plus called locally
+during release prep.
+
+## Layout
+
+```
+tools/release/
+├── bin/         CLI entrypoints (one Symfony Console SingleCommandApplication per file)
+├── src/         Service classes + value objects (PSR-4: OpenEMR\Release\)
+├── tests/       PHPUnit tests + in-memory fakes (PSR-4: OpenEMR\Release\Tests\)
+├── contracts/   JSON schemas vendored across consumer repos
+├── scripts/     Operational shell probes (App-token sanity checks etc.)
+├── templates/   PR body / changelog Twig templates
+├── Taskfile.yml Glue between workflows and the PHP CLIs (`task release:*`)
+└── versions.yml The 3-slot rotation registry (current/next/dev)
+```
+
+Workflow steps in `.github/workflows/` are deliberately thin: mint App token,
+checkout, run `task release:<name>`. All decision logic lives in PHP so it can
+be unit-tested.
+
+## Conventions
+
+- **PHP 8.5**, `declare(strict_types=1)`, **PHPStan level 10 + strict-rules**, PSR12, license-header docblock on every file.
+- **Service classes** are `final readonly class` with constructor-promoted DI. They shell out via `Symfony\Component\Process\Process::mustRun()` and throw `\RuntimeException` on failure.
+- **Result objects** are `final readonly class` value objects exposing public promoted properties + a small predicate (`isValid()`, `isReady()`, `wasSuccessful()`). Methods return result objects rather than associative arrays so the call site is type-safe and tests can assert on shape.
+- **gh as the network layer.** Network calls go through the `gh` CLI, which uses the ambient `GH_TOKEN` env var. Workflows mint a release App token via `actions/create-github-app-token@v1` and export it as `GH_TOKEN`. CLI authors don't handle auth themselves.
+- **Pure helpers stay static.** Methods that don't need shell or network (string builders, predicate logic, JSON shape interpretation) are kept `static` so unit tests can exercise them directly.
+- **Tests** live in `tests/` mirroring `src/` flat. HTTP-dependent classes are not unit-tested — pure helpers and orchestrators (with fake collaborators) are. See `tests/Fakes/` for the in-memory test doubles.
+
+## Why are some of these classes so verbose?
+
+A "wrap `gh` and merge a few PRs" service can read as ~600 lines of PHP before any meaningful logic shows up. That's not accidental:
+
+- Every file pays a ~13-line tax for the license-header docblock + `declare(strict_types=1)` + namespace + class declaration.
+- Each gh response gets a typed PHPDoc shape (`array{...}`) so PHPStan level 10 can verify field access. That's 5–15 lines per response shape, not per call.
+- We use one **value object per result** (`PullRequestSnapshot`, `PullRequestReadiness`, `ShipReleaseStepResult`, etc.) instead of returning arrays. Roughly 30 lines per object — the price of keeping the type system honest at every layer boundary.
+- Service classes that touch `gh` get an **interface + concrete impl + in-memory fake** (`PullRequestApi` / `GhPullRequestApi` / `FakePullRequestApi`). The interface seam roughly doubles the API-facing line count but is what makes the orchestrator unit-testable without a real GitHub.
+- Defensive logic (preflight, ordering enforcement, downstream-wait, status retraction, base validation, exception handling per step) accumulates over review iterations. Each piece is small and justified individually; together they dominate the orchestrator file.
+
+The smaller alternatives:
+- A bash script invoking `gh pr view --json … | jq` would be ~200 lines, ship the happy path, and be brittle on every edge case the orchestrator now defends against. No tests.
+- A single PHP file with no value objects, no interface, no fakes would land near 350 lines but cap at "trust live runs to verify."
+
+The current shape is the cost of **PHPStan level 10 + strict tests + structured failure reporting**. Worth knowing before adding the next CLI.
+
+## Adding a new CLI
+
+1. Add `src/<Service>.php` (`final readonly class`, ctor-promoted DI). If it touches the network, define an interface and a concrete `Gh*` impl so tests can substitute a fake.
+2. Add `src/<Service>Result.php` if it returns more than a primitive.
+3. Add `bin/<command>.php` (Symfony Console `SingleCommandApplication`). Keep all logic in the service class; the bin file is just option parsing + result rendering.
+4. Add a `release:<command>` entry in `Taskfile.yml` with `requires.vars` and `{{shellQuote .VAR}}` for every parameter.
+5. Add tests in `tests/` — pure helpers tested directly, services tested via fake collaborators.
+6. Add a workflow step that mints the App token and runs `task release:<command>`.
+7. After merge, append the corresponding `Bash(task -d ~/dev/oce/...)` permission to `~/.claude/settings.json` (alphabetical).
+
+## Running checks locally
+
+```sh
+composer test           # PHPUnit
+composer phpstan        # level 10 + strict-rules
+composer phpcs          # PSR12 + line-length
+composer rector-check   # dry-run modernization checks
+composer check          # all four
+composer fix            # phpcbf + rector-fix
+```

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -222,6 +222,20 @@ tasks:
       - git commit -m {{shellQuote .COMMIT_MESSAGE}}
       - git push --force-with-lease origin {{shellQuote .ROTATION_BRANCH}}
 
+  release:ship:
+    desc: Merge the three release PRs (infra → conductor → docs) in order (issue #705)
+    requires:
+      vars: [VERSION, REL_BRANCH]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/ship-release.php
+        --version={{shellQuote .VERSION}}
+        --rel-branch={{shellQuote .REL_BRANCH}}
+        {{if .TIMEOUT_SECONDS}}--timeout-seconds={{shellQuote .TIMEOUT_SECONDS}}{{end}}
+        {{if .STATUS_TARGET_URL}}--status-target-url={{shellQuote .STATUS_TARGET_URL}}{{end}}
+        {{if eq .DRY_RUN "1"}}--dry-run{{end}}
+
   release:probe-app-installation:
     desc: Verify the release App is installed on $OWNER/$REPO_NAME
     cmds:

--- a/tools/release/bin/ship-release.php
+++ b/tools/release/bin/ship-release.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Merge the three release PRs (infra → conductor → docs) in order.
+ *
+ * Authenticates via the ambient GH_TOKEN env var. The workflow mints a release
+ * App token with PR-write on all three repos and exports it before invoking.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\GhPullRequestApi;
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RotationPrPublisher;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use OpenEMR\Release\ShipReleaseRenderer;
+use OpenEMR\Release\SystemClock;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('ship-release')
+    ->setDescription('Merge the three release PRs in order (issue #705)')
+    ->addOption('version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('rel-branch', null, InputOption::VALUE_REQUIRED, 'Release branch name (e.g. rel-810)')
+    ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Check readiness without merging or posting status')
+    ->addOption(
+        'timeout-seconds',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Max seconds to wait for docs PR to update after conductor merges',
+        '600',
+    )
+    ->addOption('status-target-url', null, InputOption::VALUE_REQUIRED, 'target_url for the ship-approved status', '')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $version = RotationPrPublisher::stringOrEmpty($input->getOption('version'));
+        $relBranch = RotationPrPublisher::stringOrEmpty($input->getOption('rel-branch'));
+        if ($version === '' || $relBranch === '') {
+            $output->writeln('<error>--version and --rel-branch are required</error>');
+            return 1;
+        }
+        $timeoutRaw = RotationPrPublisher::stringOrEmpty($input->getOption('timeout-seconds'));
+        $timeout = ctype_digit($timeoutRaw) ? (int) $timeoutRaw : 600;
+
+        $orchestrator = new ShipReleaseOrchestrator(
+            new GhPullRequestApi(),
+            new SystemClock(),
+            $timeout,
+            (bool) $input->getOption('dry-run'),
+            RotationPrPublisher::stringOrEmpty($input->getOption('status-target-url')),
+        );
+        $result = $orchestrator->ship(PullRequestTarget::forRelease($version, $relBranch));
+        ShipReleaseRenderer::render($output, $result);
+        return $result->wasSuccessful() ? 0 : 1;
+    })
+    ->run();

--- a/tools/release/bin/ship-release.php
+++ b/tools/release/bin/ship-release.php
@@ -20,6 +20,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 use OpenEMR\Release\GhPullRequestApi;
 use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\ShipReleaseOptions;
 use OpenEMR\Release\ShipReleaseOrchestrator;
 use OpenEMR\Release\ShipReleaseRenderer;
 use OpenEMR\Release\SystemClock;
@@ -43,15 +44,13 @@ use Symfony\Component\Console\SingleCommandApplication;
     )
     ->addOption('status-target-url', null, InputOption::VALUE_REQUIRED, 'target_url for the ship-approved status', '')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        $stringOpt = static fn (string $name): string => is_string($v = $input->getOption($name)) ? $v : '';
-
-        $version = $stringOpt('version');
-        $relBranch = $stringOpt('rel-branch');
+        $version = ShipReleaseOptions::asString($input, 'version');
+        $relBranch = ShipReleaseOptions::asString($input, 'rel-branch');
         if ($version === '' || $relBranch === '') {
             $output->writeln('<error>--version and --rel-branch are required</error>');
             return 1;
         }
-        $timeoutRaw = $stringOpt('timeout-seconds');
+        $timeoutRaw = ShipReleaseOptions::asString($input, 'timeout-seconds');
         if (!ctype_digit($timeoutRaw) || (int) $timeoutRaw < 1) {
             $output->writeln('<error>--timeout-seconds must be a positive integer</error>');
             return 1;
@@ -62,7 +61,7 @@ use Symfony\Component\Console\SingleCommandApplication;
             new SystemClock(),
             (int) $timeoutRaw,
             (bool) $input->getOption('dry-run'),
-            $stringOpt('status-target-url'),
+            ShipReleaseOptions::asString($input, 'status-target-url'),
         );
         $result = $orchestrator->ship(PullRequestTarget::forRelease($version, $relBranch));
         ShipReleaseRenderer::render($output, $result);

--- a/tools/release/bin/ship-release.php
+++ b/tools/release/bin/ship-release.php
@@ -20,7 +20,6 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 
 use OpenEMR\Release\GhPullRequestApi;
 use OpenEMR\Release\PullRequestTarget;
-use OpenEMR\Release\RotationPrPublisher;
 use OpenEMR\Release\ShipReleaseOrchestrator;
 use OpenEMR\Release\ShipReleaseRenderer;
 use OpenEMR\Release\SystemClock;
@@ -44,21 +43,26 @@ use Symfony\Component\Console\SingleCommandApplication;
     )
     ->addOption('status-target-url', null, InputOption::VALUE_REQUIRED, 'target_url for the ship-approved status', '')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        $version = RotationPrPublisher::stringOrEmpty($input->getOption('version'));
-        $relBranch = RotationPrPublisher::stringOrEmpty($input->getOption('rel-branch'));
+        $stringOpt = static fn (string $name): string => is_string($v = $input->getOption($name)) ? $v : '';
+
+        $version = $stringOpt('version');
+        $relBranch = $stringOpt('rel-branch');
         if ($version === '' || $relBranch === '') {
             $output->writeln('<error>--version and --rel-branch are required</error>');
             return 1;
         }
-        $timeoutRaw = RotationPrPublisher::stringOrEmpty($input->getOption('timeout-seconds'));
-        $timeout = ctype_digit($timeoutRaw) ? (int) $timeoutRaw : 600;
+        $timeoutRaw = $stringOpt('timeout-seconds');
+        if (!ctype_digit($timeoutRaw) || (int) $timeoutRaw < 1) {
+            $output->writeln('<error>--timeout-seconds must be a positive integer</error>');
+            return 1;
+        }
 
         $orchestrator = new ShipReleaseOrchestrator(
             new GhPullRequestApi(),
             new SystemClock(),
-            $timeout,
+            (int) $timeoutRaw,
             (bool) $input->getOption('dry-run'),
-            RotationPrPublisher::stringOrEmpty($input->getOption('status-target-url')),
+            $stringOpt('status-target-url'),
         );
         $result = $orchestrator->ship(PullRequestTarget::forRelease($version, $relBranch));
         ShipReleaseRenderer::render($output, $result);

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -43,6 +43,7 @@
             "@phpcs",
             "@phpstan",
             "@rector-check",
+            "@require-checker",
             "@test"
         ],
         "fix": [

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^8.5",
+        "ext-mbstring": "*",
         "nikic/php-parser": "^5.0",
         "symfony/console": "^7.0",
         "symfony/process": "^7.0",

--- a/tools/release/composer.lock
+++ b/tools/release/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a6b1f8a66a38b31b874c316714afc922",
+    "content-hash": "eeeeeebec849bc51c28929c3abd7fdd4",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -3942,7 +3942,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.5"
+        "php": "^8.5",
+        "ext-mbstring": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/tools/release/src/Clock.php
+++ b/tools/release/src/Clock.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test seam for the orchestrator's downstream-effect polling loop.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+interface Clock
+{
+    public function now(): \DateTimeImmutable;
+
+    public function sleep(int $seconds): void;
+}

--- a/tools/release/src/DocsRefreshResult.php
+++ b/tools/release/src/DocsRefreshResult.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Outcome of refreshing the docs PR snapshot + readiness right before merge.
+ *
+ * Replaces an earlier 4-tuple with overloaded null semantics. Only one of the
+ * three static factories produces a usable instance; the type system enforces
+ * which fields are populated.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class DocsRefreshResult
+{
+    /**
+     * @param list<string> $blockingReasons
+     */
+    private function __construct(
+        public ?PullRequestSnapshot $snapshot,
+        public ?PullRequestReadiness $readiness,
+        public ?string $stopReason,
+        public array $blockingReasons,
+    ) {
+    }
+
+    public static function success(PullRequestSnapshot $snapshot, PullRequestReadiness $readiness): self
+    {
+        return new self($snapshot, $readiness, null, []);
+    }
+
+    /**
+     * @param list<string> $reasons
+     */
+    public static function blocked(?PullRequestSnapshot $snapshot, string $stopReason, array $reasons): self
+    {
+        return new self($snapshot, null, $stopReason, $reasons);
+    }
+
+    public function isSuccess(): bool
+    {
+        return $this->stopReason === null;
+    }
+}

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -27,7 +27,7 @@ final readonly class GhPullRequestApi implements PullRequestApi
             '--head', $branch,
             '--state', 'all',
             '--limit', '1',
-            '--json', 'number,headRefOid,baseRefName,mergedAt',
+            '--json', 'number,headRefOid,baseRefName,state',
         ]);
         $process->mustRun();
 
@@ -35,20 +35,17 @@ final readonly class GhPullRequestApi implements PullRequestApi
         if ($output === '' || $output === '[]') {
             return null;
         }
-        /** @var list<array{number: int, headRefOid: string, baseRefName: string, mergedAt: ?string}> $rows */
+        /** @var list<array{number: int, headRefOid: string, baseRefName: string, state: string}> $rows */
         $rows = $this->decodeJson($output, "gh pr list for {$repo}/{$branch}");
         if ($rows === []) {
             return null;
         }
         $row = $rows[0];
-        $mergedAt = ($row['mergedAt'] ?? null) !== null && $row['mergedAt'] !== ''
-            ? new \DateTimeImmutable($row['mergedAt'])
-            : null;
         return new PullRequestSnapshot(
             $row['number'],
             $row['headRefOid'],
             $row['baseRefName'],
-            $mergedAt,
+            PullRequestState::from($row['state']),
         );
     }
 
@@ -99,10 +96,32 @@ final readonly class GhPullRequestApi implements PullRequestApi
                 );
             }
         }
-        foreach ($data['statusCheckRollup'] as $check) {
-            $reasons = array_merge($reasons, $this->checkBlockingReason($check));
-        }
+        $reasons = array_merge(
+            $reasons,
+            self::reasonsFromStatusRollup($data['statusCheckRollup'], ShipReleaseOrchestrator::STATUS_CONTEXT),
+        );
         return new PullRequestReadiness($data['headRefOid'], $reasons);
+    }
+
+    /**
+     * Convert gh's statusCheckRollup into a list of blocking reasons. Skips
+     * any check whose context matches $ownContext — a prior ship-release run
+     * may have posted a failure status there, and the orchestrator must not
+     * gate itself on its own marker.
+     *
+     * @param  list<array<string, mixed>> $rollup
+     * @return list<string>
+     */
+    public static function reasonsFromStatusRollup(array $rollup, string $ownContext): array
+    {
+        $reasons = [];
+        foreach ($rollup as $check) {
+            if (($check['context'] ?? null) === $ownContext) {
+                continue;
+            }
+            $reasons = array_merge($reasons, self::checkBlockingReason($check));
+        }
+        return $reasons;
     }
 
     public function postCommitStatus(
@@ -143,20 +162,23 @@ final readonly class GhPullRequestApi implements PullRequestApi
         $merge->setTimeout(300.0);
         $merge->mustRun();
 
-        $view = new Process([
-            'gh', 'pr', 'view', (string) $number,
-            '--repo', $repo,
-            '--json', 'mergeCommit',
-            '--jq', '.mergeCommit.oid // ""',
-        ]);
-        $view->mustRun();
-        $sha = trim($view->getOutput());
-        if ($sha === '') {
-            throw new \RuntimeException(
-                "Merge of {$repo}#{$number} reported success but mergeCommit is empty",
-            );
+        // Best-effort fetch of the resulting merge commit SHA for the report.
+        // Failure here doesn't roll back the merge — the merge succeeded if
+        // mustRun() above didn't throw — so swallow the error and report a
+        // sentinel rather than failing the whole orchestration.
+        try {
+            $view = new Process([
+                'gh', 'pr', 'view', (string) $number,
+                '--repo', $repo,
+                '--json', 'mergeCommit',
+                '--jq', '.mergeCommit.oid // ""',
+            ]);
+            $view->mustRun();
+            $sha = trim($view->getOutput());
+        } catch (\RuntimeException) {
+            return '<merge-sha-unavailable>';
         }
-        return $sha;
+        return $sha === '' ? '<merge-sha-unavailable>' : $sha;
     }
 
     /**
@@ -181,15 +203,17 @@ final readonly class GhPullRequestApi implements PullRequestApi
      * @param array<string, mixed> $check
      * @return list<string>
      */
-    private function checkBlockingReason(array $check): array
+    private static function checkBlockingReason(array $check): array
     {
         $name = is_string($check['name'] ?? null) ? $check['name'] : 'unknown';
         $context = is_string($check['context'] ?? null) ? $check['context'] : $name;
 
-        // Check runs use status/conclusion; legacy commit statuses use state.
-        if (isset($check['conclusion'])) {
-            $conclusion = is_string($check['conclusion']) ? $check['conclusion'] : '';
-            $status = is_string($check['status'] ?? null) ? $check['status'] : '';
+        // Check runs use status/conclusion (conclusion may be null while in
+        // progress, so use array_key_exists, not isset). Legacy commit
+        // statuses use state.
+        if (array_key_exists('status', $check)) {
+            $status = is_string($check['status']) ? $check['status'] : '';
+            $conclusion = is_string($check['conclusion'] ?? null) ? $check['conclusion'] : '';
             if ($status !== 'COMPLETED') {
                 return [sprintf('check %s status=%s (need COMPLETED)', $name, $status)];
             }

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * gh-CLI implementation of PullRequestApi. Authenticates via the ambient
+ * GH_TOKEN env var (the workflow mints an App token and exports it).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class GhPullRequestApi implements PullRequestApi
+{
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot
+    {
+        $process = new Process([
+            'gh', 'pr', 'list',
+            '--repo', $repo,
+            '--head', $branch,
+            '--state', 'all',
+            '--limit', '1',
+            '--json', 'number,headRefOid,baseRefName,mergedAt',
+        ]);
+        $process->mustRun();
+
+        /** @var list<array{number: int, headRefOid: string, baseRefName: string, mergedAt: ?string}> $rows */
+        $rows = json_decode(trim($process->getOutput()), true) ?? [];
+        if ($rows === []) {
+            return null;
+        }
+        $row = $rows[0];
+        $mergedAt = ($row['mergedAt'] ?? null) !== null && $row['mergedAt'] !== ''
+            ? new \DateTimeImmutable($row['mergedAt'])
+            : null;
+        return new PullRequestSnapshot(
+            $row['number'],
+            $row['headRefOid'],
+            $row['baseRefName'],
+            $mergedAt,
+        );
+    }
+
+    public function getReadiness(string $repo, int $number): PullRequestReadiness
+    {
+        $process = new Process([
+            'gh', 'pr', 'view', (string) $number,
+            '--repo', $repo,
+            '--json', 'isDraft,mergeable,mergeStateStatus,reviewDecision,'
+                . 'statusCheckRollup,latestReviews,headRefOid',
+        ]);
+        $process->mustRun();
+
+        /**
+         * @var array{
+         *     isDraft: bool,
+         *     mergeable: string,
+         *     mergeStateStatus: string,
+         *     reviewDecision: ?string,
+         *     statusCheckRollup: list<array<string, mixed>>,
+         *     latestReviews: list<array{state: string, author?: array{login?: string}}>,
+         *     headRefOid: string,
+         * } $data
+         */
+        $data = json_decode(trim($process->getOutput()), true);
+
+        $reasons = [];
+        if ($data['isDraft']) {
+            $reasons[] = 'PR is a draft';
+        }
+        if ($data['mergeable'] !== 'MERGEABLE') {
+            $reasons[] = sprintf('mergeable=%s (need MERGEABLE)', $data['mergeable']);
+        }
+        if ($data['mergeStateStatus'] !== 'CLEAN') {
+            $reasons[] = sprintf('mergeStateStatus=%s (need CLEAN)', $data['mergeStateStatus']);
+        }
+        if (($data['reviewDecision'] ?? null) !== 'APPROVED') {
+            $reasons[] = sprintf(
+                'reviewDecision=%s (need APPROVED)',
+                $data['reviewDecision'] ?? 'null',
+            );
+        }
+        foreach ($data['latestReviews'] as $review) {
+            if ($review['state'] === 'CHANGES_REQUESTED') {
+                $reasons[] = sprintf(
+                    'CHANGES_REQUESTED review by %s',
+                    $review['author']['login'] ?? 'unknown',
+                );
+            }
+        }
+        foreach ($data['statusCheckRollup'] as $check) {
+            $reasons = array_merge($reasons, $this->checkBlockingReason($check));
+        }
+        return new PullRequestReadiness($data['headRefOid'], $reasons);
+    }
+
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void {
+        $argv = [
+            'gh', 'api',
+            "repos/{$repo}/statuses/{$sha}",
+            '--method', 'POST',
+            '-f', "state={$state}",
+            '-f', "context={$context}",
+            '-f', "description={$description}",
+        ];
+        if ($targetUrl !== '') {
+            $argv[] = '-f';
+            $argv[] = "target_url={$targetUrl}";
+        }
+        $process = new Process($argv);
+        $process->mustRun();
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        $merge = new Process([
+            'gh', 'pr', 'merge', (string) $number,
+            '--repo', $repo,
+            '--squash',
+            '--match-head-commit', $expectedHeadSha,
+        ]);
+        $merge->setTimeout(300.0);
+        $merge->mustRun();
+
+        $view = new Process([
+            'gh', 'pr', 'view', (string) $number,
+            '--repo', $repo,
+            '--json', 'mergeCommit',
+            '--jq', '.mergeCommit.oid // ""',
+        ]);
+        $view->mustRun();
+        $sha = trim($view->getOutput());
+        if ($sha === '') {
+            throw new \RuntimeException(
+                "Merge of {$repo}#{$number} reported success but mergeCommit is empty",
+            );
+        }
+        return $sha;
+    }
+
+    /**
+     * @param array<string, mixed> $check
+     * @return list<string>
+     */
+    private function checkBlockingReason(array $check): array
+    {
+        $name = is_string($check['name'] ?? null) ? $check['name'] : 'unknown';
+        $context = is_string($check['context'] ?? null) ? $check['context'] : $name;
+
+        // Check runs use status/conclusion; legacy commit statuses use state.
+        if (isset($check['conclusion'])) {
+            $conclusion = is_string($check['conclusion']) ? $check['conclusion'] : '';
+            $status = is_string($check['status'] ?? null) ? $check['status'] : '';
+            if ($status !== 'COMPLETED') {
+                return [sprintf('check %s status=%s (need COMPLETED)', $name, $status)];
+            }
+            if (!in_array($conclusion, ['SUCCESS', 'NEUTRAL', 'SKIPPED'], true)) {
+                return [sprintf('check %s conclusion=%s', $name, $conclusion)];
+            }
+            return [];
+        }
+        if (isset($check['state'])) {
+            $state = is_string($check['state']) ? $check['state'] : '';
+            if (!in_array($state, ['SUCCESS', 'EXPECTED'], true)) {
+                return [sprintf('status %s state=%s', $context, $state)];
+            }
+        }
+        return [];
+    }
+}

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -31,8 +31,12 @@ final readonly class GhPullRequestApi implements PullRequestApi
         ]);
         $process->mustRun();
 
+        $output = trim($process->getOutput());
+        if ($output === '' || $output === '[]') {
+            return null;
+        }
         /** @var list<array{number: int, headRefOid: string, baseRefName: string, mergedAt: ?string}> $rows */
-        $rows = json_decode(trim($process->getOutput()), true) ?? [];
+        $rows = $this->decodeJson($output, "gh pr list for {$repo}/{$branch}");
         if ($rows === []) {
             return null;
         }
@@ -69,7 +73,7 @@ final readonly class GhPullRequestApi implements PullRequestApi
          *     headRefOid: string,
          * } $data
          */
-        $data = json_decode(trim($process->getOutput()), true);
+        $data = $this->decodeJson(trim($process->getOutput()), "gh pr view {$repo}#{$number}");
 
         $reasons = [];
         if ($data['isDraft']) {
@@ -127,11 +131,14 @@ final readonly class GhPullRequestApi implements PullRequestApi
 
     public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
     {
+        // --delete-branch=false is set explicitly so gh doesn't prompt about
+        // branch deletion when run from the workflow's non-TTY shell.
         $merge = new Process([
             'gh', 'pr', 'merge', (string) $number,
             '--repo', $repo,
             '--squash',
             '--match-head-commit', $expectedHeadSha,
+            '--delete-branch=false',
         ]);
         $merge->setTimeout(300.0);
         $merge->mustRun();
@@ -150,6 +157,24 @@ final readonly class GhPullRequestApi implements PullRequestApi
             );
         }
         return $sha;
+    }
+
+    /**
+     * Decode JSON output from gh, raising a controlled error with the
+     * originating context instead of the bare PHP TypeError that follows
+     * indexing into a null result.
+     */
+    private function decodeJson(string $payload, string $context): mixed
+    {
+        try {
+            return json_decode($payload, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException(
+                "Failed to decode JSON from {$context}: {$e->getMessage()}",
+                $e->getCode(),
+                $e,
+            );
+        }
     }
 
     /**

--- a/tools/release/src/GhPullRequestApi.php
+++ b/tools/release/src/GhPullRequestApi.php
@@ -174,8 +174,11 @@ final readonly class GhPullRequestApi implements PullRequestApi
             return [];
         }
         if (isset($check['state'])) {
+            // Legacy commit-status states: SUCCESS / FAILURE / ERROR / PENDING / EXPECTED.
+            // EXPECTED means "this status is expected but hasn't been reported yet" — treat
+            // it as blocking, same as PENDING. Only SUCCESS clears the gate.
             $state = is_string($check['state']) ? $check['state'] : '';
-            if (!in_array($state, ['SUCCESS', 'EXPECTED'], true)) {
+            if ($state !== 'SUCCESS') {
                 return [sprintf('status %s state=%s', $context, $state)];
             }
         }

--- a/tools/release/src/PullRequestApi.php
+++ b/tools/release/src/PullRequestApi.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Cross-repo PR operations the ship-release orchestrator needs. Kept narrow on
+ * purpose so tests can substitute a fake without standing up the full gh CLI.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+interface PullRequestApi
+{
+    /**
+     * Look up the most recent PR (open or closed/merged) whose head branch
+     * matches. Returns null when no PR exists for that branch.
+     */
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot;
+
+    /**
+     * Compute readiness from GitHub's mergeability + checks + review state.
+     */
+    public function getReadiness(string $repo, int $number): PullRequestReadiness;
+
+    /**
+     * POST a commit status to a SHA. Used to publish release/ship-approved
+     * before merge so branch protection can require it.
+     */
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void;
+
+    /**
+     * Squash-merge a PR, refusing to proceed if the PR's current head SHA has
+     * moved since $expectedHeadSha. Returns the merge commit SHA.
+     */
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string;
+}

--- a/tools/release/src/PullRequestReadiness.php
+++ b/tools/release/src/PullRequestReadiness.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Whether a PR is ready to merge, with one human-readable reason per blocker.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestReadiness
+{
+    /**
+     * @param list<string> $blockingReasons
+     */
+    public function __construct(
+        public string $headRefOid,
+        public array $blockingReasons,
+    ) {
+    }
+
+    public function isReady(): bool
+    {
+        return $this->blockingReasons === [];
+    }
+}

--- a/tools/release/src/PullRequestSnapshot.php
+++ b/tools/release/src/PullRequestSnapshot.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Point-in-time snapshot of an open or closed pull request.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestSnapshot
+{
+    public function __construct(
+        public int $number,
+        public string $headRefOid,
+        public string $baseRefName,
+        public ?\DateTimeImmutable $mergedAt,
+    ) {
+    }
+
+    public function isMerged(): bool
+    {
+        return $this->mergedAt instanceof \DateTimeImmutable;
+    }
+}

--- a/tools/release/src/PullRequestSnapshot.php
+++ b/tools/release/src/PullRequestSnapshot.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Point-in-time snapshot of an open or closed pull request.
+ * Point-in-time snapshot of a pull request.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -20,12 +20,17 @@ final readonly class PullRequestSnapshot
         public int $number,
         public string $headRefOid,
         public string $baseRefName,
-        public ?\DateTimeImmutable $mergedAt,
+        public PullRequestState $state,
     ) {
     }
 
     public function isMerged(): bool
     {
-        return $this->mergedAt instanceof \DateTimeImmutable;
+        return $this->state === PullRequestState::Merged;
+    }
+
+    public function isClosedWithoutMerging(): bool
+    {
+        return $this->state === PullRequestState::Closed;
     }
 }

--- a/tools/release/src/PullRequestSnapshot.php
+++ b/tools/release/src/PullRequestSnapshot.php
@@ -29,7 +29,7 @@ final readonly class PullRequestSnapshot
         return $this->state === PullRequestState::Merged;
     }
 
-    public function isClosedWithoutMerging(): bool
+    public function isClosed(): bool
     {
         return $this->state === PullRequestState::Closed;
     }

--- a/tools/release/src/PullRequestState.php
+++ b/tools/release/src/PullRequestState.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Lifecycle state of a pull request as reported by GitHub.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum PullRequestState: string
+{
+    case Open = 'OPEN';
+    case Closed = 'CLOSED';
+    case Merged = 'MERGED';
+}

--- a/tools/release/src/PullRequestTarget.php
+++ b/tools/release/src/PullRequestTarget.php
@@ -20,6 +20,7 @@ final readonly class PullRequestTarget
     public function __construct(
         public string $repo,
         public string $branch,
+        public string $expectedBase,
         public string $roleLabel,
         public int $mergeOrder,
     ) {
@@ -29,15 +30,16 @@ final readonly class PullRequestTarget
      * Build the canonical infra → conductor → docs target list for a release.
      *
      * Branch name conventions are defined in openemr-devops#705 and #664.
+     * Conductor merges into the rel-<n> branch, the other two into master.
      *
      * @return list<self>
      */
     public static function forRelease(string $version, string $relBranch): array
     {
         return [
-            new self('openemr/openemr-devops', 'release-rotation/auto', 'infra', 1),
-            new self('openemr/openemr', "release-prep/{$relBranch}", 'conductor', 2),
-            new self('openemr/website-openemr', "release-docs/{$version}", 'docs', 3),
+            new self('openemr/openemr-devops', 'release-rotation/auto', 'master', 'infra', 1),
+            new self('openemr/openemr', "release-prep/{$relBranch}", $relBranch, 'conductor', 2),
+            new self('openemr/website-openemr', "release-docs/{$version}", 'master', 'docs', 3),
         ];
     }
 }

--- a/tools/release/src/PullRequestTarget.php
+++ b/tools/release/src/PullRequestTarget.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * One PR slot in the ship-release orchestration: which repo, which head
+ * branch, what role it plays, and the order in which it merges.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class PullRequestTarget
+{
+    public function __construct(
+        public string $repo,
+        public string $branch,
+        public string $roleLabel,
+        public int $mergeOrder,
+    ) {
+    }
+
+    /**
+     * Build the canonical infra → conductor → docs target list for a release.
+     *
+     * Branch name conventions are defined in openemr-devops#705 and #664.
+     *
+     * @return list<self>
+     */
+    public static function forRelease(string $version, string $relBranch): array
+    {
+        return [
+            new self('openemr/openemr-devops', 'release-rotation/auto', 'infra', 1),
+            new self('openemr/openemr', "release-prep/{$relBranch}", 'conductor', 2),
+            new self('openemr/website-openemr', "release-docs/{$version}", 'docs', 3),
+        ];
+    }
+}

--- a/tools/release/src/PullRequestTarget.php
+++ b/tools/release/src/PullRequestTarget.php
@@ -21,7 +21,7 @@ final readonly class PullRequestTarget
         public string $repo,
         public string $branch,
         public string $expectedBase,
-        public string $roleLabel,
+        public RoleLabel $roleLabel,
         public int $mergeOrder,
     ) {
     }
@@ -37,9 +37,9 @@ final readonly class PullRequestTarget
     public static function forRelease(string $version, string $relBranch): array
     {
         return [
-            new self('openemr/openemr-devops', 'release-rotation/auto', 'master', 'infra', 1),
-            new self('openemr/openemr', "release-prep/{$relBranch}", $relBranch, 'conductor', 2),
-            new self('openemr/website-openemr', "release-docs/{$version}", 'master', 'docs', 3),
+            new self('openemr/openemr-devops', 'release-rotation/auto', 'master', RoleLabel::Infra, 1),
+            new self('openemr/openemr', "release-prep/{$relBranch}", $relBranch, RoleLabel::Conductor, 2),
+            new self('openemr/website-openemr', "release-docs/{$version}", 'master', RoleLabel::Docs, 3),
         ];
     }
 }

--- a/tools/release/src/RoleLabel.php
+++ b/tools/release/src/RoleLabel.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Identifier for the three sibling release PRs orchestrated by ship-release.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum RoleLabel: string
+{
+    case Infra = 'infra';
+    case Conductor = 'conductor';
+    case Docs = 'docs';
+}

--- a/tools/release/src/ShipReleaseOptions.php
+++ b/tools/release/src/ShipReleaseOptions.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * CLI option coercion helper for bin/ship-release.php. Lives in src/ rather
+ * than the bin file because PSR1 forbids combining symbol declarations with
+ * side effects in the same file (the bin file's job is the side effect of
+ * running the SingleCommandApplication).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+final readonly class ShipReleaseOptions
+{
+    public static function asString(InputInterface $input, string $name): string
+    {
+        $value = $input->getOption($name);
+        return is_string($value) ? $value : '';
+    }
+}

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -39,10 +39,11 @@ final readonly class ShipReleaseOrchestrator
     }
 
     /**
-     * @param list<PullRequestTarget> $targets infra → conductor → docs (sorted by mergeOrder)
+     * @param list<PullRequestTarget> $targets infra, conductor, docs (any order — sorted internally)
      */
     public function ship(array $targets): ShipReleaseResult
     {
+        $targets = $this->sortByMergeOrder($targets);
         $snapshots = $this->snapshotAll($targets);
 
         $fatal = $this->detectDocsFirst($targets, $snapshots);
@@ -65,7 +66,27 @@ final readonly class ShipReleaseOrchestrator
     }
 
     /**
-     * @param list<PullRequestTarget> $targets
+     * Defensive sort + uniqueness check so a caller passing targets in any
+     * order still gets infra → conductor → docs at merge time.
+     *
+     * @param  list<PullRequestTarget> $targets
+     * @return list<PullRequestTarget>
+     */
+    private function sortByMergeOrder(array $targets): array
+    {
+        $orders = array_map(static fn (PullRequestTarget $t): int => $t->mergeOrder, $targets);
+        if (count(array_unique($orders)) !== count($orders)) {
+            throw new \LogicException('ship-release targets have duplicate mergeOrder values');
+        }
+        usort(
+            $targets,
+            static fn (PullRequestTarget $a, PullRequestTarget $b): int => $a->mergeOrder <=> $b->mergeOrder,
+        );
+        return $targets;
+    }
+
+    /**
+     * @param  list<PullRequestTarget> $targets
      * @return array<string, ?PullRequestSnapshot>
      */
     private function snapshotAll(array $targets): array
@@ -97,6 +118,14 @@ final readonly class ShipReleaseOrchestrator
             $snapshot = $snapshots[$target->roleLabel] ?? null;
             if ($snapshot === null) {
                 $blocked[$target->roleLabel] = ['no PR found for branch ' . $target->branch];
+                continue;
+            }
+            if ($snapshot->baseRefName !== $target->expectedBase) {
+                $blocked[$target->roleLabel] = [sprintf(
+                    'PR base is %s, expected %s — refusing to merge a PR opened against the wrong base',
+                    $snapshot->baseRefName,
+                    $target->expectedBase,
+                )];
                 continue;
             }
             if ($snapshot->isMerged()) {
@@ -254,15 +283,25 @@ final readonly class ShipReleaseOrchestrator
                 );
             }
 
-            $this->api->postCommitStatus(
-                $target->repo,
-                $stepReadiness->headRefOid,
-                self::STATUS_CONTEXT,
-                'success',
-                self::STATUS_DESCRIPTION,
-                $this->statusTargetUrl,
-            );
-            $mergeSha = $this->api->squashMerge($target->repo, $snapshot->number, $stepReadiness->headRefOid);
+            try {
+                $this->api->postCommitStatus(
+                    $target->repo,
+                    $stepReadiness->headRefOid,
+                    self::STATUS_CONTEXT,
+                    'success',
+                    self::STATUS_DESCRIPTION,
+                    $this->statusTargetUrl,
+                );
+                $mergeSha = $this->api->squashMerge($target->repo, $snapshot->number, $stepReadiness->headRefOid);
+            } catch (\RuntimeException $e) {
+                $steps[] = $this->blockedStep(
+                    $target,
+                    $snapshot->number,
+                    [sprintf('gh call failed: %s', $e->getMessage())],
+                );
+                $stopReason = sprintf('%s merge failed', $target->roleLabel);
+                continue;
+            }
             $steps[] = new ShipReleaseStepResult(
                 $target,
                 ShipReleaseStepStatus::MERGED,

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -3,11 +3,14 @@
 /**
  * Merges the three release PRs (infra → conductor → docs) in strict order.
  *
- * Skips PRs already merged so the same trigger handles partial-merge recovery.
- * Stops at the first non-ready PR without merging, so a half-finished release
- * never originates here. Detects the one unrecoverable case — docs merged
- * before conductor — and refuses to do anything; that recovery is documented
- * in the runbook (see issue #705).
+ * Two-phase: a preflight pass evaluates every unmerged target's readiness and
+ * refuses to merge anything if any unmerged PR is not ready (issue #705 step
+ * 3 + 5: "no partial merges from the workflow itself"). PRs already merged
+ * are skipped so the same trigger handles partial-merge recovery from outside
+ * causes (e.g. an admin-overridden direct merge).
+ *
+ * Detects the one unrecoverable case — docs merged before conductor — and
+ * refuses to do anything; that recovery is documented in the runbook.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -44,12 +47,154 @@ final readonly class ShipReleaseOrchestrator
 
         $fatal = $this->detectDocsFirst($targets, $snapshots);
         if ($fatal !== null) {
-            return new ShipReleaseResult(
-                $this->markAllNotReached($targets),
-                $fatal,
-            );
+            return new ShipReleaseResult($this->markAllNotReached($targets), $fatal);
         }
 
+        // Preflight: evaluate every unmerged target before any merge so a later
+        // blocker can't cause earlier ones to ship as a partial merge.
+        $preflight = $this->preflight($targets, $snapshots);
+        if ($preflight['hasBlocker']) {
+            return new ShipReleaseResult($preflight['steps']);
+        }
+
+        if ($this->dryRun) {
+            return new ShipReleaseResult($this->dryRunSteps($targets, $snapshots, $preflight['readiness']));
+        }
+
+        return new ShipReleaseResult($this->executeMerges($targets, $snapshots, $preflight['readiness']));
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets
+     * @return array<string, ?PullRequestSnapshot>
+     */
+    private function snapshotAll(array $targets): array
+    {
+        $out = [];
+        foreach ($targets as $target) {
+            $out[$target->roleLabel] = $this->api->findByHead($target->repo, $target->branch);
+        }
+        return $out;
+    }
+
+    /**
+     * Probe every unmerged target's readiness. If any is missing or blocked,
+     * return per-target step results with no merges performed.
+     *
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @return array{
+     *     hasBlocker: bool,
+     *     steps: list<ShipReleaseStepResult>,
+     *     readiness: array<string, PullRequestReadiness>,
+     * }
+     */
+    private function preflight(array $targets, array $snapshots): array
+    {
+        $readiness = [];
+        $blocked = [];
+        foreach ($targets as $target) {
+            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            if ($snapshot === null) {
+                $blocked[$target->roleLabel] = ['no PR found for branch ' . $target->branch];
+                continue;
+            }
+            if ($snapshot->isMerged()) {
+                continue;
+            }
+            $check = $this->api->getReadiness($target->repo, $snapshot->number);
+            $readiness[$target->roleLabel] = $check;
+            if (!$check->isReady()) {
+                $blocked[$target->roleLabel] = $check->blockingReasons;
+            }
+        }
+
+        $steps = [];
+        foreach ($targets as $target) {
+            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            if ($snapshot !== null && $snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+            if (isset($blocked[$target->roleLabel])) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::BLOCKED,
+                    $snapshot?->number,
+                    null,
+                    $blocked[$target->roleLabel],
+                );
+                continue;
+            }
+            // Ready, but preflight failed elsewhere — we won't merge it now.
+            if ($blocked !== []) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::NOT_REACHED,
+                    $snapshot?->number,
+                    null,
+                    ['preflight blocker on another PR — no merges performed'],
+                );
+            }
+        }
+
+        return ['hasBlocker' => $blocked !== [], 'steps' => $steps, 'readiness' => $readiness];
+    }
+
+    /**
+     * Build the dry-run report — preflight already passed, so each unmerged
+     * target is "would merge" and merged ones stay "skipped".
+     *
+     * @param list<PullRequestTarget>              $targets
+     * @param array<string, ?PullRequestSnapshot>  $snapshots
+     * @param array<string, PullRequestReadiness>  $readiness
+     * @return list<ShipReleaseStepResult>
+     */
+    private function dryRunSteps(array $targets, array $snapshots, array $readiness): array
+    {
+        $steps = [];
+        foreach ($targets as $target) {
+            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            if ($snapshot !== null && $snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+            $steps[] = new ShipReleaseStepResult(
+                $target,
+                ShipReleaseStepStatus::WOULD_MERGE,
+                $snapshot?->number,
+                null,
+                [],
+            );
+            unset($readiness[$target->roleLabel]);
+        }
+        return $steps;
+    }
+
+    /**
+     * Real merge pass. Preflight has already validated that every unmerged
+     * target was ready at snapshot time. The docs PR gets a fresh readiness
+     * check after the conductor's downstream effect re-renders it.
+     *
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @param  array<string, PullRequestReadiness> $readiness  preflight readiness, by role
+     * @return list<ShipReleaseStepResult>
+     */
+    private function executeMerges(array $targets, array $snapshots, array $readiness): array
+    {
         $steps = [];
         $stopReason = null;
         $mergedThisRun = [];
@@ -60,20 +205,8 @@ final readonly class ShipReleaseOrchestrator
                 continue;
             }
 
-            // The conductor's merge fires repository_dispatch handlers that
-            // re-render the docs PR. Wait for that effect to land (or time
-            // out), then re-snapshot before deciding readiness.
-            if (
-                $target->roleLabel === 'docs'
-                && in_array('conductor', $mergedThisRun, true)
-            ) {
-                $snapshots[$target->roleLabel] = $this->awaitDownstreamUpdate(
-                    $target,
-                    $snapshots[$target->roleLabel] ?? null,
-                );
-            }
-
             $snapshot = $snapshots[$target->roleLabel] ?? null;
+            // Preflight already filtered missing PRs.
             if ($snapshot === null) {
                 $steps[] = $this->blockedStep($target, null, ['no PR found for branch ' . $target->branch]);
                 $stopReason = sprintf('%s PR is missing', $target->roleLabel);
@@ -90,37 +223,43 @@ final readonly class ShipReleaseOrchestrator
                 continue;
             }
 
-            $readiness = $this->api->getReadiness($target->repo, $snapshot->number);
-            if (!$readiness->isReady()) {
-                $steps[] = $this->blockedStep($target, $snapshot->number, $readiness->blockingReasons);
-                $stopReason = sprintf('%s PR is not ready', $target->roleLabel);
-                continue;
+            // The conductor merge fires repository_dispatch handlers that re-render
+            // the docs PR. Wait for that effect (or time out), re-snapshot, then
+            // re-check readiness against the post-render head SHA before merging.
+            $stepReadiness = $readiness[$target->roleLabel] ?? null;
+            if (
+                $target->roleLabel === 'docs'
+                && in_array('conductor', $mergedThisRun, true)
+            ) {
+                $snapshot = $this->awaitDownstreamUpdate($target, $snapshot);
+                if (!$snapshot instanceof \OpenEMR\Release\PullRequestSnapshot) {
+                    $steps[] = $this->blockedStep($target, null, ['docs PR disappeared after conductor merge']);
+                    $stopReason = 'docs PR is missing after conductor merge';
+                    continue;
+                }
+                $stepReadiness = $this->api->getReadiness($target->repo, $snapshot->number);
+                if (!$stepReadiness->isReady()) {
+                    $steps[] = $this->blockedStep($target, $snapshot->number, $stepReadiness->blockingReasons);
+                    $stopReason = 'docs PR not ready after conductor downstream update';
+                    continue;
+                }
             }
 
-            if ($this->dryRun) {
-                $steps[] = new ShipReleaseStepResult(
-                    $target,
-                    ShipReleaseStepStatus::WOULD_MERGE,
-                    $snapshot->number,
-                    null,
-                    [],
+            if ($stepReadiness === null) {
+                throw new \LogicException(
+                    "ship-release: missing preflight readiness for {$target->roleLabel}",
                 );
-                continue;
             }
 
             $this->api->postCommitStatus(
                 $target->repo,
-                $readiness->headRefOid,
+                $stepReadiness->headRefOid,
                 self::STATUS_CONTEXT,
                 'success',
                 self::STATUS_DESCRIPTION,
                 $this->statusTargetUrl,
             );
-            $mergeSha = $this->api->squashMerge(
-                $target->repo,
-                $snapshot->number,
-                $readiness->headRefOid,
-            );
+            $mergeSha = $this->api->squashMerge($target->repo, $snapshot->number, $stepReadiness->headRefOid);
             $steps[] = new ShipReleaseStepResult(
                 $target,
                 ShipReleaseStepStatus::MERGED,
@@ -131,20 +270,7 @@ final readonly class ShipReleaseOrchestrator
             $mergedThisRun[] = $target->roleLabel;
         }
 
-        return new ShipReleaseResult($steps);
-    }
-
-    /**
-     * @param list<PullRequestTarget> $targets
-     * @return array<string, ?PullRequestSnapshot>
-     */
-    private function snapshotAll(array $targets): array
-    {
-        $out = [];
-        foreach ($targets as $target) {
-            $out[$target->roleLabel] = $this->api->findByHead($target->repo, $target->branch);
-        }
-        return $out;
+        return $steps;
     }
 
     /**
@@ -195,16 +321,13 @@ final readonly class ShipReleaseOrchestrator
      */
     private function awaitDownstreamUpdate(
         PullRequestTarget $target,
-        ?PullRequestSnapshot $before,
+        PullRequestSnapshot $before,
     ): ?PullRequestSnapshot {
-        if (!$before instanceof \OpenEMR\Release\PullRequestSnapshot) {
-            return null;
-        }
         $deadline = $this->clock->now()->getTimestamp() + $this->downstreamTimeoutSeconds;
         $current = $before;
         while ($this->clock->now()->getTimestamp() < $deadline) {
             $current = $this->api->findByHead($target->repo, $target->branch);
-            if (!$current instanceof \OpenEMR\Release\PullRequestSnapshot) {
+            if (!$current instanceof PullRequestSnapshot) {
                 return null;
             }
             if ($current->headRefOid !== $before->headRefOid) {
@@ -216,7 +339,7 @@ final readonly class ShipReleaseOrchestrator
     }
 
     /**
-     * @param list<PullRequestTarget> $targets
+     * @param  list<PullRequestTarget> $targets
      * @return list<ShipReleaseStepResult>
      */
     private function markAllNotReached(array $targets): array

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -224,24 +224,29 @@ final readonly class ShipReleaseOrchestrator
             }
 
             // The conductor merge fires repository_dispatch handlers that re-render
-            // the docs PR. Wait for that effect (or time out), re-snapshot, then
-            // re-check readiness against the post-render head SHA before merging.
+            // the docs PR. Two cases need a fresh state read before merging docs:
+            //   - conductor merged in *this* run: poll until head SHA flips (or
+            //     time out), then re-check readiness against the new SHA.
+            //   - conductor was already merged when we started (recovery case):
+            //     re-check readiness right now in case the previous run's
+            //     downstream re-render is still in flight. Don't poll — if the
+            //     PR isn't ready, fail fast and the operator re-runs.
             $stepReadiness = $readiness[$target->roleLabel] ?? null;
-            if (
-                $target->roleLabel === 'docs'
-                && in_array('conductor', $mergedThisRun, true)
-            ) {
-                $snapshot = $this->awaitDownstreamUpdate($target, $snapshot);
-                if (!$snapshot instanceof \OpenEMR\Release\PullRequestSnapshot) {
-                    $steps[] = $this->blockedStep($target, null, ['docs PR disappeared after conductor merge']);
-                    $stopReason = 'docs PR is missing after conductor merge';
-                    continue;
-                }
-                $stepReadiness = $this->api->getReadiness($target->repo, $snapshot->number);
-                if (!$stepReadiness->isReady()) {
-                    $steps[] = $this->blockedStep($target, $snapshot->number, $stepReadiness->blockingReasons);
-                    $stopReason = 'docs PR not ready after conductor downstream update';
-                    continue;
+            if ($target->roleLabel === 'docs') {
+                $refresh = $this->refreshDocsBeforeMerge($target, $snapshot, $snapshots, $mergedThisRun);
+                if ($refresh !== null) {
+                    [$refreshedSnapshot, $refreshedReadiness, $refreshStopReason, $blockingReasons] = $refresh;
+                    if ($refreshStopReason !== null) {
+                        $steps[] = $this->blockedStep($target, $refreshedSnapshot?->number, $blockingReasons);
+                        $stopReason = $refreshStopReason;
+                        continue;
+                    }
+                    // refresh succeeded — both fields are guaranteed non-null
+                    if (!$refreshedSnapshot instanceof PullRequestSnapshot || $refreshedReadiness === null) {
+                        throw new \LogicException('refreshDocsBeforeMerge returned inconsistent tuple');
+                    }
+                    $snapshot = $refreshedSnapshot;
+                    $stepReadiness = $refreshedReadiness;
                 }
             }
 
@@ -312,6 +317,52 @@ final readonly class ShipReleaseOrchestrator
             }
         }
         throw new \LogicException("ship-release targets list is missing role: {$role}");
+    }
+
+    /**
+     * Two cases need a fresh state read before merging docs:
+     *   - conductor merged in *this* run: poll until head SHA flips (or time
+     *     out), then re-check readiness against the new SHA.
+     *   - conductor was already merged when we started (recovery case): re-check
+     *     readiness right now in case the previous run's downstream re-render
+     *     is still in flight. Don't poll — if not ready, fail fast and the
+     *     operator re-runs.
+     *
+     * Returns null when no refresh is needed. Otherwise returns a tuple
+     * [snapshot, readiness, stopReason, blockingReasons]:
+     *   - on success, snapshot + readiness are non-null and stopReason is null
+     *   - on failure, stopReason is non-null and blockingReasons populated;
+     *     snapshot may be null if the PR has disappeared
+     *
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
+     * @param  list<string>                        $mergedThisRun
+     * @return array{0: ?PullRequestSnapshot, 1: ?PullRequestReadiness, 2: ?string, 3: list<string>}|null
+     */
+    private function refreshDocsBeforeMerge(
+        PullRequestTarget $target,
+        PullRequestSnapshot $current,
+        array $snapshots,
+        array $mergedThisRun,
+    ): ?array {
+        $conductorJustMerged = in_array('conductor', $mergedThisRun, true);
+        $conductorPreviouslyMerged = ($snapshots['conductor'] ?? null)?->isMerged() ?? false;
+        if (!$conductorJustMerged && !$conductorPreviouslyMerged) {
+            return null;
+        }
+        $fresh = $conductorJustMerged
+            ? $this->awaitDownstreamUpdate($target, $current)
+            : $this->api->findByHead($target->repo, $target->branch);
+        if (!$fresh instanceof PullRequestSnapshot) {
+            return [null, null, 'docs PR disappeared before merge', ['docs PR disappeared before merge']];
+        }
+        $readiness = $this->api->getReadiness($target->repo, $fresh->number);
+        if (!$readiness->isReady()) {
+            $stopReason = $conductorJustMerged
+                ? 'docs PR not ready after conductor downstream update'
+                : 'docs PR not ready (re-checked after conductor was already merged)';
+            return [$fresh, null, $stopReason, $readiness->blockingReasons];
+        }
+        return [$fresh, $readiness, null, []];
     }
 
     /**

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -58,7 +58,7 @@ final readonly class ShipReleaseOrchestrator
         }
 
         if ($this->dryRun) {
-            return new ShipReleaseResult($this->dryRunSteps($targets, $snapshots, $preflight['readiness']));
+            return new ShipReleaseResult($this->dryRunSteps($targets, $snapshots));
         }
 
         return new ShipReleaseResult($this->executeMerges($targets, $snapshots, $preflight['readiness']));
@@ -151,12 +151,11 @@ final readonly class ShipReleaseOrchestrator
      * Build the dry-run report — preflight already passed, so each unmerged
      * target is "would merge" and merged ones stay "skipped".
      *
-     * @param list<PullRequestTarget>              $targets
-     * @param array<string, ?PullRequestSnapshot>  $snapshots
-     * @param array<string, PullRequestReadiness>  $readiness
+     * @param  list<PullRequestTarget>             $targets
+     * @param  array<string, ?PullRequestSnapshot> $snapshots
      * @return list<ShipReleaseStepResult>
      */
-    private function dryRunSteps(array $targets, array $snapshots, array $readiness): array
+    private function dryRunSteps(array $targets, array $snapshots): array
     {
         $steps = [];
         foreach ($targets as $target) {
@@ -178,7 +177,6 @@ final readonly class ShipReleaseOrchestrator
                 null,
                 [],
             );
-            unset($readiness[$target->roleLabel]);
         }
         return $steps;
     }

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -294,6 +294,10 @@ final readonly class ShipReleaseOrchestrator
                 );
                 $mergeSha = $this->api->squashMerge($target->repo, $snapshot->number, $stepReadiness->headRefOid);
             } catch (\RuntimeException $e) {
+                // Best-effort: clear the success status we just posted so a failed
+                // run doesn't leave a release/ship-approved=success on the PR head
+                // that branch protection might honor for a subsequent manual merge.
+                $this->retractApprovalStatus($target->repo, $stepReadiness->headRefOid, $e->getMessage());
                 $steps[] = $this->blockedStep(
                     $target,
                     $snapshot->number,
@@ -386,9 +390,23 @@ final readonly class ShipReleaseOrchestrator
         if (!$conductorJustMerged && !$conductorPreviouslyMerged) {
             return null;
         }
-        $fresh = $conductorJustMerged
-            ? $this->awaitDownstreamUpdate($target, $current)
-            : $this->api->findByHead($target->repo, $target->branch);
+        if ($conductorJustMerged) {
+            $fresh = $this->awaitDownstreamUpdate($target, $current);
+            if ($fresh instanceof PullRequestSnapshot && $fresh->headRefOid === $current->headRefOid) {
+                // Timed out waiting for the docs PR to be re-rendered. The
+                // DRAFT→FINAL flip hasn't landed; merging now would ship
+                // stale docs content. Block — operator re-runs once the
+                // downstream workflow completes.
+                $reason = sprintf(
+                    'docs PR head SHA did not change after conductor merge (timed out waiting for downstream'
+                    . ' re-render — head still %s)',
+                    $current->headRefOid,
+                );
+                return [$fresh, null, $reason, [$reason]];
+            }
+        } else {
+            $fresh = $this->api->findByHead($target->repo, $target->branch);
+        }
         if (!$fresh instanceof PullRequestSnapshot) {
             return [null, null, 'docs PR disappeared before merge', ['docs PR disappeared before merge']];
         }
@@ -437,6 +455,23 @@ final readonly class ShipReleaseOrchestrator
             $out[] = $this->notReachedStep($target, 'fatal precondition');
         }
         return $out;
+    }
+
+    private function retractApprovalStatus(string $repo, string $sha, string $reason): void
+    {
+        try {
+            $this->api->postCommitStatus(
+                $repo,
+                $sha,
+                self::STATUS_CONTEXT,
+                'failure',
+                'ship-release failed: ' . substr($reason, 0, 100),
+                $this->statusTargetUrl,
+            );
+        } catch (\RuntimeException) {
+            // Best-effort. If the retraction itself fails, we still surface
+            // the original failure via ShipReleaseStepResult.
+        }
     }
 
     private function notReachedStep(PullRequestTarget $target, string $reason): ShipReleaseStepResult

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -122,7 +122,7 @@ final readonly class ShipReleaseOrchestrator
                 $blocked[$key] = ['no PR found for branch ' . $target->branch];
                 continue;
             }
-            if ($snapshot->isClosedWithoutMerging()) {
+            if ($snapshot->isClosed()) {
                 $blocked[$key] = [sprintf(
                     'PR #%d is CLOSED without being merged — refusing to ship a closed PR',
                     $snapshot->number,
@@ -263,7 +263,7 @@ final readonly class ShipReleaseOrchestrator
             $stepReadiness = $readiness[$target->roleLabel->value] ?? null;
             if ($target->roleLabel === RoleLabel::Docs) {
                 $refresh = $this->refreshDocsBeforeMerge($target, $snapshot, $snapshots, $mergedThisRun);
-                if ($refresh instanceof \OpenEMR\Release\DocsRefreshResult) {
+                if ($refresh instanceof DocsRefreshResult) {
                     if (!$refresh->isSuccess()) {
                         $steps[] = $this->blockedStep($target, $refresh->snapshot?->number, $refresh->blockingReasons);
                         $stopReason = $refresh->stopReason;

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -28,6 +28,7 @@ final readonly class ShipReleaseOrchestrator
     public const STATUS_CONTEXT = 'release/ship-approved';
     public const STATUS_DESCRIPTION = 'Approved by ship-release workflow';
     private const POLL_INTERVAL_SECONDS = 15;
+    private const STATUS_DESCRIPTION_MAX = 140;
 
     public function __construct(
         private PullRequestApi $api,
@@ -93,7 +94,7 @@ final readonly class ShipReleaseOrchestrator
     {
         $out = [];
         foreach ($targets as $target) {
-            $out[$target->roleLabel] = $this->api->findByHead($target->repo, $target->branch);
+            $out[$target->roleLabel->value] = $this->api->findByHead($target->repo, $target->branch);
         }
         return $out;
     }
@@ -115,13 +116,21 @@ final readonly class ShipReleaseOrchestrator
         $readiness = [];
         $blocked = [];
         foreach ($targets as $target) {
-            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            $key = $target->roleLabel->value;
+            $snapshot = $snapshots[$key] ?? null;
             if ($snapshot === null) {
-                $blocked[$target->roleLabel] = ['no PR found for branch ' . $target->branch];
+                $blocked[$key] = ['no PR found for branch ' . $target->branch];
+                continue;
+            }
+            if ($snapshot->isClosedWithoutMerging()) {
+                $blocked[$key] = [sprintf(
+                    'PR #%d is CLOSED without being merged — refusing to ship a closed PR',
+                    $snapshot->number,
+                )];
                 continue;
             }
             if ($snapshot->baseRefName !== $target->expectedBase) {
-                $blocked[$target->roleLabel] = [sprintf(
+                $blocked[$key] = [sprintf(
                     'PR base is %s, expected %s — refusing to merge a PR opened against the wrong base',
                     $snapshot->baseRefName,
                     $target->expectedBase,
@@ -132,15 +141,16 @@ final readonly class ShipReleaseOrchestrator
                 continue;
             }
             $check = $this->api->getReadiness($target->repo, $snapshot->number);
-            $readiness[$target->roleLabel] = $check;
+            $readiness[$key] = $check;
             if (!$check->isReady()) {
-                $blocked[$target->roleLabel] = $check->blockingReasons;
+                $blocked[$key] = $check->blockingReasons;
             }
         }
 
         $steps = [];
         foreach ($targets as $target) {
-            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            $key = $target->roleLabel->value;
+            $snapshot = $snapshots[$key] ?? null;
             if ($snapshot !== null && $snapshot->isMerged()) {
                 $steps[] = new ShipReleaseStepResult(
                     $target,
@@ -151,13 +161,13 @@ final readonly class ShipReleaseOrchestrator
                 );
                 continue;
             }
-            if (isset($blocked[$target->roleLabel])) {
+            if (isset($blocked[$key])) {
                 $steps[] = new ShipReleaseStepResult(
                     $target,
                     ShipReleaseStepStatus::BLOCKED,
                     $snapshot?->number,
                     null,
-                    $blocked[$target->roleLabel],
+                    $blocked[$key],
                 );
                 continue;
             }
@@ -188,7 +198,7 @@ final readonly class ShipReleaseOrchestrator
     {
         $steps = [];
         foreach ($targets as $target) {
-            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            $snapshot = $snapshots[$target->roleLabel->value] ?? null;
             if ($snapshot !== null && $snapshot->isMerged()) {
                 $steps[] = new ShipReleaseStepResult(
                     $target,
@@ -232,11 +242,11 @@ final readonly class ShipReleaseOrchestrator
                 continue;
             }
 
-            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            $snapshot = $snapshots[$target->roleLabel->value] ?? null;
             // Preflight already filtered missing PRs.
             if ($snapshot === null) {
                 $steps[] = $this->blockedStep($target, null, ['no PR found for branch ' . $target->branch]);
-                $stopReason = sprintf('%s PR is missing', $target->roleLabel);
+                $stopReason = sprintf('%s PR is missing', $target->roleLabel->value);
                 continue;
             }
             if ($snapshot->isMerged()) {
@@ -250,36 +260,23 @@ final readonly class ShipReleaseOrchestrator
                 continue;
             }
 
-            // The conductor merge fires repository_dispatch handlers that re-render
-            // the docs PR. Two cases need a fresh state read before merging docs:
-            //   - conductor merged in *this* run: poll until head SHA flips (or
-            //     time out), then re-check readiness against the new SHA.
-            //   - conductor was already merged when we started (recovery case):
-            //     re-check readiness right now in case the previous run's
-            //     downstream re-render is still in flight. Don't poll — if the
-            //     PR isn't ready, fail fast and the operator re-runs.
-            $stepReadiness = $readiness[$target->roleLabel] ?? null;
-            if ($target->roleLabel === 'docs') {
+            $stepReadiness = $readiness[$target->roleLabel->value] ?? null;
+            if ($target->roleLabel === RoleLabel::Docs) {
                 $refresh = $this->refreshDocsBeforeMerge($target, $snapshot, $snapshots, $mergedThisRun);
-                if ($refresh !== null) {
-                    [$refreshedSnapshot, $refreshedReadiness, $refreshStopReason, $blockingReasons] = $refresh;
-                    if ($refreshStopReason !== null) {
-                        $steps[] = $this->blockedStep($target, $refreshedSnapshot?->number, $blockingReasons);
-                        $stopReason = $refreshStopReason;
+                if ($refresh instanceof \OpenEMR\Release\DocsRefreshResult) {
+                    if (!$refresh->isSuccess()) {
+                        $steps[] = $this->blockedStep($target, $refresh->snapshot?->number, $refresh->blockingReasons);
+                        $stopReason = $refresh->stopReason;
                         continue;
                     }
-                    // refresh succeeded — both fields are guaranteed non-null
-                    if (!$refreshedSnapshot instanceof PullRequestSnapshot || $refreshedReadiness === null) {
-                        throw new \LogicException('refreshDocsBeforeMerge returned inconsistent tuple');
-                    }
-                    $snapshot = $refreshedSnapshot;
-                    $stepReadiness = $refreshedReadiness;
+                    $snapshot = $refresh->snapshot;
+                    $stepReadiness = $refresh->readiness;
                 }
             }
 
-            if ($stepReadiness === null) {
+            if ($snapshot === null || $stepReadiness === null) {
                 throw new \LogicException(
-                    "ship-release: missing preflight readiness for {$target->roleLabel}",
+                    "ship-release: missing snapshot or readiness for {$target->roleLabel->value}",
                 );
             }
 
@@ -303,7 +300,7 @@ final readonly class ShipReleaseOrchestrator
                     $snapshot->number,
                     [sprintf('gh call failed: %s', $e->getMessage())],
                 );
-                $stopReason = sprintf('%s merge failed', $target->roleLabel);
+                $stopReason = sprintf('%s merge failed', $target->roleLabel->value);
                 continue;
             }
             $steps[] = new ShipReleaseStepResult(
@@ -325,16 +322,16 @@ final readonly class ShipReleaseOrchestrator
      */
     private function detectDocsFirst(array $targets, array $snapshots): ?string
     {
-        $docs = $snapshots['docs'] ?? null;
-        $conductor = $snapshots['conductor'] ?? null;
+        $docs = $snapshots[RoleLabel::Docs->value] ?? null;
+        $conductor = $snapshots[RoleLabel::Conductor->value] ?? null;
         if ($docs === null || !$docs->isMerged()) {
             return null;
         }
         if ($conductor !== null && $conductor->isMerged()) {
             return null;
         }
-        $conductorTarget = $this->findRequired($targets, 'conductor');
-        $docsTarget = $this->findRequired($targets, 'docs');
+        $conductorTarget = $this->findRequired($targets, RoleLabel::Conductor);
+        $docsTarget = $this->findRequired($targets, RoleLabel::Docs);
         return sprintf(
             'docs PR (%s#%d, branch %s) was merged before conductor PR (%s, branch %s).'
             . ' This is the unrecoverable docs-first case from issue #705 — the docs page'
@@ -350,14 +347,14 @@ final readonly class ShipReleaseOrchestrator
     /**
      * @param list<PullRequestTarget> $targets
      */
-    private function findRequired(array $targets, string $role): PullRequestTarget
+    private function findRequired(array $targets, RoleLabel $role): PullRequestTarget
     {
         foreach ($targets as $target) {
             if ($target->roleLabel === $role) {
                 return $target;
             }
         }
-        throw new \LogicException("ship-release targets list is missing role: {$role}");
+        throw new \LogicException("ship-release targets list is missing role: {$role->value}");
     }
 
     /**
@@ -369,55 +366,47 @@ final readonly class ShipReleaseOrchestrator
      *     is still in flight. Don't poll — if not ready, fail fast and the
      *     operator re-runs.
      *
-     * Returns null when no refresh is needed. Otherwise returns a tuple
-     * [snapshot, readiness, stopReason, blockingReasons]:
-     *   - on success, snapshot + readiness are non-null and stopReason is null
-     *   - on failure, stopReason is non-null and blockingReasons populated;
-     *     snapshot may be null if the PR has disappeared
+     * Returns null when no refresh is needed.
      *
-     * @param  array<string, ?PullRequestSnapshot> $snapshots
-     * @param  list<string>                        $mergedThisRun
-     * @return array{0: ?PullRequestSnapshot, 1: ?PullRequestReadiness, 2: ?string, 3: list<string>}|null
+     * @param array<string, ?PullRequestSnapshot> $snapshots
+     * @param list<RoleLabel>                     $mergedThisRun
      */
     private function refreshDocsBeforeMerge(
         PullRequestTarget $target,
         PullRequestSnapshot $current,
         array $snapshots,
         array $mergedThisRun,
-    ): ?array {
-        $conductorJustMerged = in_array('conductor', $mergedThisRun, true);
-        $conductorPreviouslyMerged = ($snapshots['conductor'] ?? null)?->isMerged() ?? false;
+    ): ?DocsRefreshResult {
+        $conductorJustMerged = in_array(RoleLabel::Conductor, $mergedThisRun, true);
+        $conductorPreviouslyMerged = ($snapshots[RoleLabel::Conductor->value] ?? null)?->isMerged() ?? false;
         if (!$conductorJustMerged && !$conductorPreviouslyMerged) {
             return null;
         }
         if ($conductorJustMerged) {
             $fresh = $this->awaitDownstreamUpdate($target, $current);
             if ($fresh instanceof PullRequestSnapshot && $fresh->headRefOid === $current->headRefOid) {
-                // Timed out waiting for the docs PR to be re-rendered. The
-                // DRAFT→FINAL flip hasn't landed; merging now would ship
-                // stale docs content. Block — operator re-runs once the
-                // downstream workflow completes.
                 $reason = sprintf(
                     'docs PR head SHA did not change after conductor merge (timed out waiting for downstream'
                     . ' re-render — head still %s)',
                     $current->headRefOid,
                 );
-                return [$fresh, null, $reason, [$reason]];
+                return DocsRefreshResult::blocked($fresh, $reason, [$reason]);
             }
         } else {
             $fresh = $this->api->findByHead($target->repo, $target->branch);
         }
         if (!$fresh instanceof PullRequestSnapshot) {
-            return [null, null, 'docs PR disappeared before merge', ['docs PR disappeared before merge']];
+            $disappeared = 'docs PR disappeared before merge';
+            return DocsRefreshResult::blocked(null, $disappeared, [$disappeared]);
         }
         $readiness = $this->api->getReadiness($target->repo, $fresh->number);
         if (!$readiness->isReady()) {
             $stopReason = $conductorJustMerged
                 ? 'docs PR not ready after conductor downstream update'
                 : 'docs PR not ready (re-checked after conductor was already merged)';
-            return [$fresh, null, $stopReason, $readiness->blockingReasons];
+            return DocsRefreshResult::blocked($fresh, $stopReason, $readiness->blockingReasons);
         }
-        return [$fresh, $readiness, null, []];
+        return DocsRefreshResult::success($fresh, $readiness);
     }
 
     /**
@@ -459,13 +448,16 @@ final readonly class ShipReleaseOrchestrator
 
     private function retractApprovalStatus(string $repo, string $sha, string $reason): void
     {
+        $prefix = 'ship-release failed: ';
+        $room = self::STATUS_DESCRIPTION_MAX - mb_strlen($prefix);
+        $description = $prefix . mb_substr($reason, 0, $room);
         try {
             $this->api->postCommitStatus(
                 $repo,
                 $sha,
                 self::STATUS_CONTEXT,
                 'failure',
-                'ship-release failed: ' . substr($reason, 0, 100),
+                $description,
                 $this->statusTargetUrl,
             );
         } catch (\RuntimeException) {

--- a/tools/release/src/ShipReleaseOrchestrator.php
+++ b/tools/release/src/ShipReleaseOrchestrator.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * Merges the three release PRs (infra → conductor → docs) in strict order.
+ *
+ * Skips PRs already merged so the same trigger handles partial-merge recovery.
+ * Stops at the first non-ready PR without merging, so a half-finished release
+ * never originates here. Detects the one unrecoverable case — docs merged
+ * before conductor — and refuses to do anything; that recovery is documented
+ * in the runbook (see issue #705).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseOrchestrator
+{
+    public const STATUS_CONTEXT = 'release/ship-approved';
+    public const STATUS_DESCRIPTION = 'Approved by ship-release workflow';
+    private const POLL_INTERVAL_SECONDS = 15;
+
+    public function __construct(
+        private PullRequestApi $api,
+        private Clock $clock,
+        private int $downstreamTimeoutSeconds = 600,
+        private bool $dryRun = false,
+        private string $statusTargetUrl = '',
+    ) {
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets infra → conductor → docs (sorted by mergeOrder)
+     */
+    public function ship(array $targets): ShipReleaseResult
+    {
+        $snapshots = $this->snapshotAll($targets);
+
+        $fatal = $this->detectDocsFirst($targets, $snapshots);
+        if ($fatal !== null) {
+            return new ShipReleaseResult(
+                $this->markAllNotReached($targets),
+                $fatal,
+            );
+        }
+
+        $steps = [];
+        $stopReason = null;
+        $mergedThisRun = [];
+
+        foreach ($targets as $target) {
+            if ($stopReason !== null) {
+                $steps[] = $this->notReachedStep($target, $stopReason);
+                continue;
+            }
+
+            // The conductor's merge fires repository_dispatch handlers that
+            // re-render the docs PR. Wait for that effect to land (or time
+            // out), then re-snapshot before deciding readiness.
+            if (
+                $target->roleLabel === 'docs'
+                && in_array('conductor', $mergedThisRun, true)
+            ) {
+                $snapshots[$target->roleLabel] = $this->awaitDownstreamUpdate(
+                    $target,
+                    $snapshots[$target->roleLabel] ?? null,
+                );
+            }
+
+            $snapshot = $snapshots[$target->roleLabel] ?? null;
+            if ($snapshot === null) {
+                $steps[] = $this->blockedStep($target, null, ['no PR found for branch ' . $target->branch]);
+                $stopReason = sprintf('%s PR is missing', $target->roleLabel);
+                continue;
+            }
+            if ($snapshot->isMerged()) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+
+            $readiness = $this->api->getReadiness($target->repo, $snapshot->number);
+            if (!$readiness->isReady()) {
+                $steps[] = $this->blockedStep($target, $snapshot->number, $readiness->blockingReasons);
+                $stopReason = sprintf('%s PR is not ready', $target->roleLabel);
+                continue;
+            }
+
+            if ($this->dryRun) {
+                $steps[] = new ShipReleaseStepResult(
+                    $target,
+                    ShipReleaseStepStatus::WOULD_MERGE,
+                    $snapshot->number,
+                    null,
+                    [],
+                );
+                continue;
+            }
+
+            $this->api->postCommitStatus(
+                $target->repo,
+                $readiness->headRefOid,
+                self::STATUS_CONTEXT,
+                'success',
+                self::STATUS_DESCRIPTION,
+                $this->statusTargetUrl,
+            );
+            $mergeSha = $this->api->squashMerge(
+                $target->repo,
+                $snapshot->number,
+                $readiness->headRefOid,
+            );
+            $steps[] = new ShipReleaseStepResult(
+                $target,
+                ShipReleaseStepStatus::MERGED,
+                $snapshot->number,
+                $mergeSha,
+                [],
+            );
+            $mergedThisRun[] = $target->roleLabel;
+        }
+
+        return new ShipReleaseResult($steps);
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets
+     * @return array<string, ?PullRequestSnapshot>
+     */
+    private function snapshotAll(array $targets): array
+    {
+        $out = [];
+        foreach ($targets as $target) {
+            $out[$target->roleLabel] = $this->api->findByHead($target->repo, $target->branch);
+        }
+        return $out;
+    }
+
+    /**
+     * @param list<PullRequestTarget>             $targets
+     * @param array<string, ?PullRequestSnapshot> $snapshots
+     */
+    private function detectDocsFirst(array $targets, array $snapshots): ?string
+    {
+        $docs = $snapshots['docs'] ?? null;
+        $conductor = $snapshots['conductor'] ?? null;
+        if ($docs === null || !$docs->isMerged()) {
+            return null;
+        }
+        if ($conductor !== null && $conductor->isMerged()) {
+            return null;
+        }
+        $conductorTarget = $this->findRequired($targets, 'conductor');
+        $docsTarget = $this->findRequired($targets, 'docs');
+        return sprintf(
+            'docs PR (%s#%d, branch %s) was merged before conductor PR (%s, branch %s).'
+            . ' This is the unrecoverable docs-first case from issue #705 — the docs page'
+            . ' shipped FINAL with no tag. See the release runbook for manual reconciliation.',
+            $docsTarget->repo,
+            $docs->number,
+            $docsTarget->branch,
+            $conductorTarget->repo,
+            $conductorTarget->branch,
+        );
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets
+     */
+    private function findRequired(array $targets, string $role): PullRequestTarget
+    {
+        foreach ($targets as $target) {
+            if ($target->roleLabel === $role) {
+                return $target;
+            }
+        }
+        throw new \LogicException("ship-release targets list is missing role: {$role}");
+    }
+
+    /**
+     * Poll until the docs PR head SHA differs from the snapshot taken before
+     * the conductor merge, or until the timeout elapses. Either way, return a
+     * fresh snapshot — readiness is re-checked after this.
+     */
+    private function awaitDownstreamUpdate(
+        PullRequestTarget $target,
+        ?PullRequestSnapshot $before,
+    ): ?PullRequestSnapshot {
+        if (!$before instanceof \OpenEMR\Release\PullRequestSnapshot) {
+            return null;
+        }
+        $deadline = $this->clock->now()->getTimestamp() + $this->downstreamTimeoutSeconds;
+        $current = $before;
+        while ($this->clock->now()->getTimestamp() < $deadline) {
+            $current = $this->api->findByHead($target->repo, $target->branch);
+            if (!$current instanceof \OpenEMR\Release\PullRequestSnapshot) {
+                return null;
+            }
+            if ($current->headRefOid !== $before->headRefOid) {
+                return $current;
+            }
+            $this->clock->sleep(self::POLL_INTERVAL_SECONDS);
+        }
+        return $current;
+    }
+
+    /**
+     * @param list<PullRequestTarget> $targets
+     * @return list<ShipReleaseStepResult>
+     */
+    private function markAllNotReached(array $targets): array
+    {
+        $out = [];
+        foreach ($targets as $target) {
+            $out[] = $this->notReachedStep($target, 'fatal precondition');
+        }
+        return $out;
+    }
+
+    private function notReachedStep(PullRequestTarget $target, string $reason): ShipReleaseStepResult
+    {
+        return new ShipReleaseStepResult(
+            $target,
+            ShipReleaseStepStatus::NOT_REACHED,
+            null,
+            null,
+            [$reason],
+        );
+    }
+
+    /**
+     * @param list<string> $reasons
+     */
+    private function blockedStep(PullRequestTarget $target, ?int $number, array $reasons): ShipReleaseStepResult
+    {
+        return new ShipReleaseStepResult(
+            $target,
+            ShipReleaseStepStatus::BLOCKED,
+            $number,
+            null,
+            $reasons,
+        );
+    }
+}

--- a/tools/release/src/ShipReleaseRenderer.php
+++ b/tools/release/src/ShipReleaseRenderer.php
@@ -25,7 +25,7 @@ final readonly class ShipReleaseRenderer
             $output->writeln('<error>✗ fatal:</error> ' . $result->fatalReason);
         }
         foreach ($result->steps as $step) {
-            $tag = sprintf('[%s] %s', $step->target->roleLabel, $step->target->repo);
+            $tag = sprintf('[%s] %s', $step->target->roleLabel->value, $step->target->repo);
             $pr = $step->prNumber !== null ? '#' . $step->prNumber : '(no PR)';
             self::renderStep($output, $step, $tag, $pr);
         }

--- a/tools/release/src/ShipReleaseRenderer.php
+++ b/tools/release/src/ShipReleaseRenderer.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Symfony Console rendering for ShipReleaseResult. Kept separate so the CLI
+ * file declares no helper functions (PSR1 side-effects-vs-symbols).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+final readonly class ShipReleaseRenderer
+{
+    public static function render(OutputInterface $output, ShipReleaseResult $result): void
+    {
+        if ($result->fatalReason !== null) {
+            $output->writeln('<error>✗ fatal:</error> ' . $result->fatalReason);
+        }
+        foreach ($result->steps as $step) {
+            $tag = sprintf('[%s] %s', $step->target->roleLabel, $step->target->repo);
+            $pr = $step->prNumber !== null ? '#' . $step->prNumber : '(no PR)';
+            self::renderStep($output, $step, $tag, $pr);
+        }
+    }
+
+    private static function renderStep(
+        OutputInterface $output,
+        ShipReleaseStepResult $step,
+        string $tag,
+        string $pr,
+    ): void {
+        switch ($step->status) {
+            case ShipReleaseStepStatus::MERGED:
+                $output->writeln(sprintf(
+                    '<info>✓ merged</info>   %s %s → %s',
+                    $tag,
+                    $pr,
+                    $step->mergeSha ?? '?',
+                ));
+                return;
+            case ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED:
+                $output->writeln(sprintf('<comment>↷ skipped</comment> %s %s (already merged)', $tag, $pr));
+                return;
+            case ShipReleaseStepStatus::WOULD_MERGE:
+                $output->writeln(sprintf('<info>✓ ready</info>    %s %s (dry-run: would merge)', $tag, $pr));
+                return;
+            case ShipReleaseStepStatus::BLOCKED:
+                $output->writeln(sprintf('<error>✗ blocked</error>  %s %s', $tag, $pr));
+                foreach ($step->reasons as $reason) {
+                    $output->writeln('    - ' . $reason);
+                }
+                return;
+            case ShipReleaseStepStatus::NOT_REACHED:
+                $output->writeln(sprintf('<comment>· skipped</comment>  %s %s (not reached)', $tag, $pr));
+        }
+    }
+}

--- a/tools/release/src/ShipReleaseResult.php
+++ b/tools/release/src/ShipReleaseResult.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Aggregated outcome of a ship-release run.
+ *
+ * Successful when every step is MERGED, SKIPPED_ALREADY_MERGED, or WOULD_MERGE
+ * (dry-run) AND no fatal reason was recorded. A BLOCKED, NOT_REACHED, or
+ * fatalReason makes the run a failure.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseResult
+{
+    /**
+     * @param list<ShipReleaseStepResult> $steps
+     */
+    public function __construct(
+        public array $steps,
+        public ?string $fatalReason = null,
+    ) {
+    }
+
+    public function wasSuccessful(): bool
+    {
+        if ($this->fatalReason !== null) {
+            return false;
+        }
+        $successful = [
+            ShipReleaseStepStatus::MERGED,
+            ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED,
+            ShipReleaseStepStatus::WOULD_MERGE,
+        ];
+        foreach ($this->steps as $step) {
+            if (!in_array($step->status, $successful, true)) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/tools/release/src/ShipReleaseStepResult.php
+++ b/tools/release/src/ShipReleaseStepResult.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Per-PR outcome record produced by ShipReleaseOrchestrator.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class ShipReleaseStepResult
+{
+    /**
+     * @param list<string> $reasons
+     */
+    public function __construct(
+        public PullRequestTarget $target,
+        public ShipReleaseStepStatus $status,
+        public ?int $prNumber,
+        public ?string $mergeSha,
+        public array $reasons,
+    ) {
+    }
+}

--- a/tools/release/src/ShipReleaseStepStatus.php
+++ b/tools/release/src/ShipReleaseStepStatus.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Outcome of one step (one PR) in the ship-release orchestration.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+enum ShipReleaseStepStatus: string
+{
+    case SKIPPED_ALREADY_MERGED = 'skipped_already_merged';
+    case MERGED = 'merged';
+    case BLOCKED = 'blocked';
+    case WOULD_MERGE = 'would_merge';
+    case NOT_REACHED = 'not_reached';
+}

--- a/tools/release/src/SystemClock.php
+++ b/tools/release/src/SystemClock.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Production Clock that calls real PHP time/sleep.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class SystemClock implements Clock
+{
+    public function now(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable();
+    }
+
+    public function sleep(int $seconds): void
+    {
+        if ($seconds > 0) {
+            sleep($seconds);
+        }
+    }
+}

--- a/tools/release/tests/Fakes/FailingMergeApi.php
+++ b/tools/release/tests/Fakes/FailingMergeApi.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * FakePullRequestApi variant that throws on squashMerge for one specific PR.
+ * Used to verify the orchestrator catches gh failures per-step.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests\Fakes;
+
+final class FailingMergeApi extends FakePullRequestApi
+{
+    public function __construct(
+        private readonly string $failRepo,
+        private readonly int $failNumber,
+        private readonly string $failMessage,
+    ) {
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        if ($repo === $this->failRepo && $number === $this->failNumber) {
+            throw new \RuntimeException($this->failMessage);
+        }
+        return parent::squashMerge($repo, $number, $expectedHeadSha);
+    }
+}

--- a/tools/release/tests/Fakes/FakeClock.php
+++ b/tools/release/tests/Fakes/FakeClock.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Deterministic Clock for orchestrator tests.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests\Fakes;
+
+use OpenEMR\Release\Clock;
+
+final class FakeClock implements Clock
+{
+    private \DateTimeImmutable $current;
+
+    public int $totalSlept = 0;
+
+    public function __construct(?\DateTimeImmutable $start = null)
+    {
+        $this->current = $start ?? new \DateTimeImmutable('2026-01-01T00:00:00Z');
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->current;
+    }
+
+    public function sleep(int $seconds): void
+    {
+        $this->totalSlept += $seconds;
+        $this->current = $this->current->modify("+{$seconds} seconds");
+    }
+}

--- a/tools/release/tests/Fakes/FakePullRequestApi.php
+++ b/tools/release/tests/Fakes/FakePullRequestApi.php
@@ -26,6 +26,9 @@ final class FakePullRequestApi implements PullRequestApi
     /** @var array<int, PullRequestReadiness> */
     private array $readinessByNumber = [];
 
+    /** @var array<int, list<PullRequestReadiness>> per-number queue, consumed left-to-right */
+    private array $readinessQueue = [];
+
     /** @var array<int, string> merge SHAs by PR number */
     private array $mergeShas = [];
 
@@ -64,6 +67,17 @@ final class FakePullRequestApi implements PullRequestApi
         $this->readinessByNumber[$number] = $readiness;
     }
 
+    /**
+     * Each call to getReadiness() for $number consumes one entry. Once exhausted,
+     * the last entry is returned for subsequent calls.
+     *
+     * @param list<PullRequestReadiness> $sequence
+     */
+    public function setReadinessSequence(int $number, array $sequence): void
+    {
+        $this->readinessQueue[$number] = $sequence;
+    }
+
     public function setMergeSha(int $number, string $sha): void
     {
         $this->mergeShas[$number] = $sha;
@@ -82,6 +96,11 @@ final class FakePullRequestApi implements PullRequestApi
 
     public function getReadiness(string $repo, int $number): PullRequestReadiness
     {
+        if (isset($this->readinessQueue[$number]) && $this->readinessQueue[$number] !== []) {
+            $next = array_shift($this->readinessQueue[$number]);
+            $this->readinessByNumber[$number] = $next;
+            return $next;
+        }
         if (!isset($this->readinessByNumber[$number])) {
             throw new \RuntimeException("No readiness configured for PR #{$number}");
         }

--- a/tools/release/tests/Fakes/FakePullRequestApi.php
+++ b/tools/release/tests/Fakes/FakePullRequestApi.php
@@ -35,7 +35,7 @@ final class FakePullRequestApi implements PullRequestApi
     /** @var list<array{repo: string, number: int, expected: string}> */
     public array $merges = [];
 
-    /** @var array<string, PullRequestSnapshot> snapshots installed by setSnapshotAfterFind() */
+    /** @var array<string, PullRequestSnapshot> snapshots installed by setSnapshotAfterFinds() */
     private array $snapshotAfterFind = [];
 
     /** @var array<string, int> */

--- a/tools/release/tests/Fakes/FakePullRequestApi.php
+++ b/tools/release/tests/Fakes/FakePullRequestApi.php
@@ -3,6 +3,10 @@
 /**
  * In-memory PullRequestApi for orchestrator tests.
  *
+ * Readiness and merge SHAs are keyed by "repo#number" so PR-number collisions
+ * across repos (entirely possible — PR numbers are per-repo on GitHub) don't
+ * silently mask cross-repo bugs in the orchestrator.
+ *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
  * @author    Michael A. Smith <michael@opencoreemr.com>
@@ -18,18 +22,18 @@ use OpenEMR\Release\PullRequestApi;
 use OpenEMR\Release\PullRequestReadiness;
 use OpenEMR\Release\PullRequestSnapshot;
 
-final class FakePullRequestApi implements PullRequestApi
+class FakePullRequestApi implements PullRequestApi
 {
     /** @var array<string, ?PullRequestSnapshot> */
     private array $snapshotsByKey = [];
 
-    /** @var array<int, PullRequestReadiness> */
-    private array $readinessByNumber = [];
+    /** @var array<string, PullRequestReadiness> keyed by "repo#number" */
+    private array $readinessByPr = [];
 
-    /** @var array<int, list<PullRequestReadiness>> per-number queue, consumed left-to-right */
+    /** @var array<string, list<PullRequestReadiness>> per-PR queue, consumed left-to-right */
     private array $readinessQueue = [];
 
-    /** @var array<int, string> merge SHAs by PR number */
+    /** @var array<string, string> merge SHAs by "repo#number" */
     private array $mergeShas = [];
 
     /** @var list<array{repo: string, sha: string, context: string, state: string}> */
@@ -46,7 +50,7 @@ final class FakePullRequestApi implements PullRequestApi
 
     public function setSnapshot(string $repo, string $branch, ?PullRequestSnapshot $snapshot): void
     {
-        $this->snapshotsByKey[$this->key($repo, $branch)] = $snapshot;
+        $this->snapshotsByKey[$this->branchKey($repo, $branch)] = $snapshot;
     }
 
     /**
@@ -59,33 +63,33 @@ final class FakePullRequestApi implements PullRequestApi
         int $afterNCalls,
         PullRequestSnapshot $snapshot,
     ): void {
-        $this->snapshotAfterFind[$this->key($repo, $branch) . '|' . $afterNCalls] = $snapshot;
+        $this->snapshotAfterFind[$this->branchKey($repo, $branch) . '|' . $afterNCalls] = $snapshot;
     }
 
-    public function setReadiness(int $number, PullRequestReadiness $readiness): void
+    public function setReadiness(string $repo, int $number, PullRequestReadiness $readiness): void
     {
-        $this->readinessByNumber[$number] = $readiness;
+        $this->readinessByPr[$this->prKey($repo, $number)] = $readiness;
     }
 
     /**
-     * Each call to getReadiness() for $number consumes one entry. Once exhausted,
+     * Each call to getReadiness() for $repo#$number consumes one entry. Once exhausted,
      * the last entry is returned for subsequent calls.
      *
      * @param list<PullRequestReadiness> $sequence
      */
-    public function setReadinessSequence(int $number, array $sequence): void
+    public function setReadinessSequence(string $repo, int $number, array $sequence): void
     {
-        $this->readinessQueue[$number] = $sequence;
+        $this->readinessQueue[$this->prKey($repo, $number)] = $sequence;
     }
 
-    public function setMergeSha(int $number, string $sha): void
+    public function setMergeSha(string $repo, int $number, string $sha): void
     {
-        $this->mergeShas[$number] = $sha;
+        $this->mergeShas[$this->prKey($repo, $number)] = $sha;
     }
 
     public function findByHead(string $repo, string $branch): ?PullRequestSnapshot
     {
-        $key = $this->key($repo, $branch);
+        $key = $this->branchKey($repo, $branch);
         $this->findCalls[$key] = ($this->findCalls[$key] ?? 0) + 1;
         $swap = $this->snapshotAfterFind[$key . '|' . $this->findCalls[$key]] ?? null;
         if ($swap !== null) {
@@ -96,15 +100,16 @@ final class FakePullRequestApi implements PullRequestApi
 
     public function getReadiness(string $repo, int $number): PullRequestReadiness
     {
-        if (isset($this->readinessQueue[$number]) && $this->readinessQueue[$number] !== []) {
-            $next = array_shift($this->readinessQueue[$number]);
-            $this->readinessByNumber[$number] = $next;
+        $key = $this->prKey($repo, $number);
+        if (isset($this->readinessQueue[$key]) && $this->readinessQueue[$key] !== []) {
+            $next = array_shift($this->readinessQueue[$key]);
+            $this->readinessByPr[$key] = $next;
             return $next;
         }
-        if (!isset($this->readinessByNumber[$number])) {
-            throw new \RuntimeException("No readiness configured for PR #{$number}");
+        if (!isset($this->readinessByPr[$key])) {
+            throw new \RuntimeException("No readiness configured for {$key}");
         }
-        return $this->readinessByNumber[$number];
+        return $this->readinessByPr[$key];
     }
 
     public function postCommitStatus(
@@ -126,11 +131,16 @@ final class FakePullRequestApi implements PullRequestApi
     public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
     {
         $this->merges[] = ['repo' => $repo, 'number' => $number, 'expected' => $expectedHeadSha];
-        return $this->mergeShas[$number] ?? "merge-sha-{$number}";
+        return $this->mergeShas[$this->prKey($repo, $number)] ?? "merge-sha-{$number}";
     }
 
-    private function key(string $repo, string $branch): string
+    private function branchKey(string $repo, string $branch): string
     {
         return $repo . '|' . $branch;
+    }
+
+    private function prKey(string $repo, int $number): string
+    {
+        return $repo . '#' . $number;
     }
 }

--- a/tools/release/tests/Fakes/FakePullRequestApi.php
+++ b/tools/release/tests/Fakes/FakePullRequestApi.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * In-memory PullRequestApi for orchestrator tests.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests\Fakes;
+
+use OpenEMR\Release\PullRequestApi;
+use OpenEMR\Release\PullRequestReadiness;
+use OpenEMR\Release\PullRequestSnapshot;
+
+final class FakePullRequestApi implements PullRequestApi
+{
+    /** @var array<string, ?PullRequestSnapshot> */
+    private array $snapshotsByKey = [];
+
+    /** @var array<int, PullRequestReadiness> */
+    private array $readinessByNumber = [];
+
+    /** @var array<int, string> merge SHAs by PR number */
+    private array $mergeShas = [];
+
+    /** @var list<array{repo: string, sha: string, context: string, state: string}> */
+    public array $postedStatuses = [];
+
+    /** @var list<array{repo: string, number: int, expected: string}> */
+    public array $merges = [];
+
+    /** @var array<string, PullRequestSnapshot> snapshots installed by setSnapshotAfterFind() */
+    private array $snapshotAfterFind = [];
+
+    /** @var array<string, int> */
+    private array $findCalls = [];
+
+    public function setSnapshot(string $repo, string $branch, ?PullRequestSnapshot $snapshot): void
+    {
+        $this->snapshotsByKey[$this->key($repo, $branch)] = $snapshot;
+    }
+
+    /**
+     * After the Nth call to findByHead for this repo+branch, swap to a new snapshot.
+     * Used to simulate the docs PR being re-rendered by the conductor merge.
+     */
+    public function setSnapshotAfterFinds(
+        string $repo,
+        string $branch,
+        int $afterNCalls,
+        PullRequestSnapshot $snapshot,
+    ): void {
+        $this->snapshotAfterFind[$this->key($repo, $branch) . '|' . $afterNCalls] = $snapshot;
+    }
+
+    public function setReadiness(int $number, PullRequestReadiness $readiness): void
+    {
+        $this->readinessByNumber[$number] = $readiness;
+    }
+
+    public function setMergeSha(int $number, string $sha): void
+    {
+        $this->mergeShas[$number] = $sha;
+    }
+
+    public function findByHead(string $repo, string $branch): ?PullRequestSnapshot
+    {
+        $key = $this->key($repo, $branch);
+        $this->findCalls[$key] = ($this->findCalls[$key] ?? 0) + 1;
+        $swap = $this->snapshotAfterFind[$key . '|' . $this->findCalls[$key]] ?? null;
+        if ($swap !== null) {
+            $this->snapshotsByKey[$key] = $swap;
+        }
+        return $this->snapshotsByKey[$key] ?? null;
+    }
+
+    public function getReadiness(string $repo, int $number): PullRequestReadiness
+    {
+        if (!isset($this->readinessByNumber[$number])) {
+            throw new \RuntimeException("No readiness configured for PR #{$number}");
+        }
+        return $this->readinessByNumber[$number];
+    }
+
+    public function postCommitStatus(
+        string $repo,
+        string $sha,
+        string $context,
+        string $state,
+        string $description,
+        string $targetUrl,
+    ): void {
+        $this->postedStatuses[] = [
+            'repo' => $repo,
+            'sha' => $sha,
+            'context' => $context,
+            'state' => $state,
+        ];
+    }
+
+    public function squashMerge(string $repo, int $number, string $expectedHeadSha): string
+    {
+        $this->merges[] = ['repo' => $repo, 'number' => $number, 'expected' => $expectedHeadSha];
+        return $this->mergeShas[$number] ?? "merge-sha-{$number}";
+    }
+
+    private function key(string $repo, string $branch): string
+    {
+        return $repo . '|' . $branch;
+    }
+}

--- a/tools/release/tests/GhPullRequestApiTest.php
+++ b/tools/release/tests/GhPullRequestApiTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Unit tests for the pure helpers on GhPullRequestApi. The shell-touching
+ * methods are exercised end-to-end through the orchestrator with a fake API.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\GhPullRequestApi;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use PHPUnit\Framework\TestCase;
+
+final class GhPullRequestApiTest extends TestCase
+{
+    public function testRollupSkipsOwnContextEvenWhenItIsFailure(): void
+    {
+        // Regression: a prior ship-release run that failed left
+        // release/ship-approved=failure on the head SHA. The next preflight
+        // must not treat that as a blocking external check.
+        $rollup = [
+            ['context' => 'ci/build', 'state' => 'SUCCESS'],
+            ['context' => ShipReleaseOrchestrator::STATUS_CONTEXT, 'state' => 'FAILURE'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupBlocksOnFailingExternalCheck(): void
+    {
+        $rollup = [
+            ['context' => 'ci/build', 'state' => 'FAILURE'],
+            ['context' => ShipReleaseOrchestrator::STATUS_CONTEXT, 'state' => 'SUCCESS'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('ci/build', $reasons[0]);
+        self::assertStringContainsString('FAILURE', $reasons[0]);
+    }
+
+    public function testRollupBlocksOnPendingCheckRun(): void
+    {
+        $rollup = [
+            ['name' => 'phpstan', 'status' => 'IN_PROGRESS', 'conclusion' => null],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('phpstan', $reasons[0]);
+        self::assertStringContainsString('IN_PROGRESS', $reasons[0]);
+    }
+
+    public function testRollupAllowsNeutralAndSkippedConclusions(): void
+    {
+        $rollup = [
+            ['name' => 'optional-job', 'status' => 'COMPLETED', 'conclusion' => 'NEUTRAL'],
+            ['name' => 'skipped-job', 'status' => 'COMPLETED', 'conclusion' => 'SKIPPED'],
+            ['name' => 'green-job', 'status' => 'COMPLETED', 'conclusion' => 'SUCCESS'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertSame([], $reasons);
+    }
+
+    public function testRollupBlocksOnLegacyExpectedState(): void
+    {
+        $rollup = [
+            ['context' => 'required/check', 'state' => 'EXPECTED'],
+        ];
+
+        $reasons = GhPullRequestApi::reasonsFromStatusRollup($rollup, ShipReleaseOrchestrator::STATUS_CONTEXT);
+
+        self::assertCount(1, $reasons);
+        self::assertStringContainsString('EXPECTED', $reasons[0]);
+    }
+}

--- a/tools/release/tests/PullRequestTargetTest.php
+++ b/tools/release/tests/PullRequestTargetTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\PullRequestTarget;
+use PHPUnit\Framework\TestCase;
+
+final class PullRequestTargetTest extends TestCase
+{
+    public function testForReleaseProducesInfraConductorDocsInOrder(): void
+    {
+        $targets = PullRequestTarget::forRelease('8.1.0', 'rel-810');
+
+        self::assertCount(3, $targets);
+        self::assertSame('infra', $targets[0]->roleLabel);
+        self::assertSame('openemr/openemr-devops', $targets[0]->repo);
+        self::assertSame('release-rotation/auto', $targets[0]->branch);
+        self::assertSame(1, $targets[0]->mergeOrder);
+
+        self::assertSame('conductor', $targets[1]->roleLabel);
+        self::assertSame('openemr/openemr', $targets[1]->repo);
+        self::assertSame('release-prep/rel-810', $targets[1]->branch);
+        self::assertSame(2, $targets[1]->mergeOrder);
+
+        self::assertSame('docs', $targets[2]->roleLabel);
+        self::assertSame('openemr/website-openemr', $targets[2]->repo);
+        self::assertSame('release-docs/8.1.0', $targets[2]->branch);
+        self::assertSame(3, $targets[2]->mergeOrder);
+    }
+}

--- a/tools/release/tests/PullRequestTargetTest.php
+++ b/tools/release/tests/PullRequestTargetTest.php
@@ -25,16 +25,19 @@ final class PullRequestTargetTest extends TestCase
         self::assertSame('infra', $targets[0]->roleLabel);
         self::assertSame('openemr/openemr-devops', $targets[0]->repo);
         self::assertSame('release-rotation/auto', $targets[0]->branch);
+        self::assertSame('master', $targets[0]->expectedBase);
         self::assertSame(1, $targets[0]->mergeOrder);
 
         self::assertSame('conductor', $targets[1]->roleLabel);
         self::assertSame('openemr/openemr', $targets[1]->repo);
         self::assertSame('release-prep/rel-810', $targets[1]->branch);
+        self::assertSame('rel-810', $targets[1]->expectedBase);
         self::assertSame(2, $targets[1]->mergeOrder);
 
         self::assertSame('docs', $targets[2]->roleLabel);
         self::assertSame('openemr/website-openemr', $targets[2]->repo);
         self::assertSame('release-docs/8.1.0', $targets[2]->branch);
+        self::assertSame('master', $targets[2]->expectedBase);
         self::assertSame(3, $targets[2]->mergeOrder);
     }
 }

--- a/tools/release/tests/PullRequestTargetTest.php
+++ b/tools/release/tests/PullRequestTargetTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace OpenEMR\Release\Tests;
 
 use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RoleLabel;
 use PHPUnit\Framework\TestCase;
 
 final class PullRequestTargetTest extends TestCase
@@ -22,19 +23,19 @@ final class PullRequestTargetTest extends TestCase
         $targets = PullRequestTarget::forRelease('8.1.0', 'rel-810');
 
         self::assertCount(3, $targets);
-        self::assertSame('infra', $targets[0]->roleLabel);
+        self::assertSame(RoleLabel::Infra, $targets[0]->roleLabel);
         self::assertSame('openemr/openemr-devops', $targets[0]->repo);
         self::assertSame('release-rotation/auto', $targets[0]->branch);
         self::assertSame('master', $targets[0]->expectedBase);
         self::assertSame(1, $targets[0]->mergeOrder);
 
-        self::assertSame('conductor', $targets[1]->roleLabel);
+        self::assertSame(RoleLabel::Conductor, $targets[1]->roleLabel);
         self::assertSame('openemr/openemr', $targets[1]->repo);
         self::assertSame('release-prep/rel-810', $targets[1]->branch);
         self::assertSame('rel-810', $targets[1]->expectedBase);
         self::assertSame(2, $targets[1]->mergeOrder);
 
-        self::assertSame('docs', $targets[2]->roleLabel);
+        self::assertSame(RoleLabel::Docs, $targets[2]->roleLabel);
         self::assertSame('openemr/website-openemr', $targets[2]->repo);
         self::assertSame('release-docs/8.1.0', $targets[2]->branch);
         self::assertSame('master', $targets[2]->expectedBase);

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -106,7 +106,7 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertCount(2, $api->merges);
     }
 
-    public function testConductorBlockedStopsBeforeDocs(): void
+    public function testConductorBlockedAtPreflightMergesNothing(): void
     {
         $api = new FakePullRequestApi();
         $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
@@ -119,11 +119,34 @@ final class ShipReleaseOrchestratorTest extends TestCase
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
 
         self::assertFalse($result->wasSuccessful());
-        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[0]->status);
         self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
         self::assertContains('check core-test conclusion=FAILURE', $result->steps[1]->reasons);
         self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
-        self::assertCount(1, $api->merges);
+        self::assertSame([], $api->merges);
+        self::assertSame([], $api->postedStatuses);
+    }
+
+    public function testInfraReadyButDocsBlockedAtPreflightMergesNothing(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        $api->setReadiness(202, $this->ready('sha-conductor'));
+        $api->setReadiness(303, new PullRequestReadiness(
+            'sha-docs',
+            ['reviewDecision=REVIEW_REQUIRED (need APPROVED)'],
+        ));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[2]->status);
+        self::assertSame([], $api->merges);
     }
 
     public function testDocsFirstFatalRefusesToMergeAnything(): void

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -386,6 +386,8 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertFalse($result->wasSuccessful());
         self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
         self::assertStringContainsString('CLOSED without being merged', $result->steps[0]->reasons[0]);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
         self::assertSame([], $api->merges);
     }
 

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -187,6 +187,66 @@ final class ShipReleaseOrchestratorTest extends TestCase
         }
     }
 
+    public function testConductorAlreadyMergedRefetchesDocsBeforeMerging(): void
+    {
+        // Recovery scenario: conductor was merged in a previous run. The
+        // orchestrator must re-fetch the docs PR + readiness right before
+        // merging — preflight readiness alone could be stale if the previous
+        // run's downstream re-render was still in flight.
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->merged(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs-stale'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        // Preflight reads the stale head; the post-conductor refetch returns the fresh head.
+        $api->setReadinessSequence(303, [
+            $this->ready('sha-docs-stale'),
+            $this->ready('sha-docs-fresh'),
+        ]);
+        $api->setSnapshotAfterFinds(
+            'openemr/website-openemr',
+            'release-docs/8.1.0',
+            2,
+            $this->open(303, 'sha-docs-fresh'),
+        );
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
+        // Docs merge must use the fresh head SHA, not the preflight one.
+        self::assertSame('sha-docs-fresh', $api->merges[1]['expected']);
+    }
+
+    public function testConductorAlreadyMergedBlocksDocsIfDownstreamStillInFlight(): void
+    {
+        // Same recovery scenario, but the post-conductor docs re-check finds
+        // the docs PR not yet ready (e.g. checks still PENDING from the
+        // previous run's downstream regeneration). Orchestrator must stop.
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->merged(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        // Preflight passes; the post-merge re-check finds it not ready.
+        $api->setReadinessSequence(303, [
+            $this->ready('sha-docs'),
+            new PullRequestReadiness('sha-docs', ['check core-test status=IN_PROGRESS']),
+        ]);
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[2]->status);
+        self::assertContains('check core-test status=IN_PROGRESS', $result->steps[2]->reasons);
+        // Only infra was merged.
+        self::assertCount(1, $api->merges);
+    }
+
     public function testDownstreamWaitTimesOutAndReChecksReadiness(): void
     {
         $api = new FakePullRequestApi();

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -18,12 +18,21 @@ use OpenEMR\Release\PullRequestTarget;
 use OpenEMR\Release\ShipReleaseOrchestrator;
 use OpenEMR\Release\ShipReleaseStepResult;
 use OpenEMR\Release\ShipReleaseStepStatus;
+use OpenEMR\Release\Tests\Fakes\FailingMergeApi;
 use OpenEMR\Release\Tests\Fakes\FakeClock;
 use OpenEMR\Release\Tests\Fakes\FakePullRequestApi;
 use PHPUnit\Framework\TestCase;
 
 final class ShipReleaseOrchestratorTest extends TestCase
 {
+    private const INFRA_REPO = 'openemr/openemr-devops';
+    private const INFRA_BRANCH = 'release-rotation/auto';
+    private const CONDUCTOR_REPO = 'openemr/openemr';
+    private const CONDUCTOR_BRANCH = 'release-prep/rel-810';
+    private const CONDUCTOR_BASE = 'rel-810';
+    private const DOCS_REPO = 'openemr/website-openemr';
+    private const DOCS_BRANCH = 'release-docs/8.1.0';
+
     /**
      * @return list<PullRequestTarget>
      */
@@ -42,28 +51,38 @@ final class ShipReleaseOrchestratorTest extends TestCase
         return new PullRequestSnapshot($number, $head, $base, null);
     }
 
-    private function merged(int $number, string $head): PullRequestSnapshot
+    private function merged(int $number, string $head, string $base = 'master'): PullRequestSnapshot
     {
-        return new PullRequestSnapshot($number, $head, 'master', new \DateTimeImmutable('2026-05-01T00:00:00Z'));
+        return new PullRequestSnapshot($number, $head, $base, new \DateTimeImmutable('2026-05-01T00:00:00Z'));
+    }
+
+    private function openConductor(): PullRequestSnapshot
+    {
+        return $this->open(202, 'sha-conductor', self::CONDUCTOR_BASE);
+    }
+
+    private function mergedConductor(): PullRequestSnapshot
+    {
+        return $this->merged(202, 'sha-conductor', self::CONDUCTOR_BASE);
     }
 
     public function testHappyPathMergesAllThreeInOrderAndPostsApprovalStatus(): void
     {
         $api = new FakePullRequestApi();
         $targets = $this->targets();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs-old'));
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-old'));
         // After conductor merge, the docs PR is re-rendered with a new head SHA.
         $api->setSnapshotAfterFinds(
-            'openemr/website-openemr',
-            'release-docs/8.1.0',
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
             2,
             $this->open(303, 'sha-docs-new'),
         );
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        $api->setReadiness(202, $this->ready('sha-conductor'));
-        $api->setReadiness(303, $this->ready('sha-docs-new'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs-new'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
 
@@ -76,12 +95,11 @@ final class ShipReleaseOrchestratorTest extends TestCase
             ),
         );
         self::assertSame(
-            [['repo' => 'openemr/openemr-devops', 'number' => 101, 'expected' => 'sha-infra'],
-                ['repo' => 'openemr/openemr', 'number' => 202, 'expected' => 'sha-conductor'],
-                ['repo' => 'openemr/website-openemr', 'number' => 303, 'expected' => 'sha-docs-new']],
+            [['repo' => self::INFRA_REPO, 'number' => 101, 'expected' => 'sha-infra'],
+                ['repo' => self::CONDUCTOR_REPO, 'number' => 202, 'expected' => 'sha-conductor'],
+                ['repo' => self::DOCS_REPO, 'number' => 303, 'expected' => 'sha-docs-new']],
             $api->merges,
         );
-        // Three approval statuses, one per merge, on the head SHA we merged.
         self::assertCount(3, $api->postedStatuses);
         self::assertSame(ShipReleaseOrchestrator::STATUS_CONTEXT, $api->postedStatuses[0]['context']);
         self::assertSame('sha-infra', $api->postedStatuses[0]['sha']);
@@ -91,11 +109,11 @@ final class ShipReleaseOrchestratorTest extends TestCase
     public function testInfraAlreadyMergedSkipsThenContinues(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->merged(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(202, $this->ready('sha-conductor'));
-        $api->setReadiness(303, $this->ready('sha-docs'));
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->merged(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
 
@@ -109,12 +127,16 @@ final class ShipReleaseOrchestratorTest extends TestCase
     public function testConductorBlockedAtPreflightMergesNothing(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        $api->setReadiness(202, new PullRequestReadiness('sha-conductor', ['check core-test conclusion=FAILURE']));
-        $api->setReadiness(303, $this->ready('sha-docs'));
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(
+            self::CONDUCTOR_REPO,
+            202,
+            new PullRequestReadiness('sha-conductor', ['check core-test conclusion=FAILURE']),
+        );
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
 
@@ -130,12 +152,12 @@ final class ShipReleaseOrchestratorTest extends TestCase
     public function testInfraReadyButDocsBlockedAtPreflightMergesNothing(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        $api->setReadiness(202, $this->ready('sha-conductor'));
-        $api->setReadiness(303, new PullRequestReadiness(
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, new PullRequestReadiness(
             'sha-docs',
             ['reviewDecision=REVIEW_REQUIRED (need APPROVED)'],
         ));
@@ -152,9 +174,9 @@ final class ShipReleaseOrchestratorTest extends TestCase
     public function testDocsFirstFatalRefusesToMergeAnything(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->merged(303, 'sha-docs'));
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->merged(303, 'sha-docs'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
 
@@ -170,12 +192,12 @@ final class ShipReleaseOrchestratorTest extends TestCase
     public function testDryRunDoesNotMergeOrPostStatuses(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        $api->setReadiness(202, $this->ready('sha-conductor'));
-        $api->setReadiness(303, $this->ready('sha-docs'));
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock(), 600, true))->ship($this->targets());
 
@@ -189,23 +211,18 @@ final class ShipReleaseOrchestratorTest extends TestCase
 
     public function testConductorAlreadyMergedRefetchesDocsBeforeMerging(): void
     {
-        // Recovery scenario: conductor was merged in a previous run. The
-        // orchestrator must re-fetch the docs PR + readiness right before
-        // merging — preflight readiness alone could be stale if the previous
-        // run's downstream re-render was still in flight.
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->merged(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs-stale'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        // Preflight reads the stale head; the post-conductor refetch returns the fresh head.
-        $api->setReadinessSequence(303, [
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->mergedConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-stale'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadinessSequence(self::DOCS_REPO, 303, [
             $this->ready('sha-docs-stale'),
             $this->ready('sha-docs-fresh'),
         ]);
         $api->setSnapshotAfterFinds(
-            'openemr/website-openemr',
-            'release-docs/8.1.0',
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
             2,
             $this->open(303, 'sha-docs-fresh'),
         );
@@ -216,22 +233,17 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
         self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[1]->status);
         self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
-        // Docs merge must use the fresh head SHA, not the preflight one.
         self::assertSame('sha-docs-fresh', $api->merges[1]['expected']);
     }
 
     public function testConductorAlreadyMergedBlocksDocsIfDownstreamStillInFlight(): void
     {
-        // Same recovery scenario, but the post-conductor docs re-check finds
-        // the docs PR not yet ready (e.g. checks still PENDING from the
-        // previous run's downstream regeneration). Orchestrator must stop.
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->merged(202, 'sha-conductor'));
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        // Preflight passes; the post-merge re-check finds it not ready.
-        $api->setReadinessSequence(303, [
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->mergedConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadinessSequence(self::DOCS_REPO, 303, [
             $this->ready('sha-docs'),
             new PullRequestReadiness('sha-docs', ['check core-test status=IN_PROGRESS']),
         ]);
@@ -243,20 +255,18 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[1]->status);
         self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[2]->status);
         self::assertContains('check core-test status=IN_PROGRESS', $result->steps[2]->reasons);
-        // Only infra was merged.
         self::assertCount(1, $api->merges);
     }
 
     public function testDownstreamWaitTimesOutAndReChecksReadiness(): void
     {
         $api = new FakePullRequestApi();
-        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
-        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
-        // Docs PR head SHA never changes — simulates downstream workflow not firing.
-        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
-        $api->setReadiness(101, $this->ready('sha-infra'));
-        $api->setReadiness(202, $this->ready('sha-conductor'));
-        $api->setReadiness(303, $this->ready('sha-docs')); // still ready — proceed despite no flip
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
 
         $clock = new FakeClock();
         $result = (new ShipReleaseOrchestrator($api, $clock, 30))->ship($this->targets());
@@ -264,5 +274,76 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertTrue($result->wasSuccessful());
         self::assertGreaterThanOrEqual(30, $clock->totalSlept);
         self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
+    }
+
+    public function testWrongBaseBranchBlocksWithoutMerging(): void
+    {
+        // Conductor PR exists but has been opened against `master` instead of
+        // the expected `rel-810`. Refuse to merge it (would ship the wrong content).
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->open(202, 'sha-conductor', 'master'));
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertStringContainsString('PR base is master, expected rel-810', $result->steps[1]->reasons[0]);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testTargetsAreSortedByMergeOrderRegardlessOfInputOrder(): void
+    {
+        // Pass targets in shuffled order; the orchestrator must still merge
+        // infra → conductor → docs.
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-old'));
+        $api->setSnapshotAfterFinds(
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
+            2,
+            $this->open(303, 'sha-docs-new'),
+        );
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs-new'));
+
+        $shuffled = $this->targets();
+        $shuffled = [$shuffled[2], $shuffled[0], $shuffled[1]]; // docs, infra, conductor
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($shuffled);
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(
+            [self::INFRA_REPO, self::CONDUCTOR_REPO, self::DOCS_REPO],
+            array_column($api->merges, 'repo'),
+        );
+    }
+
+    public function testMergeApiFailureReportsBlockedAndStopsSubsequentMerges(): void
+    {
+        // Simulate gh failing on the conductor merge (e.g. --match-head-commit
+        // mismatch from a race). Infra still merges, conductor reports BLOCKED
+        // with the gh error, docs is NOT_REACHED.
+        $api = new FailingMergeApi('openemr/openemr', 202, 'gh: --match-head-commit does not match');
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertStringContainsString('--match-head-commit does not match', $result->steps[1]->reasons[0]);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
     }
 }

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -14,7 +14,9 @@ namespace OpenEMR\Release\Tests;
 
 use OpenEMR\Release\PullRequestReadiness;
 use OpenEMR\Release\PullRequestSnapshot;
+use OpenEMR\Release\PullRequestState;
 use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\RoleLabel;
 use OpenEMR\Release\ShipReleaseOrchestrator;
 use OpenEMR\Release\ShipReleaseStepResult;
 use OpenEMR\Release\ShipReleaseStepStatus;
@@ -48,12 +50,17 @@ final class ShipReleaseOrchestratorTest extends TestCase
 
     private function open(int $number, string $head, string $base = 'master'): PullRequestSnapshot
     {
-        return new PullRequestSnapshot($number, $head, $base, null);
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Open);
     }
 
     private function merged(int $number, string $head, string $base = 'master'): PullRequestSnapshot
     {
-        return new PullRequestSnapshot($number, $head, $base, new \DateTimeImmutable('2026-05-01T00:00:00Z'));
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Merged);
+    }
+
+    private function closed(int $number, string $head, string $base = 'master'): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, $base, PullRequestState::Closed);
     }
 
     private function openConductor(): PullRequestSnapshot
@@ -361,6 +368,39 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
         self::assertStringContainsString('--match-head-commit does not match', $result->steps[1]->reasons[0]);
         self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
+    }
+
+    public function testClosedWithoutMergingPrBlocks(): void
+    {
+        // A PR that was closed without merging (state=CLOSED, mergedAt=null)
+        // must not be treated as "open and ready to merge".
+        $api = new FakePullRequestApi();
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->closed(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[0]->status);
+        self::assertStringContainsString('CLOSED without being merged', $result->steps[0]->reasons[0]);
+        self::assertSame([], $api->merges);
+    }
+
+    public function testDuplicateMergeOrderThrowsLogicException(): void
+    {
+        $api = new FakePullRequestApi();
+        $targets = [
+            new PullRequestTarget('a/x', 'b1', 'master', RoleLabel::Infra, 1),
+            new PullRequestTarget('a/y', 'b2', 'master', RoleLabel::Conductor, 1),
+            new PullRequestTarget('a/z', 'b3', 'master', RoleLabel::Docs, 2),
+        ];
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('duplicate mergeOrder');
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
     }
 
     public function testMergeFailureRetractsApprovalStatus(): void

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -111,9 +111,16 @@ final class ShipReleaseOrchestratorTest extends TestCase
         $api = new FakePullRequestApi();
         $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->merged(101, 'sha-infra'));
         $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
-        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs-old'));
+        // After conductor merges, the docs PR is re-rendered (DRAFT→FINAL).
+        $api->setSnapshotAfterFinds(
+            self::DOCS_REPO,
+            self::DOCS_BRANCH,
+            2,
+            $this->open(303, 'sha-docs-new'),
+        );
         $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
-        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs-new'));
 
         $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
 
@@ -258,8 +265,12 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertCount(1, $api->merges);
     }
 
-    public function testDownstreamWaitTimesOutAndReChecksReadiness(): void
+    public function testDownstreamWaitTimeoutBlocksDocsMerge(): void
     {
+        // Docs PR head SHA never changes during the wait — simulates the
+        // conductor's downstream re-render workflow not firing in time.
+        // Even if readiness still looks "clean", we must NOT merge stale
+        // docs content (DRAFT→FINAL flip never happened).
         $api = new FakePullRequestApi();
         $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
         $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
@@ -271,9 +282,14 @@ final class ShipReleaseOrchestratorTest extends TestCase
         $clock = new FakeClock();
         $result = (new ShipReleaseOrchestrator($api, $clock, 30))->ship($this->targets());
 
-        self::assertTrue($result->wasSuccessful());
+        self::assertFalse($result->wasSuccessful());
         self::assertGreaterThanOrEqual(30, $clock->totalSlept);
-        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[2]->status);
+        self::assertStringContainsString('did not change after conductor merge', $result->steps[2]->reasons[0]);
+        // Only infra + conductor merged; docs not.
+        self::assertCount(2, $api->merges);
     }
 
     public function testWrongBaseBranchBlocksWithoutMerging(): void
@@ -345,5 +361,30 @@ final class ShipReleaseOrchestratorTest extends TestCase
         self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
         self::assertStringContainsString('--match-head-commit does not match', $result->steps[1]->reasons[0]);
         self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
+    }
+
+    public function testMergeFailureRetractsApprovalStatus(): void
+    {
+        // Verify the success status is followed by a failure status on the
+        // same head SHA so a stale release/ship-approved=success doesn't
+        // remain on the PR for branch protection to honor.
+        $api = new FailingMergeApi('openemr/openemr', 202, 'gh: api error');
+        $api->setSnapshot(self::INFRA_REPO, self::INFRA_BRANCH, $this->open(101, 'sha-infra'));
+        $api->setSnapshot(self::CONDUCTOR_REPO, self::CONDUCTOR_BRANCH, $this->openConductor());
+        $api->setSnapshot(self::DOCS_REPO, self::DOCS_BRANCH, $this->open(303, 'sha-docs'));
+        $api->setReadiness(self::INFRA_REPO, 101, $this->ready('sha-infra'));
+        $api->setReadiness(self::CONDUCTOR_REPO, 202, $this->ready('sha-conductor'));
+        $api->setReadiness(self::DOCS_REPO, 303, $this->ready('sha-docs'));
+
+        (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        // Statuses on conductor head: success (pre-merge) then failure (retraction).
+        $conductorStatuses = array_values(array_filter(
+            $api->postedStatuses,
+            static fn (array $s): bool => $s['sha'] === 'sha-conductor',
+        ));
+        self::assertCount(2, $conductorStatuses);
+        self::assertSame('success', $conductorStatuses[0]['state']);
+        self::assertSame('failure', $conductorStatuses[1]['state']);
     }
 }

--- a/tools/release/tests/ShipReleaseOrchestratorTest.php
+++ b/tools/release/tests/ShipReleaseOrchestratorTest.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\PullRequestReadiness;
+use OpenEMR\Release\PullRequestSnapshot;
+use OpenEMR\Release\PullRequestTarget;
+use OpenEMR\Release\ShipReleaseOrchestrator;
+use OpenEMR\Release\ShipReleaseStepResult;
+use OpenEMR\Release\ShipReleaseStepStatus;
+use OpenEMR\Release\Tests\Fakes\FakeClock;
+use OpenEMR\Release\Tests\Fakes\FakePullRequestApi;
+use PHPUnit\Framework\TestCase;
+
+final class ShipReleaseOrchestratorTest extends TestCase
+{
+    /**
+     * @return list<PullRequestTarget>
+     */
+    private function targets(): array
+    {
+        return PullRequestTarget::forRelease('8.1.0', 'rel-810');
+    }
+
+    private function ready(string $headSha): PullRequestReadiness
+    {
+        return new PullRequestReadiness($headSha, []);
+    }
+
+    private function open(int $number, string $head, string $base = 'master'): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, $base, null);
+    }
+
+    private function merged(int $number, string $head): PullRequestSnapshot
+    {
+        return new PullRequestSnapshot($number, $head, 'master', new \DateTimeImmutable('2026-05-01T00:00:00Z'));
+    }
+
+    public function testHappyPathMergesAllThreeInOrderAndPostsApprovalStatus(): void
+    {
+        $api = new FakePullRequestApi();
+        $targets = $this->targets();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs-old'));
+        // After conductor merge, the docs PR is re-rendered with a new head SHA.
+        $api->setSnapshotAfterFinds(
+            'openemr/website-openemr',
+            'release-docs/8.1.0',
+            2,
+            $this->open(303, 'sha-docs-new'),
+        );
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        $api->setReadiness(202, $this->ready('sha-conductor'));
+        $api->setReadiness(303, $this->ready('sha-docs-new'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($targets);
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(
+            [ShipReleaseStepStatus::MERGED, ShipReleaseStepStatus::MERGED, ShipReleaseStepStatus::MERGED],
+            array_map(
+                static fn (ShipReleaseStepResult $s): ShipReleaseStepStatus => $s->status,
+                $result->steps,
+            ),
+        );
+        self::assertSame(
+            [['repo' => 'openemr/openemr-devops', 'number' => 101, 'expected' => 'sha-infra'],
+                ['repo' => 'openemr/openemr', 'number' => 202, 'expected' => 'sha-conductor'],
+                ['repo' => 'openemr/website-openemr', 'number' => 303, 'expected' => 'sha-docs-new']],
+            $api->merges,
+        );
+        // Three approval statuses, one per merge, on the head SHA we merged.
+        self::assertCount(3, $api->postedStatuses);
+        self::assertSame(ShipReleaseOrchestrator::STATUS_CONTEXT, $api->postedStatuses[0]['context']);
+        self::assertSame('sha-infra', $api->postedStatuses[0]['sha']);
+        self::assertSame('sha-docs-new', $api->postedStatuses[2]['sha']);
+    }
+
+    public function testInfraAlreadyMergedSkipsThenContinues(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->merged(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(202, $this->ready('sha-conductor'));
+        $api->setReadiness(303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::SKIPPED_ALREADY_MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[1]->status);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
+        self::assertCount(2, $api->merges);
+    }
+
+    public function testConductorBlockedStopsBeforeDocs(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        $api->setReadiness(202, new PullRequestReadiness('sha-conductor', ['check core-test conclusion=FAILURE']));
+        $api->setReadiness(303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[0]->status);
+        self::assertSame(ShipReleaseStepStatus::BLOCKED, $result->steps[1]->status);
+        self::assertContains('check core-test conclusion=FAILURE', $result->steps[1]->reasons);
+        self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $result->steps[2]->status);
+        self::assertCount(1, $api->merges);
+    }
+
+    public function testDocsFirstFatalRefusesToMergeAnything(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->merged(303, 'sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock()))->ship($this->targets());
+
+        self::assertFalse($result->wasSuccessful());
+        self::assertNotNull($result->fatalReason);
+        self::assertStringContainsString('docs-first', $result->fatalReason);
+        self::assertSame([], $api->merges);
+        foreach ($result->steps as $step) {
+            self::assertSame(ShipReleaseStepStatus::NOT_REACHED, $step->status);
+        }
+    }
+
+    public function testDryRunDoesNotMergeOrPostStatuses(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        $api->setReadiness(202, $this->ready('sha-conductor'));
+        $api->setReadiness(303, $this->ready('sha-docs'));
+
+        $result = (new ShipReleaseOrchestrator($api, new FakeClock(), 600, true))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertSame([], $api->merges);
+        self::assertSame([], $api->postedStatuses);
+        foreach ($result->steps as $step) {
+            self::assertSame(ShipReleaseStepStatus::WOULD_MERGE, $step->status);
+        }
+    }
+
+    public function testDownstreamWaitTimesOutAndReChecksReadiness(): void
+    {
+        $api = new FakePullRequestApi();
+        $api->setSnapshot('openemr/openemr-devops', 'release-rotation/auto', $this->open(101, 'sha-infra'));
+        $api->setSnapshot('openemr/openemr', 'release-prep/rel-810', $this->open(202, 'sha-conductor'));
+        // Docs PR head SHA never changes — simulates downstream workflow not firing.
+        $api->setSnapshot('openemr/website-openemr', 'release-docs/8.1.0', $this->open(303, 'sha-docs'));
+        $api->setReadiness(101, $this->ready('sha-infra'));
+        $api->setReadiness(202, $this->ready('sha-conductor'));
+        $api->setReadiness(303, $this->ready('sha-docs')); // still ready — proceed despite no flip
+
+        $clock = new FakeClock();
+        $result = (new ShipReleaseOrchestrator($api, $clock, 30))->ship($this->targets());
+
+        self::assertTrue($result->wasSuccessful());
+        self::assertGreaterThanOrEqual(30, $clock->totalSlept);
+        self::assertSame(ShipReleaseStepStatus::MERGED, $result->steps[2]->status);
+    }
+}


### PR DESCRIPTION
Closes #705.

## Summary

Adds a manually-triggered workflow (`ship-release.yml`) that orchestrates merging the three sibling release PRs in strict order — infra (`openemr-devops`) → conductor (`openemr/openemr`) → docs (`website-openemr`) — with mergeability gates on each step. Replaces three browser tabs and three required-checks waits with one button press, and removes the partial-merge risk documented in `openemr/openemr` `docs/RELEASE_PROCESS.md`.

## What's in the box

- **`.github/workflows/ship-release.yml`** — `workflow_dispatch` with `version`, `rel_branch`, `dry_run`, `timeout_seconds` inputs. Mints one App token scoped to all three repos; `permissions: {}`; `concurrency: ship-release`.
- **`tools/release/src/ShipReleaseOrchestrator.php`** — strict-order merge, skip-if-merged (so the same trigger handles partial-merge recovery), blocked-stops-the-line (no partial merges originate here), `release/ship-approved` commit status posted before each merge, conductor→docs head-SHA polling with timeout, docs-first detection.
- **`tools/release/src/PullRequestApi.php`** + **`GhPullRequestApi.php`** — narrow cross-repo PR interface (findByHead / getReadiness / postCommitStatus / squashMerge with `--match-head-commit`) over the `gh` CLI; kept separate from `GitHubApi.php` to stay testable and focused.
- **`tools/release/bin/ship-release.php`** — Symfony Console CLI (matches existing `bin/` shape), wired through Taskfile as `release:ship`.
- **Result/value objects + `Clock` test seam** — `PullRequestTarget`, `PullRequestSnapshot`, `PullRequestReadiness`, `ShipReleaseStepResult`/`Status`, `ShipReleaseResult`, `ShipReleaseRenderer`.
- **Tests** — `FakePullRequestApi` + `FakeClock`; covers happy path, infra-already-merged skip, conductor-blocked-stops-docs, docs-first fatal (refuses to merge anything), dry-run, downstream-wait timeout. 12 new tests, 62 total.

## Recovery behavior

Re-running the workflow handles partial-merge recovery automatically because every merged step is detected as `SKIPPED_ALREADY_MERGED` and the run continues with whatever's left. The one case that can't be recovered automatically — docs merged before conductor — is detected up front and the workflow refuses to do anything, matching what issue #705 calls out as the manual reconciliation case.

## Test plan

- [x] `composer test` (62 tests, 171 assertions)
- [x] `composer phpstan` (level 10 + strict-rules, no errors)
- [x] `composer phpcs` (clean)
- [x] `composer rector-check` (clean)
- [x] `actionlint .github/workflows/ship-release.yml` (clean)
- [ ] First real use: dry-run against the next live release-prep PRs to confirm readiness reporting matches reality before doing a real merge.

## Out of scope (per #705)

- Configuring branch protection on the three base branches to require `release/ship-approved` (separate repo-admin step; this PR only emits the status so admins *can* enable it).
- Docs-side reconciliation for the docs-first-merged case.
- Auto-rollback on partial failure.