### PR TITLE
ci: build production and flex-3.22 images nightly

### DIFF
--- a/.github/workflows/build-322.yml
+++ b/.github/workflows/build-322.yml
@@ -15,6 +15,8 @@ name: Flex 3.22 Dockers Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-704.yml
+++ b/.github/workflows/build-704.yml
@@ -2,6 +2,8 @@ name: Production 7.0.4 Docker Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-800.yml
+++ b/.github/workflows/build-800.yml
@@ -2,6 +2,8 @@ name: Production 8.0.0 Docker Build
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

Adds a 2 AM UTC schedule to the three remaining manually-triggered Docker build workflows so the production tags get the same daily base-image refresh that dev and most flex variants already get:

- `build-704.yml` (production 7.0.4)
- `build-800.yml` (production 8.0.0, also republishes `latest`)
- `build-322.yml` (flex 3.22)

This matches the existing `0 2 * * *` cron on `build-810.yml`, `build-811.yml`, `build-323.yml`, and `build-edge.yml`.

## Notes

- `build-800.yml` will republish `openemr/openemr:latest` nightly. Intentional — `latest` should track the most recent rebuild of the current production image.
- Both production workflows already emit `<version>-<date>` tags, so each nightly run leaves an audit trail.
- If flex 3.22 is being sunsetted, drop that file from this PR.

## Test plan

- [ ] Confirm scheduled runs appear in the Actions tab after merge
- [ ] Verify next nightly produces fresh image digests on Docker Hub