### PR TITLE
feat(release): reusable check-vendored-contracts workflow + path overrides

### DIFF
--- a/.github/workflows/_test-vendored-contracts.yml
+++ b/.github/workflows/_test-vendored-contracts.yml
@@ -1,0 +1,57 @@
+name: Test Vendored Contracts (self-test)
+
+# Exercises check-vendored-contracts.yml against committed fixtures so the
+# reusable workflow has end-to-end CI coverage in this repo. Without this,
+# its only validation is whatever consumer adopts it first.
+#
+# good                — canonical layout, no overrides. Validates checkout
+#                       wiring, composer install, and CLI invocation.
+# good-with-overrides — same content under a website-openemr-style
+#                       src/Release/ layout. Exercises the path_overrides
+#                       input end-to-end (newline-delimited parsing →
+#                       --override flags).
+#
+# Drift-detection failure propagation isn't tested here — exit-code → job
+# status is GHA's intrinsic behavior, so a drifted fixture just turns the
+# test red without proving anything new about the workflow.
+#
+# canonical_ref pins to the PR head SHA so the test compares against this
+# PR's canonical files, not whatever happens to be on master.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/check-vendored-contracts.yml'
+      - '.github/workflows/_test-vendored-contracts.yml'
+      - 'tools/release/bin/check-vendored.php'
+      - 'tools/release/src/VendoredFileChecker.php'
+      - 'tools/release/src/VendoredDriftIssue.php'
+      - 'tools/release/contracts/dispatch.schema.json'
+      - 'tools/release/src/TagVerifier.php'
+      - 'tools/release/src/TagVerificationResult.php'
+      - 'tools/release/tests/fixtures/vendored/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  good:
+    name: good fixture matches canonical
+    uses: ./.github/workflows/check-vendored-contracts.yml
+    with:
+      consumer_subpath: tools/release/tests/fixtures/vendored/good
+      canonical_ref: ${{ github.event.pull_request.head.sha }}
+
+  good-with-overrides:
+    name: good fixture under website-style layout via path_overrides
+    uses: ./.github/workflows/check-vendored-contracts.yml
+    with:
+      consumer_subpath: tools/release/tests/fixtures/vendored/good-overrides
+      canonical_ref: ${{ github.event.pull_request.head.sha }}
+      path_overrides: |
+        src/TagVerifier.php=src/Release/TagVerifier.php
+        src/TagVerificationResult.php=src/Release/TagVerificationResult.php

--- a/.github/workflows/check-vendored-contracts.yml
+++ b/.github/workflows/check-vendored-contracts.yml
@@ -1,0 +1,101 @@
+name: Check Vendored Contracts
+
+# Reusable workflow for consumer repos to drift-check their vendored copies
+# of cross-repo release contracts (dispatch.schema.json, TagVerifier,
+# TagVerificationResult) against the canonical sources here. Fails the
+# calling job on drift.
+#
+# See tools/release/src/VendoredFileChecker.php for the canonical file list.
+# See tools/release/contracts/dispatch.schema.json and
+# tools/release/src/TagVerifier.php for the contracts themselves.
+#
+# Caller example (in a consumer repo's PR workflow):
+#
+#   jobs:
+#     drift:
+#       uses: openemr/openemr-devops/.github/workflows/check-vendored-contracts.yml@master
+#       with:
+#         consumer_subpath: tools/release
+#
+# website-openemr (which vendored into a non-canonical layout) passes overrides:
+#
+#       with:
+#         consumer_subpath: tools/release-docs
+#         path_overrides: |
+#           src/TagVerifier.php=src/Release/TagVerifier.php
+#           src/TagVerificationResult.php=src/Release/TagVerificationResult.php
+
+on:
+  workflow_call:
+    inputs:
+      consumer_subpath:
+        description: 'Path within the caller repo holding the vendored copies (e.g. tools/release).'
+        required: true
+        type: string
+      canonical_ref:
+        description: 'Ref of openemr/openemr-devops to compare against. Defaults to master.'
+        required: false
+        type: string
+        default: master
+      path_overrides:
+        description: |
+          Optional newline-delimited canonical=consumer path overrides for consumers
+          that vendored into a non-canonical layout. Example:
+            src/TagVerifier.php=src/Release/TagVerifier.php
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: vendored contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout consumer
+        uses: actions/checkout@v6
+
+      - name: Checkout canonical openemr-devops
+        uses: actions/checkout@v6
+        with:
+          repository: openemr/openemr-devops
+          ref: ${{ inputs.canonical_ref }}
+          path: _canonical-openemr-devops
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - name: Install canonical release-tools dependencies
+        working-directory: _canonical-openemr-devops/tools/release
+        run: composer install --no-interaction --no-progress --no-dev
+
+      - name: Build override flags
+        id: overrides
+        env:
+          PATH_OVERRIDES: ${{ inputs.path_overrides }}
+        run: |
+          flags=''
+          while IFS= read -r line; do
+              line="${line## }"
+              line="${line%% }"
+              [[ -z $line ]] && continue
+              flags+=" --override $line"
+          done <<< "$PATH_OVERRIDES"
+          {
+              echo "flags<<EOF"
+              echo "$flags"
+              echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check vendored contracts
+        env:
+          CONSUMER_PATH: ${{ github.workspace }}/${{ inputs.consumer_subpath }}
+          OVERRIDE_FLAGS: ${{ steps.overrides.outputs.flags }}
+        working-directory: _canonical-openemr-devops/tools/release
+        run: |
+          # shellcheck disable=SC2086 # OVERRIDE_FLAGS is a flag list; word-split is intentional
+          php bin/check-vendored.php --consumer "$CONSUMER_PATH" $OVERRIDE_FLAGS

--- a/.github/workflows/check-vendored-contracts.yml
+++ b/.github/workflows/check-vendored-contracts.yml
@@ -73,29 +73,9 @@ jobs:
         working-directory: _canonical-openemr-devops/tools/release
         run: composer install --no-interaction --no-progress --no-dev
 
-      - name: Build override flags
-        id: overrides
-        env:
-          PATH_OVERRIDES: ${{ inputs.path_overrides }}
-        run: |
-          flags=''
-          while IFS= read -r line; do
-              line="${line## }"
-              line="${line%% }"
-              [[ -z $line ]] && continue
-              flags+=" --override $line"
-          done <<< "$PATH_OVERRIDES"
-          {
-              echo "flags<<EOF"
-              echo "$flags"
-              echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Check vendored contracts
         env:
           CONSUMER_PATH: ${{ github.workspace }}/${{ inputs.consumer_subpath }}
-          OVERRIDE_FLAGS: ${{ steps.overrides.outputs.flags }}
+          PATH_OVERRIDES: ${{ inputs.path_overrides }}
         working-directory: _canonical-openemr-devops/tools/release
-        run: |
-          # shellcheck disable=SC2086 # OVERRIDE_FLAGS is a flag list; word-split is intentional
-          php bin/check-vendored.php --consumer "$CONSUMER_PATH" $OVERRIDE_FLAGS
+        run: php bin/check-vendored.php --consumer "$CONSUMER_PATH" --overrides "$PATH_OVERRIDES"

--- a/.github/workflows/vendored-contracts-self-test.yml
+++ b/.github/workflows/vendored-contracts-self-test.yml
@@ -8,8 +8,8 @@ name: Test Vendored Contracts (self-test)
 #                       wiring, composer install, and CLI invocation.
 # good-with-overrides — same content under a website-openemr-style
 #                       src/Release/ layout. Exercises the path_overrides
-#                       input end-to-end (newline-delimited parsing →
-#                       --override flags).
+#                       input end-to-end (newline-delimited string →
+#                       PHP-side parsing in --overrides).
 #
 # Drift-detection failure propagation isn't tested here — exit-code → job
 # status is GHA's intrinsic behavior, so a drifted fixture just turns the
@@ -22,7 +22,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/check-vendored-contracts.yml'
-      - '.github/workflows/_test-vendored-contracts.yml'
+      - '.github/workflows/vendored-contracts-self-test.yml'
       - 'tools/release/bin/check-vendored.php'
       - 'tools/release/src/VendoredFileChecker.php'
       - 'tools/release/src/VendoredDriftIssue.php'

--- a/.github/workflows/vendored-contracts-self-test.yml
+++ b/.github/workflows/vendored-contracts-self-test.yml
@@ -30,6 +30,8 @@ on:
       - 'tools/release/src/TagVerifier.php'
       - 'tools/release/src/TagVerificationResult.php'
       - 'tools/release/tests/fixtures/vendored/**'
+      - 'tools/release/composer.json'
+      - 'tools/release/composer.lock'
 
 permissions:
   contents: read

--- a/tools/release/bin/check-vendored.php
+++ b/tools/release/bin/check-vendored.php
@@ -42,6 +42,13 @@ use Symfony\Component\Console\SingleCommandApplication;
         InputOption::VALUE_REQUIRED,
         'Path to the consumer repo dir holding the vendored copies',
     )
+    ->addOption(
+        'override',
+        null,
+        InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
+        'Map a canonical path to a different consumer-relative path '
+            . '(e.g. --override src/TagVerifier.php=src/Release/TagVerifier.php). Repeatable.',
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $canonical = $input->getOption('canonical');
         if (!is_string($canonical) || $canonical === '') {
@@ -63,7 +70,34 @@ use Symfony\Component\Console\SingleCommandApplication;
             return 1;
         }
 
-        $issues = (new VendoredFileChecker($canonical, $consumer))->check();
+        $rawOverrides = $input->getOption('override');
+        if (!is_array($rawOverrides)) {
+            $rawOverrides = [];
+        }
+        $overrides = [];
+        foreach ($rawOverrides as $entry) {
+            if (!is_string($entry) || !str_contains($entry, '=')) {
+                $output->writeln(sprintf(
+                    '<error>--override expects CANONICAL=CONSUMER, got: %s</error>',
+                    is_string($entry) ? $entry : gettype($entry),
+                ));
+                return 1;
+            }
+            [$canon, $cons] = explode('=', $entry, 2);
+            if ($canon === '' || $cons === '') {
+                $output->writeln(sprintf('<error>--override has empty side: %s</error>', $entry));
+                return 1;
+            }
+            $overrides[$canon] = $cons;
+        }
+
+        try {
+            $checker = new VendoredFileChecker($canonical, $consumer, $overrides);
+        } catch (\InvalidArgumentException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return 1;
+        }
+        $issues = $checker->check();
         if ($issues === []) {
             $output->writeln(sprintf(
                 '<info>✓</info> All %d vendored file(s) match canonical.',

--- a/tools/release/bin/check-vendored.php
+++ b/tools/release/bin/check-vendored.php
@@ -49,6 +49,14 @@ use Symfony\Component\Console\SingleCommandApplication;
         'Map a canonical path to a different consumer-relative path '
             . '(e.g. --override src/TagVerifier.php=src/Release/TagVerifier.php). Repeatable.',
     )
+    ->addOption(
+        'overrides',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Same mapping as --override but as a single newline-delimited string '
+            . '(blank lines and surrounding whitespace ignored). Convenient for '
+            . 'CI inputs that arrive as multi-line strings. Combines with --override.',
+    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $canonical = $input->getOption('canonical');
         if (!is_string($canonical) || $canonical === '') {
@@ -74,21 +82,35 @@ use Symfony\Component\Console\SingleCommandApplication;
         if (!is_array($rawOverrides)) {
             $rawOverrides = [];
         }
+        $multiline = $input->getOption('overrides');
+        if (is_string($multiline) && $multiline !== '') {
+            $lines = preg_split('/\R/', $multiline);
+            if ($lines === false) {
+                $output->writeln('<error>--overrides could not be parsed</error>');
+                return 1;
+            }
+            foreach ($lines as $line) {
+                $trimmed = trim($line);
+                if ($trimmed !== '') {
+                    $rawOverrides[] = $trimmed;
+                }
+            }
+        }
         $overrides = [];
         foreach ($rawOverrides as $entry) {
             if (!is_string($entry) || !str_contains($entry, '=')) {
                 $output->writeln(sprintf(
-                    '<error>--override expects CANONICAL=CONSUMER, got: %s</error>',
+                    '<error>override entry expects CANONICAL=CONSUMER, got: %s</error>',
                     is_string($entry) ? $entry : gettype($entry),
                 ));
                 return 1;
             }
-            [$canon, $cons] = explode('=', $entry, 2);
-            if ($canon === '' || $cons === '') {
-                $output->writeln(sprintf('<error>--override has empty side: %s</error>', $entry));
+            [$canonicalPath, $consumerPath] = explode('=', $entry, 2);
+            if ($canonicalPath === '' || $consumerPath === '') {
+                $output->writeln(sprintf('<error>override entry has empty side: %s</error>', $entry));
                 return 1;
             }
-            $overrides[$canon] = $cons;
+            $overrides[$canonicalPath] = $consumerPath;
         }
 
         try {

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -8,7 +8,9 @@
  * Layout assumption: the consumer mirrors the canonical relative paths under
  * its vendored dir. A consumer that vendors to `vendored/openemr-devops/`
  * therefore has `vendored/openemr-devops/contracts/dispatch.schema.json` and
- * `vendored/openemr-devops/src/TagVerifier.php`.
+ * `vendored/openemr-devops/src/TagVerifier.php`. A consumer that vendored
+ * into a different layout (e.g. `src/Release/TagVerifier.php`) can pass a
+ * `$pathOverrides` map keyed by canonical path → consumer-relative path.
  *
  * Equivalence is per-file-type, per the openemr-devops#664 spec:
  *
@@ -44,10 +46,25 @@ final readonly class VendoredFileChecker
         'src/TagVerificationResult.php',
     ];
 
+    /**
+     * @param array<string, string> $pathOverrides Map of canonical relative
+     *     path → consumer relative path. Unmapped entries default to the
+     *     canonical path. Unknown keys (not in VENDORED_PATHS) throw.
+     */
     public function __construct(
         private string $canonicalRoot,
         private string $consumerDir,
+        private array $pathOverrides = [],
     ) {
+        foreach (array_keys($pathOverrides) as $key) {
+            if (!in_array($key, self::VENDORED_PATHS, true)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Unknown override key %s; must be one of: %s',
+                    $key,
+                    implode(', ', self::VENDORED_PATHS),
+                ));
+            }
+        }
     }
 
     /**
@@ -58,7 +75,8 @@ final readonly class VendoredFileChecker
         $issues = [];
         foreach (self::VENDORED_PATHS as $rel) {
             $canonicalAbs = $this->canonicalRoot . '/' . $rel;
-            $consumerAbs = $this->consumerDir . '/' . $rel;
+            $consumerRel = $this->pathOverrides[$rel] ?? $rel;
+            $consumerAbs = $this->consumerDir . '/' . $consumerRel;
 
             if (!is_file($canonicalAbs)) {
                 $issues[] = new VendoredDriftIssue(
@@ -70,7 +88,7 @@ final readonly class VendoredFileChecker
             }
             if (!is_file($consumerAbs)) {
                 $issues[] = new VendoredDriftIssue(
-                    $rel,
+                    $consumerRel,
                     'missing_consumer',
                     'Consumer copy missing — vendor it from canonical at ' . $canonicalAbs,
                 );
@@ -78,7 +96,7 @@ final readonly class VendoredFileChecker
             }
             if (!$this->equivalent($rel, $canonicalAbs, $consumerAbs)) {
                 $issues[] = new VendoredDriftIssue(
-                    $rel,
+                    $consumerRel,
                     'drift',
                     'Consumer copy differs from canonical — re-vendor from ' . $canonicalAbs,
                 );

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -49,19 +49,28 @@ final readonly class VendoredFileChecker
     /**
      * @param array<string, string> $pathOverrides Map of canonical relative
      *     path → consumer relative path. Unmapped entries default to the
-     *     canonical path. Unknown keys (not in VENDORED_PATHS) throw.
+     *     canonical path. Unknown keys (not in VENDORED_PATHS) throw, as do
+     *     values that are absolute or contain `..` segments — overrides must
+     *     stay inside the consumer dir.
      */
     public function __construct(
         private string $canonicalRoot,
         private string $consumerDir,
         private array $pathOverrides = [],
     ) {
-        foreach (array_keys($pathOverrides) as $key) {
+        foreach ($pathOverrides as $key => $value) {
             if (!in_array($key, self::VENDORED_PATHS, true)) {
                 throw new \InvalidArgumentException(sprintf(
                     'Unknown override key %s; must be one of: %s',
                     $key,
                     implode(', ', self::VENDORED_PATHS),
+                ));
+            }
+            if ($value === '' || $value[0] === '/' || preg_match('#(^|/)\.\.(/|$)#', $value) === 1) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Override value for %s must be a relative path inside the consumer dir, got: %s',
+                    $key,
+                    $value,
                 ));
             }
         }

--- a/tools/release/src/VendoredFileChecker.php
+++ b/tools/release/src/VendoredFileChecker.php
@@ -46,19 +46,32 @@ final readonly class VendoredFileChecker
         'src/TagVerificationResult.php',
     ];
 
+    /** @var array<string, string> */
+    private array $pathOverrides;
+
     /**
-     * @param array<string, string> $pathOverrides Map of canonical relative
-     *     path → consumer relative path. Unmapped entries default to the
-     *     canonical path. Unknown keys (not in VENDORED_PATHS) throw, as do
-     *     values that are absolute or contain `..` segments — overrides must
-     *     stay inside the consumer dir.
+     * @param array<array-key, mixed> $pathOverrides Map of canonical relative
+     *     path → consumer relative path. Validated at runtime since CLI/CI
+     *     callers can produce arbitrary input: keys and values must both be
+     *     strings; unmapped entries default to the canonical path; unknown
+     *     keys (not in VENDORED_PATHS) throw, as do values that are absolute
+     *     or contain `..` segments — overrides must stay inside the
+     *     consumer dir.
      */
     public function __construct(
         private string $canonicalRoot,
         private string $consumerDir,
-        private array $pathOverrides = [],
+        array $pathOverrides = [],
     ) {
+        $validated = [];
         foreach ($pathOverrides as $key => $value) {
+            if (!is_string($key) || !is_string($value)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Override entries must be string=>string, got %s=>%s',
+                    get_debug_type($key),
+                    get_debug_type($value),
+                ));
+            }
             if (!in_array($key, self::VENDORED_PATHS, true)) {
                 throw new \InvalidArgumentException(sprintf(
                     'Unknown override key %s; must be one of: %s',
@@ -73,7 +86,9 @@ final readonly class VendoredFileChecker
                     $value,
                 ));
             }
+            $validated[$key] = $value;
         }
+        $this->pathOverrides = $validated;
     }
 
     /**

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -294,6 +294,28 @@ final class VendoredFileCheckerTest extends TestCase
         );
     }
 
+    public function testNonStringOverrideValueThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 123],
+        );
+    }
+
+    public function testNonStringOverrideKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            [42 => 'src/Release/TagVerifier.php'],
+        );
+    }
+
     /**
      * @param list<string>|null $only restrict which paths to write
      */

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -222,6 +222,53 @@ final class VendoredFileCheckerTest extends TestCase
         self::assertContains('src/TagVerificationResult.php', VendoredFileChecker::VENDORED_PATHS);
     }
 
+    public function testPathOverrideMapsCanonicalToConsumerLayout(): void
+    {
+        foreach (VendoredFileChecker::VENDORED_PATHS as $rel) {
+            $consumerRel = $rel === 'src/TagVerifier.php' ? 'src/Release/TagVerifier.php' : $rel;
+            $this->writeFile($this->consumerDir, $consumerRel, $this->canonicalContents($rel));
+        }
+
+        $issues = (new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 'src/Release/TagVerifier.php'],
+        ))->check();
+
+        self::assertSame([], $issues);
+    }
+
+    public function testOverriddenPathDriftReportsConsumerRelativePath(): void
+    {
+        $this->writeCanonicalFixtures($this->consumerDir);
+        $this->writeFile(
+            $this->consumerDir,
+            'src/Release/TagVerifier.php',
+            sprintf(self::CANONICAL_PHP_TEMPLATE, 'OpenEMR\\Release') . "\n// extra\n",
+        );
+
+        $issues = (new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => 'src/Release/TagVerifier.php'],
+        ))->check();
+
+        self::assertCount(1, $issues);
+        self::assertSame('src/Release/TagVerifier.php', $issues[0]->relativePath);
+        self::assertSame('drift', $issues[0]->kind);
+    }
+
+    public function testUnknownOverrideKeyThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['not/a/canonical/path.php' => 'irrelevant'],
+        );
+    }
+
     /**
      * @param list<string>|null $only restrict which paths to write
      */

--- a/tools/release/tests/VendoredFileCheckerTest.php
+++ b/tools/release/tests/VendoredFileCheckerTest.php
@@ -14,6 +14,7 @@ namespace OpenEMR\Release\Tests;
 
 use OpenEMR\Release\VendoredDriftIssue;
 use OpenEMR\Release\VendoredFileChecker;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class VendoredFileCheckerTest extends TestCase
@@ -266,6 +267,30 @@ final class VendoredFileCheckerTest extends TestCase
             $this->canonicalRoot,
             $this->consumerDir,
             ['not/a/canonical/path.php' => 'irrelevant'],
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unsafeOverrideValueProvider(): iterable
+    {
+        yield 'absolute path' => ['/etc/passwd'];
+        yield 'parent traversal' => ['../outside.php'];
+        yield 'embedded parent traversal' => ['src/../../outside.php'];
+        yield 'trailing parent traversal' => ['src/Release/..'];
+        yield 'empty value' => [''];
+    }
+
+    #[DataProvider('unsafeOverrideValueProvider')]
+    public function testUnsafeOverrideValueThrows(string $unsafeValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new VendoredFileChecker(
+            $this->canonicalRoot,
+            $this->consumerDir,
+            ['src/TagVerifier.php' => $unsafeValue],
         );
     }
 

--- a/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/openemr/openemr-devops/blob/master/tools/release/contracts/dispatch.schema.json",
+    "title": "OpenEMR release dispatch payload",
+    "description": "Cross-repo repository_dispatch payloads emitted between openemr/openemr (conductor) and openemr/openemr-devops, openemr/website-openemr, openemr/website-openemr-files (consumers). See openemr/openemr-devops#664. The canonical copy lives here; consumers vendor it and CI fails on drift via tools/release/bin/check-vendored.php.",
+    "type": "object",
+    "required": ["event", "repo", "sha", "actor", "dispatched_at", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "event": {
+            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "type": "string",
+            "enum": [
+                "openemr-rel-cut",
+                "openemr-rel-update",
+                "openemr-tag",
+                "openemr-docs-binaries"
+            ]
+        },
+        "repo": {
+            "description": "Source repo in owner/name form.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$"
+        },
+        "sha": {
+            "description": "40-character lowercase hex commit SHA the event refers to.",
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+        },
+        "actor": {
+            "description": "Identity that produced the dispatch (App slug or login).",
+            "type": "string",
+            "minLength": 1
+        },
+        "dispatched_at": {
+            "description": "ISO 8601 UTC timestamp, e.g. 2026-04-29T12:00:00Z.",
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+        },
+        "data": {
+            "type": "object"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-cut" },
+                "data": { "$ref": "#/definitions/relCutData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-update" },
+                "data": { "$ref": "#/definitions/relUpdateData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-tag" },
+                "data": { "$ref": "#/definitions/tagData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-docs-binaries" },
+                "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        }
+    ],
+    "definitions": {
+        "version": {
+            "description": "Hugo version param shape (MAJOR.MINOR.PATCH).",
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "branch": {
+            "description": "Release branch name. Per #664 spec real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut.",
+            "type": "string",
+            "pattern": "^rel-[A-Za-z0-9]+$"
+        },
+        "tag": {
+            "description": "Release tag name. Per #664 spec real releases use v<MAJOR>_<MINOR>_<PATCH>. Test runs append -test.<shortSha> (7 hex chars) so a test merge does not collide with a real release tag.",
+            "type": "string",
+            "pattern": "^v\\d+_\\d+_\\d+(-test\\.[0-9a-f]{7})?$"
+        },
+        "relCutData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "relUpdateData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "tagData": {
+            "type": "object",
+            "required": ["tag", "branch", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "tag": { "$ref": "#/definitions/tag" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" }
+            }
+        },
+        "docsBinariesData": {
+            "type": "object",
+            "required": ["version", "branch", "files"],
+            "additionalProperties": false,
+            "properties": {
+                "version": { "$ref": "#/definitions/version" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "files": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/release/tests/fixtures/vendored/good-overrides/src/Release/TagVerificationResult.php
+++ b/tools/release/tests/fixtures/vendored/good-overrides/src/Release/TagVerificationResult.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Result of verifying a release tag against the openemr-devops#664 spec.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class TagVerificationResult
+{
+    /**
+     * @param list<string> $errors
+     */
+    public function __construct(
+        public string $tagName,
+        public bool $isAnnotated,
+        public ?string $version,
+        public ?string $date,
+        public ?string $mergeSha,
+        public array $errors,
+    ) {
+    }
+
+    public function isValid(): bool
+    {
+        return $this->errors === [];
+    }
+}

--- a/tools/release/tests/fixtures/vendored/good-overrides/src/Release/TagVerifier.php
+++ b/tools/release/tests/fixtures/vendored/good-overrides/src/Release/TagVerifier.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Verify a release tag is annotated and its message conforms to the
+ * openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class TagVerifier
+{
+    public function __construct(
+        private string $repoDir,
+    ) {
+    }
+
+    public function verify(string $tagName): TagVerificationResult
+    {
+        $errors = [];
+        $type = $this->git(['cat-file', '-t', $tagName]);
+        $isAnnotated = $type === 'tag';
+        if (!$isAnnotated) {
+            $errors[] = sprintf(
+                '%s is not annotated (object type: %s); the spec requires `git tag -a`',
+                $tagName,
+                $type,
+            );
+            return new TagVerificationResult($tagName, false, null, null, null, $errors);
+        }
+
+        $message = $this->extractMessage($this->git(['cat-file', '-p', $tagName]));
+
+        $version = $this->firstMatch('/\b(\d+\.\d+\.\d+)\b/', $message);
+        if ($version === null) {
+            $errors[] = 'tag message does not contain a version (MAJOR.MINOR.PATCH)';
+        }
+
+        $date = $this->firstMatch('/\b(\d{4}-\d{2}-\d{2})\b/', $message);
+        if ($date === null) {
+            $errors[] = 'tag message does not contain an ISO date (YYYY-MM-DD)';
+        }
+
+        $mergeSha = $this->firstMatch('/\b([0-9a-f]{40})\b/', $message);
+        if ($mergeSha === null) {
+            $errors[] = 'tag message does not contain a merge-commit SHA (40 hex chars)';
+        }
+
+        return new TagVerificationResult($tagName, true, $version, $date, $mergeSha, $errors);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): string
+    {
+        $process = new Process(['git', ...$args], $this->repoDir);
+        $process->mustRun();
+        return rtrim($process->getOutput(), "\n");
+    }
+
+    /**
+     * Extract the message body of a `git cat-file -p <tag>` annotated-tag dump.
+     *
+     * Headers (object/type/tag/tagger) precede a blank line, then the message.
+     */
+    private function extractMessage(string $catFileOutput): string
+    {
+        $parts = preg_split('/\R\R/', $catFileOutput, 2);
+        if ($parts === false || count($parts) < 2) {
+            return '';
+        }
+        return $parts[1];
+    }
+
+    private function firstMatch(string $pattern, string $subject): ?string
+    {
+        if (preg_match($pattern, $subject, $matches) !== 1) {
+            return null;
+        }
+        return $matches[1];
+    }
+}

--- a/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
@@ -1,0 +1,134 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://github.com/openemr/openemr-devops/blob/master/tools/release/contracts/dispatch.schema.json",
+    "title": "OpenEMR release dispatch payload",
+    "description": "Cross-repo repository_dispatch payloads emitted between openemr/openemr (conductor) and openemr/openemr-devops, openemr/website-openemr, openemr/website-openemr-files (consumers). See openemr/openemr-devops#664. The canonical copy lives here; consumers vendor it and CI fails on drift via tools/release/bin/check-vendored.php.",
+    "type": "object",
+    "required": ["event", "repo", "sha", "actor", "dispatched_at", "data"],
+    "additionalProperties": false,
+    "properties": {
+        "event": {
+            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "type": "string",
+            "enum": [
+                "openemr-rel-cut",
+                "openemr-rel-update",
+                "openemr-tag",
+                "openemr-docs-binaries"
+            ]
+        },
+        "repo": {
+            "description": "Source repo in owner/name form.",
+            "type": "string",
+            "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9._-]+$"
+        },
+        "sha": {
+            "description": "40-character lowercase hex commit SHA the event refers to.",
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+        },
+        "actor": {
+            "description": "Identity that produced the dispatch (App slug or login).",
+            "type": "string",
+            "minLength": 1
+        },
+        "dispatched_at": {
+            "description": "ISO 8601 UTC timestamp, e.g. 2026-04-29T12:00:00Z.",
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
+        },
+        "data": {
+            "type": "object"
+        }
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-cut" },
+                "data": { "$ref": "#/definitions/relCutData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-rel-update" },
+                "data": { "$ref": "#/definitions/relUpdateData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-tag" },
+                "data": { "$ref": "#/definitions/tagData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "openemr-docs-binaries" },
+                "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        }
+    ],
+    "definitions": {
+        "version": {
+            "description": "Hugo version param shape (MAJOR.MINOR.PATCH).",
+            "type": "string",
+            "pattern": "^\\d+\\.\\d+\\.\\d+$"
+        },
+        "branch": {
+            "description": "Release branch name. Per #664 spec real releases use rel-<MAJOR><MINOR>0 (e.g. rel-810). Pattern is widened to rel-<alphanumeric> so test branches like rel-test can exercise the same workflow end-to-end without a real release-cut.",
+            "type": "string",
+            "pattern": "^rel-[A-Za-z0-9]+$"
+        },
+        "tag": {
+            "description": "Release tag name. Per #664 spec real releases use v<MAJOR>_<MINOR>_<PATCH>. Test runs append -test.<shortSha> (7 hex chars) so a test merge does not collide with a real release tag.",
+            "type": "string",
+            "pattern": "^v\\d+_\\d+_\\d+(-test\\.[0-9a-f]{7})?$"
+        },
+        "relCutData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "relUpdateData": {
+            "type": "object",
+            "required": ["branch", "version", "prev_release"],
+            "additionalProperties": false,
+            "properties": {
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
+            }
+        },
+        "tagData": {
+            "type": "object",
+            "required": ["tag", "branch", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "tag": { "$ref": "#/definitions/tag" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "version": { "$ref": "#/definitions/version" }
+            }
+        },
+        "docsBinariesData": {
+            "type": "object",
+            "required": ["version", "branch", "files"],
+            "additionalProperties": false,
+            "properties": {
+                "version": { "$ref": "#/definitions/version" },
+                "branch": { "$ref": "#/definitions/branch" },
+                "files": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/release/tests/fixtures/vendored/good/src/TagVerificationResult.php
+++ b/tools/release/tests/fixtures/vendored/good/src/TagVerificationResult.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Result of verifying a release tag against the openemr-devops#664 spec.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class TagVerificationResult
+{
+    /**
+     * @param list<string> $errors
+     */
+    public function __construct(
+        public string $tagName,
+        public bool $isAnnotated,
+        public ?string $version,
+        public ?string $date,
+        public ?string $mergeSha,
+        public array $errors,
+    ) {
+    }
+
+    public function isValid(): bool
+    {
+        return $this->errors === [];
+    }
+}

--- a/tools/release/tests/fixtures/vendored/good/src/TagVerifier.php
+++ b/tools/release/tests/fixtures/vendored/good/src/TagVerifier.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Verify a release tag is annotated and its message conforms to the
+ * openemr-devops#664 spec (contains a version, ISO date, and merge SHA).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Process\Process;
+
+final readonly class TagVerifier
+{
+    public function __construct(
+        private string $repoDir,
+    ) {
+    }
+
+    public function verify(string $tagName): TagVerificationResult
+    {
+        $errors = [];
+        $type = $this->git(['cat-file', '-t', $tagName]);
+        $isAnnotated = $type === 'tag';
+        if (!$isAnnotated) {
+            $errors[] = sprintf(
+                '%s is not annotated (object type: %s); the spec requires `git tag -a`',
+                $tagName,
+                $type,
+            );
+            return new TagVerificationResult($tagName, false, null, null, null, $errors);
+        }
+
+        $message = $this->extractMessage($this->git(['cat-file', '-p', $tagName]));
+
+        $version = $this->firstMatch('/\b(\d+\.\d+\.\d+)\b/', $message);
+        if ($version === null) {
+            $errors[] = 'tag message does not contain a version (MAJOR.MINOR.PATCH)';
+        }
+
+        $date = $this->firstMatch('/\b(\d{4}-\d{2}-\d{2})\b/', $message);
+        if ($date === null) {
+            $errors[] = 'tag message does not contain an ISO date (YYYY-MM-DD)';
+        }
+
+        $mergeSha = $this->firstMatch('/\b([0-9a-f]{40})\b/', $message);
+        if ($mergeSha === null) {
+            $errors[] = 'tag message does not contain a merge-commit SHA (40 hex chars)';
+        }
+
+        return new TagVerificationResult($tagName, true, $version, $date, $mergeSha, $errors);
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(array $args): string
+    {
+        $process = new Process(['git', ...$args], $this->repoDir);
+        $process->mustRun();
+        return rtrim($process->getOutput(), "\n");
+    }
+
+    /**
+     * Extract the message body of a `git cat-file -p <tag>` annotated-tag dump.
+     *
+     * Headers (object/type/tag/tagger) precede a blank line, then the message.
+     */
+    private function extractMessage(string $catFileOutput): string
+    {
+        $parts = preg_split('/\R\R/', $catFileOutput, 2);
+        if ($parts === false || count($parts) < 2) {
+            return '';
+        }
+        return $parts[1];
+    }
+
+    private function firstMatch(string $pattern, string $subject): ?string
+    {
+        if (preg_match($pattern, $subject, $matches) !== 1) {
+            return null;
+        }
+        return $matches[1];
+    }
+}


### PR DESCRIPTION
Adds the missing piece for catching cross-repo contract drift in CI: a reusable workflow consumer repos call to drift-check their vendored copies of `dispatch.schema.json`, `TagVerifier.php`, and `TagVerificationResult.php` against canonical, plus path-override flags that let website-openemr's non-canonical layout participate.

Refs openemr/openemr-devops#664. Closes the May 8 status snapshot's open follow-up: *"Drift-check tooling for the vendored `dispatch.schema.json` copies — today proved the manual propagation is a real failure mode."*

## Why now

The check-vendored tool itself has existed since #665 and was tightened in #668 (semantic equivalence: JSON canonicalization, namespace stripping). But **no consumer's CI runs it.** I confirmed this by running the tool locally against checkouts of openemr/openemr and openemr/website-openemr — both are silently drifted right now. The failure mode #700 hit (manual propagation skipped) is alive and well; without a CI gate in each consumer it'll keep biting us.

## What this PR adds

1. **`tools/release/src/VendoredFileChecker.php`** — optional canonical→consumer path-overrides map. Required because website-openemr vendored `TagVerifier` and `TagVerificationResult` into `src/Release/` instead of `src/`, so the checker could never validate it before. Drift findings now report the *consumer-relative* path so the failure points at the file the consumer actually has on disk.
2. **`tools/release/bin/check-vendored.php`** — two complementary flags:
   - `--override CANON=CONSUMER` (repeatable) for direct CLI use.
   - `--overrides` (single value, newline-delimited) for CI inputs that arrive as multi-line strings; the PHP CLI does the parsing so the calling workflow doesn't have to construct a flag list in shell.
3. **`.github/workflows/check-vendored-contracts.yml`** — `workflow_call` reusable workflow consumers invoke with one job:

   ```yaml
   jobs:
     drift:
       uses: openemr/openemr-devops/.github/workflows/check-vendored-contracts.yml@master
       with:
         consumer_subpath: tools/release
   ```

   website-openemr passes `path_overrides` to map its `src/Release/...` layout.
4. **`.github/workflows/vendored-contracts-self-test.yml`** + fixtures — exercises the reusable workflow against a canonical-layout fixture and a website-style override fixture inside this PR's CI, so the workflow has end-to-end coverage before any consumer adopts it.

Same shape as the reusable-workflow shim the May 8 follow-up on #664 proposes for the conductor itself; building it here at lower stakes validates the pattern before we apply it to the conductor.

## Adoption (separate PRs, after this lands)

- openemr/openemr — add a workflow that calls this one with `consumer_subpath: tools/release`. Will fail until the existing PHP-file drift is reconciled (this PR doesn't touch the canonical content, only the checker).
- openemr/website-openemr — add a workflow with `consumer_subpath: tools/release-docs` and the path overrides. Same drift-reconciliation prerequisite, plus the `TagVerificationResult` ↔ `VerificationResult` rename to sort out.

Both adoptions are blocked on a separate drift-reconciliation pass; this PR only ships the tooling so the gate *can* be added later without further changes here.

## Test plan

- [x] `vendor/bin/phpunit` — 14 tests, +4 covering override mapping, override-aware drift reporting, and unknown-key validation
- [x] `vendor/bin/phpcs` — clean
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `actionlint` on both new workflows — clean
- [x] CLI smoke-tested against both consumer checkouts — overrides resolve correctly, drift findings name the consumer's actual paths
- [x] Self-test workflow green on PR CI — both `good` and `good-with-overrides` jobs pass, validating the reusable workflow end-to-end