### PR TITLE
ci(release): switch token mint to client-id var

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -73,7 +73,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3.1
       with:
-        client-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         owner: openemr
         repositories: openemr

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -73,7 +73,7 @@ jobs:
       id: app-token
       uses: actions/create-github-app-token@v3.1
       with:
-        client-id: ${{ secrets.RELEASE_APP_ID }}
+        client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
         private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
         owner: openemr
         repositories: openemr

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -1,7 +1,8 @@
 name: Release Permissions Check
 
 # Manual probe of the release App's installed permissions on this repo.
-# Mints an App token from RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY and
+# Mints an App token from the RELEASE_APP_CLIENT_ID org variable +
+# RELEASE_APP_PRIVATE_KEY org secret and
 # exercises only what tools/release/ rotation needs (per docs/release-automation-plan.md).
 # Run after installing the App and after secrets rotations.
 
@@ -34,7 +35,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Probe — installation includes this repo

--- a/.github/workflows/release-rotation.yml
+++ b/.github/workflows/release-rotation.yml
@@ -44,7 +44,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout

--- a/.github/workflows/release-rotation.yml
+++ b/.github/workflows/release-rotation.yml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Mint release App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3.1
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -46,7 +46,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: openemr
           repositories: |

--- a/docs/release-automation-plan.md
+++ b/docs/release-automation-plan.md
@@ -93,7 +93,8 @@ host most of the rewrite logic.
 ## Permissions self-check
 
 `.github/workflows/release-permissions-check.yml` (manual `workflow_dispatch`).
-Mints an App token from `RELEASE_APP_ID` + `RELEASE_APP_PRIVATE_KEY` and
+Mints an App token from the `RELEASE_APP_CLIENT_ID` org variable +
+`RELEASE_APP_PRIVATE_KEY` org secret and
 probes only what this repo's rotation workflow needs:
 
 - `GET /installation/repositories` — confirm this repo is in the install list.


### PR DESCRIPTION
The `RELEASE_APP_ID` org secret was deleted in favor of a `RELEASE_APP_CLIENT_ID` org variable (#701). This swaps every workflow that mints a release App token to the new variable and updates the plan doc to match.

Files touched:
- `.github/workflows/release-rotation.yml`
- `.github/workflows/release-permissions-check.yml`
- `.github/workflows/ship-release.yml`
- `.github/workflows/build-patch.yml`
- `.github/workflows/build-release.yml`
- `docs/release-automation-plan.md`

`build-patch.yml` and `build-release.yml` had already moved to the `client-id:` input but were still reading the deleted `secrets.RELEASE_APP_ID` — this fixes that half-migrated state. Private-key references are unchanged.