### PR TITLE
feat(release): draft per-channel announcement workflow

### DIFF
--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -70,11 +70,22 @@ jobs:
               branch=${INPUT_BRANCH}
               forum_url=${INPUT_FORUM_URL}
           else
-              version=$(jq -r '.data.version' <<<"${CLIENT_PAYLOAD}")
-              tag=$(jq -r '.data.tag' <<<"${CLIENT_PAYLOAD}")
-              branch=$(jq -r '.data.branch' <<<"${CLIENT_PAYLOAD}")
+              # jq -r emits the literal string "null" for missing fields, so
+              # validate non-empty AND non-"null" before continuing — a
+              # malformed dispatch payload should fail loud, not produce
+              # artifacts referring to "null".
+              version=$(jq -re '.data.version // empty' <<<"${CLIENT_PAYLOAD}")
+              tag=$(jq -re '.data.tag // empty' <<<"${CLIENT_PAYLOAD}")
+              branch=$(jq -re '.data.branch // empty' <<<"${CLIENT_PAYLOAD}")
               forum_url=''
           fi
+          for field in version tag branch; do
+              value=${!field}
+              if [[ -z ${value} || ${value} == 'null' ]]; then
+                  printf '::error::dispatch payload missing or null: %s\n' "${field}"
+                  exit 1
+              fi
+          done
           {
               printf 'version=%s\n' "${version}"
               printf 'tag=%s\n' "${tag}"

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -30,7 +30,8 @@ on:
         required: false
         type: string
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: release-announcements-${{ github.event.client_payload.data.tag || inputs.tag }}

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -1,0 +1,138 @@
+name: Release Announcements (drafts)
+
+# Drafts-only first phase of openemr/openemr-devops#711 (tracked in #719).
+# On openemr-tag dispatch (or workflow_dispatch), renders a per-channel
+# announcement for forum/chat/X/Facebook/LinkedIn/mailing-list and surfaces
+# them as a workflow artifact + step summary. Maintainer copy/pastes onto
+# each channel; mailing list is sent separately via openemr-registration's
+# oe-sender.js, which takes the rendered mail.html + mail.subject.txt files
+# this workflow produces. No posting, no SMTP, no API integration.
+
+on:
+  repository_dispatch:
+    types: [openemr-tag]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. 8.1.0)'
+        required: true
+        type: string
+      tag:
+        description: 'Annotated release tag (e.g. v8_1_0)'
+        required: true
+        type: string
+      branch:
+        description: 'Release branch (e.g. rel-810)'
+        required: true
+        type: string
+      forum_url:
+        description: 'Per-release Discourse thread URL (optional; placeholder used if blank)'
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: release-announcements-${{ github.event.client_payload.data.tag || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  draft:
+    name: Render announcement drafts
+    runs-on: ubuntu-24.04
+    env:
+      EVENT_NAME: ${{ github.event_name }}
+      CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+      INPUT_VERSION: ${{ inputs.version }}
+      INPUT_TAG: ${{ inputs.tag }}
+      INPUT_BRANCH: ${{ inputs.branch }}
+      INPUT_FORUM_URL: ${{ inputs.forum_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - name: Install release-tools dependencies
+        working-directory: tools/release
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Derive release inputs
+        id: inputs
+        run: |
+          set -euo pipefail
+          if [[ ${EVENT_NAME} == 'workflow_dispatch' ]]; then
+              version=${INPUT_VERSION}
+              tag=${INPUT_TAG}
+              branch=${INPUT_BRANCH}
+              forum_url=${INPUT_FORUM_URL}
+          else
+              version=$(jq -r '.data.version' <<<"${CLIENT_PAYLOAD}")
+              tag=$(jq -r '.data.tag' <<<"${CLIENT_PAYLOAD}")
+              branch=$(jq -r '.data.branch' <<<"${CLIENT_PAYLOAD}")
+              forum_url=''
+          fi
+          {
+              printf 'version=%s\n' "${version}"
+              printf 'tag=%s\n' "${tag}"
+              printf 'branch=%s\n' "${branch}"
+              printf 'forum_url=%s\n' "${forum_url:-{{FORUM_URL}}}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Render announcements
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          BRANCH: ${{ steps.inputs.outputs.branch }}
+          FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p out/announcements
+          php tools/release/bin/render-announcements.php \
+              --output-dir=out/announcements \
+              --release-version="${VERSION}" \
+              --release-tag="${TAG}" \
+              --release-branch="${BRANCH}" \
+              --forum-url="${FORUM_URL}"
+
+      - name: Write step summary
+        env:
+          VERSION: ${{ steps.inputs.outputs.version }}
+          TAG: ${{ steps.inputs.outputs.tag }}
+          FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2016  # backticks below are markdown code spans, not command substitution
+          summary() { printf '%s\n' "$@" >> "${GITHUB_STEP_SUMMARY}"; }
+          channel() {
+              local heading=$1 path=$2 fence=${3:-text}
+              summary "## ${heading}" '' "\`\`\`${fence}"
+              cat "out/announcements/${path}" >> "${GITHUB_STEP_SUMMARY}"
+              summary '```' ''
+          }
+          summary "# Release announcement drafts — OpenEMR ${VERSION} (${TAG})" ''
+          if [[ ${FORUM_URL} == '{{FORUM_URL}}' ]]; then
+              summary "> **Forum URL placeholder.** Find/replace \`{{FORUM_URL}}\` in the rendered output once you create the Discourse thread." ''
+          fi
+          channel 'Forum (Discourse)' forum.md markdown
+          channel 'Chat' chat.md markdown
+          channel 'X' x.txt
+          channel 'Facebook' facebook.txt
+          channel 'LinkedIn' linkedin.txt
+          # shellcheck disable=SC2016  # backticks are markdown code spans
+          summary '## Mailing list' '' \
+              'Three artifacts are uploaded with the workflow run:' '' \
+              '- `mail.subject.txt` — pass to `oe-sender.js -s`' \
+              '- `mail.html` — pass to `oe-sender.js -f`' \
+              '- `mail.eml` — preview in a mail client; not used by the sender' '' \
+              'Production sender lives in [openemr-registration/oe-sender.js](https://github.com/openemr/openemr-registration/blob/master/oe-sender.js); recipients come from the DynamoDB scan, not from the `.eml` headers.'
+
+      - name: Upload announcement drafts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-announcements
+          path: out/announcements/
+          if-no-files-found: error

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -41,12 +41,7 @@ jobs:
     name: Render announcement drafts
     runs-on: ubuntu-24.04
     env:
-      EVENT_NAME: ${{ github.event_name }}
-      CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
-      INPUT_VERSION: ${{ inputs.version }}
-      INPUT_TAG: ${{ inputs.tag }}
-      INPUT_BRANCH: ${{ inputs.branch }}
-      INPUT_FORUM_URL: ${{ inputs.forum_url }}
+      OUTPUT_DIR: ${{ github.workspace }}/out/announcements
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -66,77 +61,43 @@ jobs:
       - name: Derive release inputs
         id: inputs
         working-directory: tools/release
+        env:
+          # repository_dispatch path: PAYLOAD_FILE='-' on stdin, all other vars empty.
+          # workflow_dispatch path:    PAYLOAD_FILE empty, VERSION/TAG/BRANCH/FORUM_URL set.
+          # The PHP CLI rejects mixing the two and validates each field against
+          # the canonical dispatch.schema.json patterns; missing/null/malformed
+          # envelopes abort here instead of producing artifacts that reference "null".
+          PAYLOAD_FILE: ${{ github.event_name == 'repository_dispatch' && '-' || '' }}
+          VERSION: ${{ inputs.version }}
+          TAG: ${{ inputs.tag }}
+          BRANCH: ${{ inputs.branch }}
+          FORUM_URL: ${{ inputs.forum_url }}
+          CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
         run: |
-          set -euo pipefail
-          if [[ ${EVENT_NAME} == 'workflow_dispatch' ]]; then
-              {
-                  printf 'version=%s\n' "${INPUT_VERSION}"
-                  printf 'tag=%s\n' "${INPUT_TAG}"
-                  printf 'branch=%s\n' "${INPUT_BRANCH}"
-                  printf 'forum_url=%s\n' "${INPUT_FORUM_URL:-{{FORUM_URL}}}"
-              } >> "${GITHUB_OUTPUT}"
-          else
-              # AnnouncementDispatchPayload validates each field against the
-              # canonical dispatch.schema.json patterns; a missing/null/
-              # malformed envelope aborts the step instead of producing
-              # artifacts that reference "null".
-              printf '%s' "${CLIENT_PAYLOAD}" \
-                  | task release:derive-announcement-inputs PAYLOAD_FILE='-' \
-                  >> "${GITHUB_OUTPUT}"
-              printf 'forum_url=%s\n' '{{FORUM_URL}}' >> "${GITHUB_OUTPUT}"
-          fi
+          printf '%s' "${CLIENT_PAYLOAD}" \
+              | task release:derive-announcement-inputs \
+              >> "${GITHUB_OUTPUT}"
 
       - name: Render announcements
+        working-directory: tools/release
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
           TAG: ${{ steps.inputs.outputs.tag }}
           BRANCH: ${{ steps.inputs.outputs.branch }}
           FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
-        run: |
-          set -euo pipefail
-          mkdir -p out/announcements
-          php tools/release/bin/render-announcements.php \
-              --output-dir=out/announcements \
-              --release-version="${VERSION}" \
-              --release-tag="${TAG}" \
-              --release-branch="${BRANCH}" \
-              --forum-url="${FORUM_URL}"
+        run: task release:render-announcements
 
       - name: Write step summary
+        working-directory: tools/release
         env:
           VERSION: ${{ steps.inputs.outputs.version }}
           TAG: ${{ steps.inputs.outputs.tag }}
           FORUM_URL: ${{ steps.inputs.outputs.forum_url }}
-        run: |
-          set -euo pipefail
-          # shellcheck disable=SC2016  # backticks below are markdown code spans, not command substitution
-          summary() { printf '%s\n' "$@" >> "${GITHUB_STEP_SUMMARY}"; }
-          channel() {
-              local heading=$1 path=$2 fence=${3:-text}
-              summary "## ${heading}" '' "\`\`\`${fence}"
-              cat "out/announcements/${path}" >> "${GITHUB_STEP_SUMMARY}"
-              summary '```' ''
-          }
-          summary "# Release announcement drafts — OpenEMR ${VERSION} (${TAG})" ''
-          if [[ ${FORUM_URL} == '{{FORUM_URL}}' ]]; then
-              summary "> **Forum URL placeholder.** Find/replace \`{{FORUM_URL}}\` in the rendered output once you create the Discourse thread." ''
-          fi
-          channel 'Forum (Discourse)' forum.md markdown
-          channel 'Chat' chat.md markdown
-          channel 'X' x.txt
-          channel 'Facebook' facebook.txt
-          channel 'LinkedIn' linkedin.txt
-          # shellcheck disable=SC2016  # backticks are markdown code spans
-          summary '## Mailing list' '' \
-              'Three artifacts are uploaded with the workflow run:' '' \
-              '- `mail.subject.txt` — pass to `oe-sender.js -s`' \
-              '- `mail.html` — pass to `oe-sender.js -f`' \
-              '- `mail.eml` — preview in a mail client; not used by the sender' '' \
-              'Production sender lives in [openemr-registration/oe-sender.js](https://github.com/openemr/openemr-registration/blob/master/oe-sender.js); recipients come from the DynamoDB scan, not from the `.eml` headers.'
+        run: OUTPUT="${GITHUB_STEP_SUMMARY}" task release:render-announcement-step-summary
 
       - name: Upload announcement drafts
         uses: actions/upload-artifact@v7
         with:
           name: release-announcements
-          path: out/announcements/
+          path: ${{ env.OUTPUT_DIR }}/
           if-no-files-found: error

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -56,42 +56,35 @@ jobs:
         with:
           php-version: '8.5'
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
       - name: Install release-tools dependencies
         working-directory: tools/release
         run: composer install --no-interaction --no-progress --prefer-dist
 
       - name: Derive release inputs
         id: inputs
+        working-directory: tools/release
         run: |
           set -euo pipefail
           if [[ ${EVENT_NAME} == 'workflow_dispatch' ]]; then
-              version=${INPUT_VERSION}
-              tag=${INPUT_TAG}
-              branch=${INPUT_BRANCH}
-              forum_url=${INPUT_FORUM_URL}
+              {
+                  printf 'version=%s\n' "${INPUT_VERSION}"
+                  printf 'tag=%s\n' "${INPUT_TAG}"
+                  printf 'branch=%s\n' "${INPUT_BRANCH}"
+                  printf 'forum_url=%s\n' "${INPUT_FORUM_URL:-{{FORUM_URL}}}"
+              } >> "${GITHUB_OUTPUT}"
           else
-              # jq -r emits the literal string "null" for missing fields, so
-              # validate non-empty AND non-"null" before continuing — a
-              # malformed dispatch payload should fail loud, not produce
-              # artifacts referring to "null".
-              version=$(jq -re '.data.version // empty' <<<"${CLIENT_PAYLOAD}")
-              tag=$(jq -re '.data.tag // empty' <<<"${CLIENT_PAYLOAD}")
-              branch=$(jq -re '.data.branch // empty' <<<"${CLIENT_PAYLOAD}")
-              forum_url=''
+              # AnnouncementDispatchPayload validates each field against the
+              # canonical dispatch.schema.json patterns; a missing/null/
+              # malformed envelope aborts the step instead of producing
+              # artifacts that reference "null".
+              printf '%s' "${CLIENT_PAYLOAD}" \
+                  | task release:derive-announcement-inputs PAYLOAD_FILE='-' \
+                  >> "${GITHUB_OUTPUT}"
+              printf 'forum_url=%s\n' '{{FORUM_URL}}' >> "${GITHUB_OUTPUT}"
           fi
-          for field in version tag branch; do
-              value=${!field}
-              if [[ -z ${value} || ${value} == 'null' ]]; then
-                  printf '::error::dispatch payload missing or null: %s\n' "${field}"
-                  exit 1
-              fi
-          done
-          {
-              printf 'version=%s\n' "${version}"
-              printf 'tag=%s\n' "${tag}"
-              printf 'branch=%s\n' "${branch}"
-              printf 'forum_url=%s\n' "${forum_url:-{{FORUM_URL}}}"
-          } >> "${GITHUB_OUTPUT}"
 
       - name: Render announcements
         env:

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -131,7 +131,7 @@ jobs:
               'Production sender lives in [openemr-registration/oe-sender.js](https://github.com/openemr/openemr-registration/blob/master/oe-sender.js); recipients come from the DynamoDB scan, not from the `.eml` headers.'
 
       - name: Upload announcement drafts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-announcements
           path: out/announcements/

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -206,14 +206,44 @@ tasks:
         --payload-file={{shellQuote .PAYLOAD_FILE}}
 
   release:derive-announcement-inputs:
-    desc: Translate an openemr-tag dispatch envelope into version=/tag=/branch= lines
-    vars:
-      PAYLOAD_FILE: '{{.PAYLOAD_FILE | default "-"}}'
+    desc: Emit version/tag/branch/forum_url lines for the announcements workflow
     deps: [setup]
     cmds:
       - >-
         php bin/derive-announcement-inputs.php
-        --payload-file={{shellQuote .PAYLOAD_FILE}}
+        {{if .PAYLOAD_FILE}}--payload-file={{shellQuote .PAYLOAD_FILE}}{{end}}
+        {{if .VERSION}}--release-version={{shellQuote .VERSION}}{{end}}
+        {{if .TAG}}--release-tag={{shellQuote .TAG}}{{end}}
+        {{if .BRANCH}}--release-branch={{shellQuote .BRANCH}}{{end}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+
+  release:render-announcements:
+    desc: Render per-channel release-announcement drafts to a directory
+    requires:
+      vars: [OUTPUT_DIR, VERSION, TAG, BRANCH]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/render-announcements.php
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+        --release-version={{shellQuote .VERSION}}
+        --release-tag={{shellQuote .TAG}}
+        --release-branch={{shellQuote .BRANCH}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+
+  release:render-announcement-step-summary:
+    desc: Render the GitHub Actions step-summary markdown for the announcement drafts
+    requires:
+      vars: [OUTPUT_DIR, VERSION, TAG]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/render-announcement-step-summary.php
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+        --release-version={{shellQuote .VERSION}}
+        --release-tag={{shellQuote .TAG}}
+        {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
+        {{if .OUTPUT}}--output={{shellQuote .OUTPUT}}{{end}}
 
   release:open-rotation-pr:
     desc: Open or update the long-lived rotation draft PR

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -205,6 +205,16 @@ tasks:
         --event-type={{shellQuote .EVENT_TYPE}}
         --payload-file={{shellQuote .PAYLOAD_FILE}}
 
+  release:derive-announcement-inputs:
+    desc: Translate an openemr-tag dispatch envelope into version=/tag=/branch= lines
+    vars:
+      PAYLOAD_FILE: '{{.PAYLOAD_FILE | default "-"}}'
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/derive-announcement-inputs.php
+        --payload-file={{shellQuote .PAYLOAD_FILE}}
+
   release:open-rotation-pr:
     desc: Open or update the long-lived rotation draft PR
     requires:

--- a/tools/release/bin/derive-announcement-inputs.php
+++ b/tools/release/bin/derive-announcement-inputs.php
@@ -26,6 +26,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 use OpenEMR\Release\AnnouncementDispatchPayload;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 
@@ -49,6 +50,9 @@ use Symfony\Component\Console\SingleCommandApplication;
         '',
     )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        // Stdout is reserved for the GITHUB_OUTPUT key=value lines the
+        // workflow appends with `>>`. Errors must not pollute it.
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
         $str = static function (string $name) use ($input): string {
             $value = $input->getOption($name);
             return is_string($value) ? $value : '';
@@ -63,13 +67,13 @@ use Symfony\Component\Console\SingleCommandApplication;
             static fn (string $v): bool => $v !== '',
         );
         if ($payloadFile !== '' && $flagsProvided !== []) {
-            $output->writeln(
+            $err->writeln(
                 '<error>--payload-file is mutually exclusive with --release-* flags</error>',
             );
             return 1;
         }
         if ($payloadFile === '' && count($flagsProvided) !== 3) {
-            $output->writeln(
+            $err->writeln(
                 '<error>Provide either --payload-file or all of'
                 . ' --release-version/--release-tag/--release-branch</error>',
             );
@@ -81,10 +85,10 @@ use Symfony\Component\Console\SingleCommandApplication;
                 ? AnnouncementDispatchPayload::fromPayloadFile($payloadFile)
                 : new AnnouncementDispatchPayload($version, $tag, $branch);
         } catch (\JsonException $e) {
-            $output->writeln(sprintf('<error>Payload is not valid JSON: %s</error>', $e->getMessage()));
+            $err->writeln(sprintf('<error>Payload is not valid JSON: %s</error>', $e->getMessage()));
             return 1;
         } catch (\RuntimeException $e) {
-            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            $err->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             return 1;
         }
 

--- a/tools/release/bin/derive-announcement-inputs.php
+++ b/tools/release/bin/derive-announcement-inputs.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Translate an `openemr-tag` repository_dispatch envelope into the
+ * `version=` / `tag=` / `branch=` lines the release-announcements
+ * workflow appends to $GITHUB_OUTPUT.
+ *
+ * Validation lives in AnnouncementDispatchPayload (mirrors the canonical
+ * dispatch.schema.json patterns); a missing or malformed field aborts
+ * the step instead of producing artifacts that reference "null".
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\AnnouncementDispatchPayload;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('derive-announcement-inputs')
+    ->setDescription('Convert an openemr-tag dispatch envelope into key=value lines for the announcements workflow')
+    ->addOption(
+        'payload-file',
+        null,
+        InputOption::VALUE_REQUIRED,
+        "Path to JSON envelope (use '-' for stdin)",
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $payloadFile = $input->getOption('payload-file');
+        if (!is_string($payloadFile) || $payloadFile === '') {
+            $output->writeln('<error>--payload-file is required (use - for stdin)</error>');
+            return 1;
+        }
+
+        if ($payloadFile === '-') {
+            $raw = (string) file_get_contents('php://stdin');
+        } else {
+            if (!is_file($payloadFile)) {
+                $output->writeln(sprintf('<error>Payload file not found: %s</error>', $payloadFile));
+                return 1;
+            }
+            $contents = file_get_contents($payloadFile);
+            if ($contents === false) {
+                $output->writeln(sprintf('<error>Payload file unreadable: %s</error>', $payloadFile));
+                return 1;
+            }
+            $raw = $contents;
+        }
+        if ($raw === '') {
+            $output->writeln(sprintf('<error>Empty payload from: %s</error>', $payloadFile));
+            return 1;
+        }
+
+        try {
+            $envelope = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            $payload = AnnouncementDispatchPayload::fromEnvelope($envelope);
+        } catch (\JsonException $e) {
+            $output->writeln(sprintf('<error>Payload is not valid JSON: %s</error>', $e->getMessage()));
+            return 1;
+        } catch (\RuntimeException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return 1;
+        }
+
+        $output->writeln(sprintf('version=%s', $payload->version));
+        $output->writeln(sprintf('tag=%s', $payload->tag));
+        $output->writeln(sprintf('branch=%s', $payload->branch));
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/derive-announcement-inputs.php
+++ b/tools/release/bin/derive-announcement-inputs.php
@@ -2,9 +2,11 @@
 <?php
 
 /**
- * Translate an `openemr-tag` repository_dispatch envelope into the
- * `version=` / `tag=` / `branch=` lines the release-announcements
- * workflow appends to $GITHUB_OUTPUT.
+ * Emit the `version=` / `tag=` / `branch=` / `forum_url=` lines the
+ * release-announcements workflow appends to $GITHUB_OUTPUT, regardless
+ * of whether the trigger was an `openemr-tag` repository_dispatch
+ * (--payload-file) or a manual workflow_dispatch (--release-version /
+ * --release-tag / --release-branch / --forum-url).
  *
  * Validation lives in AnnouncementDispatchPayload (mirrors the canonical
  * dispatch.schema.json patterns); a missing or malformed field aborts
@@ -29,42 +31,55 @@ use Symfony\Component\Console\SingleCommandApplication;
 
 (new SingleCommandApplication())
     ->setName('derive-announcement-inputs')
-    ->setDescription('Convert an openemr-tag dispatch envelope into key=value lines for the announcements workflow')
+    ->setDescription('Emit version/tag/branch/forum_url lines for the announcements workflow')
     ->addOption(
         'payload-file',
         null,
         InputOption::VALUE_REQUIRED,
-        "Path to JSON envelope (use '-' for stdin)",
+        "Path to openemr-tag JSON envelope (use '-' for stdin). Mutually exclusive with --release-* flags.",
+    )
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption('release-branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g. rel-810)')
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Per-release Discourse thread URL; empty value falls back to the placeholder',
+        '',
     )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        $payloadFile = $input->getOption('payload-file');
-        if (!is_string($payloadFile) || $payloadFile === '') {
-            $output->writeln('<error>--payload-file is required (use - for stdin)</error>');
+        $str = static function (string $name) use ($input): string {
+            $value = $input->getOption($name);
+            return is_string($value) ? $value : '';
+        };
+        $payloadFile = $str('payload-file');
+        $version = $str('release-version');
+        $tag = $str('release-tag');
+        $branch = $str('release-branch');
+
+        $flagsProvided = array_filter(
+            [$version, $tag, $branch],
+            static fn (string $v): bool => $v !== '',
+        );
+        if ($payloadFile !== '' && $flagsProvided !== []) {
+            $output->writeln(
+                '<error>--payload-file is mutually exclusive with --release-* flags</error>',
+            );
             return 1;
         }
-
-        if ($payloadFile === '-') {
-            $raw = (string) file_get_contents('php://stdin');
-        } else {
-            if (!is_file($payloadFile)) {
-                $output->writeln(sprintf('<error>Payload file not found: %s</error>', $payloadFile));
-                return 1;
-            }
-            $contents = file_get_contents($payloadFile);
-            if ($contents === false) {
-                $output->writeln(sprintf('<error>Payload file unreadable: %s</error>', $payloadFile));
-                return 1;
-            }
-            $raw = $contents;
-        }
-        if ($raw === '') {
-            $output->writeln(sprintf('<error>Empty payload from: %s</error>', $payloadFile));
+        if ($payloadFile === '' && count($flagsProvided) !== 3) {
+            $output->writeln(
+                '<error>Provide either --payload-file or all of'
+                . ' --release-version/--release-tag/--release-branch</error>',
+            );
             return 1;
         }
 
         try {
-            $envelope = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
-            $payload = AnnouncementDispatchPayload::fromEnvelope($envelope);
+            $payload = $payloadFile !== ''
+                ? AnnouncementDispatchPayload::fromPayloadFile($payloadFile)
+                : new AnnouncementDispatchPayload($version, $tag, $branch);
         } catch (\JsonException $e) {
             $output->writeln(sprintf('<error>Payload is not valid JSON: %s</error>', $e->getMessage()));
             return 1;
@@ -73,9 +88,15 @@ use Symfony\Component\Console\SingleCommandApplication;
             return 1;
         }
 
+        // Emit forum_url verbatim (possibly empty); downstream renderers
+        // substitute their own placeholder when the maintainer hasn't
+        // supplied a real URL. Keeping the placeholder string out of the
+        // pipeline avoids Taskfile/Go-template confusion over the literal
+        // braces.
         $output->writeln(sprintf('version=%s', $payload->version));
         $output->writeln(sprintf('tag=%s', $payload->tag));
         $output->writeln(sprintf('branch=%s', $payload->branch));
+        $output->writeln(sprintf('forum_url=%s', $str('forum-url')));
         return 0;
     })
     ->run();

--- a/tools/release/bin/render-announcement-step-summary.php
+++ b/tools/release/bin/render-announcement-step-summary.php
@@ -1,0 +1,84 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Render the GitHub Actions step-summary markdown for the
+ * release-announcements workflow.
+ *
+ * Reads the per-channel files AnnouncementRenderer wrote into
+ * --output-dir and emits the summary markdown to stdout (or --output);
+ * the workflow appends it to $GITHUB_STEP_SUMMARY.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\AnnouncementRenderer;
+use OpenEMR\Release\AnnouncementStepSummaryRenderer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('render-announcement-step-summary')
+    ->setDescription('Render the GitHub Actions step-summary markdown for the announcement drafts')
+    ->addOption(
+        'template-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Twig template directory (defaults to the binary\'s sibling templates/ dir)',
+    )
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Directory containing the per-channel rendered files')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Forum URL value rendered into the summary; defaults to the placeholder',
+        AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+    )
+    ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file (defaults to stdout)')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $templateDir = $input->getOption('template-dir');
+        if (!is_string($templateDir) || $templateDir === '') {
+            $templateDir = dirname(__DIR__) . '/templates';
+        }
+
+        foreach (['output-dir', 'release-version', 'release-tag'] as $required) {
+            $value = $input->getOption($required);
+            if (!is_string($value) || $value === '') {
+                $output->writeln(sprintf('<error>--%s is required</error>', $required));
+                return 1;
+            }
+        }
+        /** @var string $outputDir */
+        $outputDir = $input->getOption('output-dir');
+        /** @var string $version */
+        $version = $input->getOption('release-version');
+        /** @var string $tag */
+        $tag = $input->getOption('release-tag');
+        $forumUrl = $input->getOption('forum-url');
+        if (!is_string($forumUrl) || $forumUrl === '') {
+            $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER;
+        }
+
+        $rendered = (new AnnouncementStepSummaryRenderer($templateDir))->render($outputDir, $version, $tag, $forumUrl);
+
+        $target = $input->getOption('output');
+        if (is_string($target) && $target !== '') {
+            file_put_contents($target, $rendered);
+            return 0;
+        }
+        $output->write($rendered);
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/render-announcement-step-summary.php
+++ b/tools/release/bin/render-announcement-step-summary.php
@@ -24,6 +24,7 @@ use OpenEMR\Release\AnnouncementRenderer;
 use OpenEMR\Release\AnnouncementStepSummaryRenderer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 
@@ -48,6 +49,7 @@ use Symfony\Component\Console\SingleCommandApplication;
     )
     ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'Output file (defaults to stdout)')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
         $templateDir = $input->getOption('template-dir');
         if (!is_string($templateDir) || $templateDir === '') {
             $templateDir = dirname(__DIR__) . '/templates';
@@ -56,7 +58,7 @@ use Symfony\Component\Console\SingleCommandApplication;
         foreach (['output-dir', 'release-version', 'release-tag'] as $required) {
             $value = $input->getOption($required);
             if (!is_string($value) || $value === '') {
-                $output->writeln(sprintf('<error>--%s is required</error>', $required));
+                $err->writeln(sprintf('<error>--%s is required</error>', $required));
                 return 1;
             }
         }

--- a/tools/release/bin/render-announcements.php
+++ b/tools/release/bin/render-announcements.php
@@ -30,17 +30,10 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->setName('render-announcements')
     ->setDescription('Render per-channel release-announcement drafts')
     ->addOption(
-        'repo',
-        null,
-        InputOption::VALUE_REQUIRED,
-        'Path to the repo root',
-        getcwd() === false ? '.' : getcwd(),
-    )
-    ->addOption(
         'template-dir',
         null,
         InputOption::VALUE_REQUIRED,
-        'Twig template directory (defaults to <repo>/tools/release/templates)',
+        'Twig template directory (defaults to the binary\'s sibling templates/ dir)',
     )
     ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Directory to write per-channel files into')
     ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
@@ -63,18 +56,12 @@ use Symfony\Component\Console\SingleCommandApplication;
         null,
         InputOption::VALUE_REQUIRED,
         'Per-release Discourse thread URL; left as a placeholder if not supplied',
-        '{{FORUM_URL}}',
+        AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
     )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
-        $repo = $input->getOption('repo');
-        if (!is_string($repo) || $repo === '') {
-            $output->writeln('<error>--repo is required</error>');
-            return 1;
-        }
-
         $templateDir = $input->getOption('template-dir');
         if (!is_string($templateDir) || $templateDir === '') {
-            $templateDir = $repo . '/tools/release/templates';
+            $templateDir = dirname(__DIR__) . '/templates';
         }
         if (!is_dir($templateDir)) {
             $output->writeln("<error>Template directory not found: {$templateDir}</error>");
@@ -118,7 +105,7 @@ use Symfony\Component\Console\SingleCommandApplication;
 
         $forumUrl = $input->getOption('forum-url');
         if (!is_string($forumUrl) || $forumUrl === '') {
-            $forumUrl = '{{FORUM_URL}}';
+            $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER;
         }
 
         $context = [

--- a/tools/release/bin/render-announcements.php
+++ b/tools/release/bin/render-announcements.php
@@ -23,6 +23,7 @@ require dirname(__DIR__) . '/vendor/autoload.php';
 use OpenEMR\Release\AnnouncementRenderer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 
@@ -59,29 +60,30 @@ use Symfony\Component\Console\SingleCommandApplication;
         AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
     )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $err = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : $output;
         $templateDir = $input->getOption('template-dir');
         if (!is_string($templateDir) || $templateDir === '') {
             $templateDir = dirname(__DIR__) . '/templates';
         }
         if (!is_dir($templateDir)) {
-            $output->writeln("<error>Template directory not found: {$templateDir}</error>");
+            $err->writeln("<error>Template directory not found: {$templateDir}</error>");
             return 1;
         }
 
         $outputDir = $input->getOption('output-dir');
         if (!is_string($outputDir) || $outputDir === '') {
-            $output->writeln('<error>--output-dir is required</error>');
+            $err->writeln('<error>--output-dir is required</error>');
             return 1;
         }
         if (!is_dir($outputDir) && !mkdir($outputDir, 0755, true) && !is_dir($outputDir)) {
-            $output->writeln("<error>Failed to create output dir: {$outputDir}</error>");
+            $err->writeln("<error>Failed to create output dir: {$outputDir}</error>");
             return 1;
         }
 
         foreach (['release-version', 'release-tag', 'release-branch'] as $required) {
             $value = $input->getOption($required);
             if (!is_string($value) || $value === '') {
-                $output->writeln("<error>--{$required} is required</error>");
+                $err->writeln("<error>--{$required} is required</error>");
                 return 1;
             }
         }

--- a/tools/release/bin/render-announcements.php
+++ b/tools/release/bin/render-announcements.php
@@ -1,0 +1,156 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Render per-channel release-announcement drafts to a directory.
+ *
+ * Wraps AnnouncementRenderer; called by .github/workflows/release-announcements.yml
+ * on openemr-tag dispatch (or workflow_dispatch). Writes one file per channel
+ * plus a synthesized mail.eml preview the maintainer can drag into a mail
+ * client. No posting, no sending. See openemr/openemr-devops#719.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\AnnouncementRenderer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('render-announcements')
+    ->setDescription('Render per-channel release-announcement drafts')
+    ->addOption(
+        'repo',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the repo root',
+        getcwd() === false ? '.' : getcwd(),
+    )
+    ->addOption(
+        'template-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Twig template directory (defaults to <repo>/tools/release/templates)',
+    )
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Directory to write per-channel files into')
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
+    ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
+    ->addOption('release-branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g. rel-810)')
+    ->addOption(
+        'release-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'GitHub release URL (defaults to https://github.com/openemr/openemr/releases/tag/<tag>)',
+    )
+    ->addOption(
+        'release-notes-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Release-notes URL (defaults to the wiki Release Features anchor for the version)',
+    )
+    ->addOption(
+        'forum-url',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Per-release Discourse thread URL; left as a placeholder if not supplied',
+        '{{FORUM_URL}}',
+    )
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $repo = $input->getOption('repo');
+        if (!is_string($repo) || $repo === '') {
+            $output->writeln('<error>--repo is required</error>');
+            return 1;
+        }
+
+        $templateDir = $input->getOption('template-dir');
+        if (!is_string($templateDir) || $templateDir === '') {
+            $templateDir = $repo . '/tools/release/templates';
+        }
+        if (!is_dir($templateDir)) {
+            $output->writeln("<error>Template directory not found: {$templateDir}</error>");
+            return 1;
+        }
+
+        $outputDir = $input->getOption('output-dir');
+        if (!is_string($outputDir) || $outputDir === '') {
+            $output->writeln('<error>--output-dir is required</error>');
+            return 1;
+        }
+        if (!is_dir($outputDir) && !mkdir($outputDir, 0755, true) && !is_dir($outputDir)) {
+            $output->writeln("<error>Failed to create output dir: {$outputDir}</error>");
+            return 1;
+        }
+
+        foreach (['release-version', 'release-tag', 'release-branch'] as $required) {
+            $value = $input->getOption($required);
+            if (!is_string($value) || $value === '') {
+                $output->writeln("<error>--{$required} is required</error>");
+                return 1;
+            }
+        }
+
+        /** @var string $version */
+        $version = $input->getOption('release-version');
+        /** @var string $tag */
+        $tag = $input->getOption('release-tag');
+        /** @var string $branch */
+        $branch = $input->getOption('release-branch');
+
+        $releaseUrl = $input->getOption('release-url');
+        if (!is_string($releaseUrl) || $releaseUrl === '') {
+            $releaseUrl = "https://github.com/openemr/openemr/releases/tag/{$tag}";
+        }
+
+        $releaseNotesUrl = $input->getOption('release-notes-url');
+        if (!is_string($releaseNotesUrl) || $releaseNotesUrl === '') {
+            $releaseNotesUrl = 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_' . $version;
+        }
+
+        $forumUrl = $input->getOption('forum-url');
+        if (!is_string($forumUrl) || $forumUrl === '') {
+            $forumUrl = '{{FORUM_URL}}';
+        }
+
+        $context = [
+            'version' => $version,
+            'tag' => $tag,
+            'branch' => $branch,
+            'release_url' => $releaseUrl,
+            'release_notes_url' => $releaseNotesUrl,
+            'forum_url' => $forumUrl,
+        ];
+
+        $rendered = (new AnnouncementRenderer($templateDir))->renderAll($context);
+
+        foreach ($rendered as $name => $body) {
+            file_put_contents($outputDir . '/' . $name, $body);
+            $output->writeln("Wrote <info>{$name}</info>");
+        }
+
+        // .eml is a preview only: oe-sender.js hard-codes Source and reads
+        // recipients from DynamoDB; these headers exist so the maintainer can
+        // open the file in a mail client to eyeball the rendered HTML.
+        $emlHeaders = implode("\r\n", [
+            'From: OpenEMR <no-reply@open-emr.org>',
+            'To: OpenEMR Announce <announce@open-emr.org>',
+            'Subject: ' . trim($rendered['mail.subject.txt']),
+            'MIME-Version: 1.0',
+            'Content-Type: text/html; charset=UTF-8',
+            'Content-Transfer-Encoding: 8bit',
+        ]);
+        file_put_contents($outputDir . '/mail.eml', $emlHeaders . "\r\n\r\n" . $rendered['mail.html']);
+        $output->writeln('Wrote <info>mail.eml</info> (preview)');
+
+        return 0;
+    })
+    ->run();

--- a/tools/release/src/AnnouncementDispatchPayload.php
+++ b/tools/release/src/AnnouncementDispatchPayload.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Parsed `openemr-tag` repository_dispatch payload for the announcement
+ * workflow.
+ *
+ * Validates each field against the canonical pattern from
+ * tools/release/contracts/dispatch.schema.json so a malformed envelope
+ * fails loudly at parse time instead of producing artifacts that
+ * reference "null" or empty strings further down the pipeline.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class AnnouncementDispatchPayload
+{
+    // Patterns mirror dispatch.schema.json's tag/branch/version definitions.
+    private const VERSION_PATTERN = '/^\d+\.\d+\.\d+$/';
+    private const TAG_PATTERN = '/^v\d+_\d+_\d+(-test\.[0-9a-f]{7})?$/';
+    private const BRANCH_PATTERN = '/^rel-[A-Za-z0-9]+$/';
+
+    public function __construct(
+        public string $version,
+        public string $tag,
+        public string $branch,
+    ) {
+        $this->assertMatches('version', $version, self::VERSION_PATTERN);
+        $this->assertMatches('tag', $tag, self::TAG_PATTERN);
+        $this->assertMatches('branch', $branch, self::BRANCH_PATTERN);
+    }
+
+    public static function fromEnvelope(mixed $envelope): self
+    {
+        if (!is_array($envelope)) {
+            throw new \RuntimeException('Dispatch envelope is not a JSON object');
+        }
+        $event = $envelope['event'] ?? null;
+        if ($event !== 'openemr-tag') {
+            throw new \RuntimeException(sprintf(
+                'Expected event=openemr-tag, got: %s',
+                is_string($event) ? $event : '(missing)',
+            ));
+        }
+        $data = $envelope['data'] ?? null;
+        if (!is_array($data)) {
+            throw new \RuntimeException('Dispatch envelope missing data object');
+        }
+        $normalized = [];
+        foreach ($data as $key => $value) {
+            if (is_string($key)) {
+                $normalized[$key] = $value;
+            }
+        }
+        return new self(
+            self::stringField($normalized, 'version'),
+            self::stringField($normalized, 'tag'),
+            self::stringField($normalized, 'branch'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private static function stringField(array $data, string $name): string
+    {
+        $value = $data[$name] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw new \RuntimeException(sprintf('Dispatch payload missing or empty field: data.%s', $name));
+        }
+        return $value;
+    }
+
+    private function assertMatches(string $field, string $value, string $pattern): void
+    {
+        if (preg_match($pattern, $value) !== 1) {
+            throw new \RuntimeException(sprintf(
+                'Dispatch payload field %s does not match expected shape: %s',
+                $field,
+                $value,
+            ));
+        }
+    }
+}

--- a/tools/release/src/AnnouncementDispatchPayload.php
+++ b/tools/release/src/AnnouncementDispatchPayload.php
@@ -37,6 +37,29 @@ final readonly class AnnouncementDispatchPayload
         $this->assertMatches('branch', $branch, self::BRANCH_PATTERN);
     }
 
+    /**
+     * @throws \JsonException|\RuntimeException
+     */
+    public static function fromPayloadFile(string $path): self
+    {
+        if ($path === '-') {
+            $raw = (string) file_get_contents('php://stdin');
+        } else {
+            if (!is_file($path)) {
+                throw new \RuntimeException(sprintf('Payload file not found: %s', $path));
+            }
+            $contents = file_get_contents($path);
+            if ($contents === false) {
+                throw new \RuntimeException(sprintf('Payload file unreadable: %s', $path));
+            }
+            $raw = $contents;
+        }
+        if ($raw === '') {
+            throw new \RuntimeException(sprintf('Empty payload from: %s', $path));
+        }
+        return self::fromEnvelope(json_decode($raw, true, 512, JSON_THROW_ON_ERROR));
+    }
+
     public static function fromEnvelope(mixed $envelope): self
     {
         if (!is_array($envelope)) {

--- a/tools/release/src/AnnouncementRenderer.php
+++ b/tools/release/src/AnnouncementRenderer.php
@@ -25,6 +25,13 @@ use Twig\Loader\FilesystemLoader;
 final readonly class AnnouncementRenderer
 {
     /**
+     * Literal placeholder substituted into channels that link to the forum
+     * when the maintainer hasn't supplied the per-release Discourse URL yet.
+     * Find/replace target after the thread is created.
+     */
+    public const FORUM_URL_PLACEHOLDER = '{{FORUM_URL}}';
+
+    /**
      * Channel name → template filename (relative to the announcements dir).
      *
      * The keys are also the output filenames stripped of `.twig`. mail.eml

--- a/tools/release/src/AnnouncementRenderer.php
+++ b/tools/release/src/AnnouncementRenderer.php
@@ -28,7 +28,7 @@ final readonly class AnnouncementRenderer
      * Channel name → template filename (relative to the announcements dir).
      *
      * The keys are also the output filenames stripped of `.twig`. mail.eml
-     * is synthesized by the CLI from mail.html + mail.subject.
+     * is synthesized by the CLI from mail.html + mail.subject.txt.
      */
     public const CHANNELS = [
         'forum.md' => 'forum.md.twig',
@@ -62,9 +62,13 @@ final readonly class AnnouncementRenderer
         if (!is_dir($announcementsDir)) {
             throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
         }
+        // autoescape: 'name' picks the strategy from the template filename —
+        // *.html.twig gets HTML escaping; *.md.twig and *.txt.twig get none.
+        // The {{FORUM_URL}} placeholder is preserved verbatim because Twig
+        // doesn't touch literal text in templates.
         $twig = new Environment(
             new FilesystemLoader($announcementsDir),
-            ['autoescape' => false],
+            ['autoescape' => 'name'],
         );
 
         $rendered = [];

--- a/tools/release/src/AnnouncementRenderer.php
+++ b/tools/release/src/AnnouncementRenderer.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Render per-channel release-announcement drafts from Twig templates.
+ *
+ * Drafts only — no posting, no sending. The workflow that wraps this
+ * renderer surfaces the output in $GITHUB_STEP_SUMMARY and as run
+ * artifacts; a maintainer copy-pastes / forwards them to each channel.
+ * See openemr/openemr-devops#719.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final readonly class AnnouncementRenderer
+{
+    /**
+     * Channel name → template filename (relative to the announcements dir).
+     *
+     * The keys are also the output filenames stripped of `.twig`. mail.eml
+     * is synthesized by the CLI from mail.html + mail.subject.
+     */
+    public const CHANNELS = [
+        'forum.md' => 'forum.md.twig',
+        'chat.md' => 'chat.md.twig',
+        'x.txt' => 'x.txt.twig',
+        'facebook.txt' => 'facebook.txt.twig',
+        'linkedin.txt' => 'linkedin.txt.twig',
+        'mail.html' => 'mail.html.twig',
+        'mail.subject.txt' => 'mail.subject.txt.twig',
+    ];
+
+    public function __construct(
+        private string $templateDir,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     version: string,
+     *     tag: string,
+     *     branch: string,
+     *     release_url: string,
+     *     release_notes_url: string,
+     *     forum_url: string,
+     * } $context
+     * @return array<string, string> channel-output-name → rendered content
+     */
+    public function renderAll(array $context): array
+    {
+        $announcementsDir = $this->templateDir . '/announcements';
+        if (!is_dir($announcementsDir)) {
+            throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
+        }
+        $twig = new Environment(
+            new FilesystemLoader($announcementsDir),
+            ['autoescape' => false],
+        );
+
+        $rendered = [];
+        foreach (self::CHANNELS as $output => $template) {
+            $rendered[$output] = $twig->render($template, $context);
+        }
+        return $rendered;
+    }
+}

--- a/tools/release/src/AnnouncementStepSummaryRenderer.php
+++ b/tools/release/src/AnnouncementStepSummaryRenderer.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Render the GitHub Actions step-summary markdown for the
+ * release-announcements workflow from the per-channel files
+ * AnnouncementRenderer wrote to disk.
+ *
+ * Reads `forum.md`, `chat.md`, `x.txt`, `facebook.txt`, `linkedin.txt`
+ * out of the announcements output directory; the mailing-list channel
+ * appears as a static section pointing at the uploaded artifacts.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+
+final readonly class AnnouncementStepSummaryRenderer
+{
+    public const TEMPLATE_NAME = 'step-summary.md.twig';
+
+    /**
+     * Short-copy channels included inline in the step summary, in display
+     * order. Each entry is [filename, heading, fenced-code language].
+     * Mailing list isn't in this list — its section is static markdown
+     * because the rendered HTML is too large to embed inline.
+     *
+     * @var list<array{filename: string, heading: string, fence: string}>
+     */
+    private const SHORT_COPY_CHANNELS = [
+        ['filename' => 'forum.md', 'heading' => 'Forum (Discourse)', 'fence' => 'markdown'],
+        ['filename' => 'chat.md', 'heading' => 'Chat', 'fence' => 'markdown'],
+        ['filename' => 'x.txt', 'heading' => 'X', 'fence' => 'text'],
+        ['filename' => 'facebook.txt', 'heading' => 'Facebook', 'fence' => 'text'],
+        ['filename' => 'linkedin.txt', 'heading' => 'LinkedIn', 'fence' => 'text'],
+    ];
+
+    public function __construct(
+        private string $templateDir,
+    ) {
+    }
+
+    public function render(string $outputDir, string $version, string $tag, string $forumUrl): string
+    {
+        $announcementsDir = $this->templateDir . '/announcements';
+        if (!is_dir($announcementsDir)) {
+            throw new \RuntimeException("Announcements template dir not found: {$announcementsDir}");
+        }
+
+        $shortCopy = [];
+        foreach (self::SHORT_COPY_CHANNELS as $channel) {
+            $path = $outputDir . '/' . $channel['filename'];
+            $body = @file_get_contents($path);
+            if ($body === false) {
+                throw new \RuntimeException("Rendered channel missing: {$path}");
+            }
+            $shortCopy[] = [
+                'heading' => $channel['heading'],
+                'fence' => $channel['fence'],
+                'body' => rtrim($body, "\n"),
+            ];
+        }
+
+        $twig = new Environment(
+            new FilesystemLoader($announcementsDir),
+            ['autoescape' => false],
+        );
+        return $twig->render(self::TEMPLATE_NAME, [
+            'version' => $version,
+            'tag' => $tag,
+            'forum_url' => $forumUrl,
+            'placeholder' => AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+            'short_copy_channels' => $shortCopy,
+        ]);
+    }
+}

--- a/tools/release/templates/announcements/chat.md.twig
+++ b/tools/release/templates/announcements/chat.md.twig
@@ -1,0 +1,5 @@
+**OpenEMR {{ version }} released!** 🎉
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}

--- a/tools/release/templates/announcements/facebook.txt.twig
+++ b/tools/release/templates/announcements/facebook.txt.twig
@@ -1,0 +1,9 @@
+OpenEMR {{ version }} has just been released!
+
+The OpenEMR community has released version {{ version }} of the most popular open source electronic health records and medical practice management solution.
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}
+
+Thanks to the OpenEMR community for producing this release. Support OpenEMR: https://www.open-emr.org/donate/

--- a/tools/release/templates/announcements/forum.md.twig
+++ b/tools/release/templates/announcements/forum.md.twig
@@ -7,4 +7,4 @@ The OpenEMR community has released version **{{ version }}**.
 
 Thanks to [the OpenEMR community](https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments) for producing this release.
 
-OpenEMR needs donations to fund critical work like maintaining ONC certification, the API, FHIR, and more. Please consider donating at <https://www.open-emr.org/donate/> or sponsoring on GitHub at <https://github.com/sponsors/openemr>.
+OpenEMR needs donations to fund critical work like maintaining ONC certification, the API, FHIR, and more. Please consider donating at <https://www.open-emr.org/donate/>.

--- a/tools/release/templates/announcements/forum.md.twig
+++ b/tools/release/templates/announcements/forum.md.twig
@@ -1,0 +1,10 @@
+# OpenEMR {{ version }} has just been released
+
+The OpenEMR community has released version **{{ version }}**.
+
+- Release notes: {{ release_notes_url }}
+- Download: {{ release_url }}
+
+Thanks to [the OpenEMR community](https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments) for producing this release.
+
+OpenEMR needs donations to fund critical work like maintaining ONC certification, the API, FHIR, and more. Please consider donating at <https://www.open-emr.org/donate/> or sponsoring on GitHub at <https://github.com/sponsors/openemr>.

--- a/tools/release/templates/announcements/linkedin.txt.twig
+++ b/tools/release/templates/announcements/linkedin.txt.twig
@@ -6,6 +6,6 @@ Release notes: {{ release_notes_url }}
 Download: {{ release_url }}
 Discussion: {{ forum_url }}
 
-Thanks to the OpenEMR community for producing this release. Sponsor OpenEMR on GitHub: https://github.com/sponsors/openemr
+Thanks to the OpenEMR community for producing this release. Sponsor OpenEMR: https://www.open-emr.org/donate/
 
 #OpenEMR #OpenSource #HealthIT #EHR

--- a/tools/release/templates/announcements/linkedin.txt.twig
+++ b/tools/release/templates/announcements/linkedin.txt.twig
@@ -1,0 +1,11 @@
+OpenEMR {{ version }} has just been released.
+
+OpenEMR is the most popular open source electronic health records and medical practice management solution. Version {{ version }} includes new features, improvements, and fixes.
+
+Release notes: {{ release_notes_url }}
+Download: {{ release_url }}
+Discussion: {{ forum_url }}
+
+Thanks to the OpenEMR community for producing this release. Sponsor OpenEMR on GitHub: https://github.com/sponsors/openemr
+
+#OpenEMR #OpenSource #HealthIT #EHR

--- a/tools/release/templates/announcements/mail.html.twig
+++ b/tools/release/templates/announcements/mail.html.twig
@@ -58,7 +58,7 @@ p { display:block;margin:13px 0; }
 <div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
 <p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">The <a href="https://www.open-emr.org">OpenEMR</a> community has released version {{ version }}. OpenEMR {{ version }} includes <a href="{{ release_notes_url }}">new features, improvements, and fixes</a>.</span></p>
 <p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">OpenEMR {{ version }} can be downloaded from the OpenEMR Project website at <a href="https://www.open-emr.org">www.open-emr.org</a>.</span></p>
-<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">Thanks goes to <a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments">the OpenEMR community</a> for producing this release.</span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">Thanks go to <a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments">the OpenEMR community</a> for producing this release.</span></p>
 <p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">See here for more details on downloading and installing the new {{ version }} release: <a href="{{ forum_url }}">{{ forum_url }}</a></span></p>
 </div>
 </td></tr>
@@ -66,7 +66,7 @@ p { display:block;margin:13px 0; }
 <tr><td align="left" style="font-size:0px;padding:0px 25px;word-break:break-word;">
 <div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
 <p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:15px;">OpenEMR needs donations for funding of critical features like maintaining ONC 2015 certification, API, FHIR, and a huge amount of other cool stuff. So please donate to the OpenEMR project: <a href="https://www.open-emr.org/donate/">https://www.open-emr.org/donate/</a></span></p>
-<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:15px;"><b>For only $1 per month you can be an Official OpenEMR Sponsor on github! You can sign up at: <a href="https://github.com/sponsors/openemr">https://github.com/sponsors/openemr</a></b></span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:15px;"><b>For only $1 per month you can be an Official OpenEMR Sponsor on GitHub! You can sign up at: <a href="https://github.com/sponsors/openemr">https://github.com/sponsors/openemr</a></b></span></p>
 </div>
 </td></tr>
 
@@ -82,7 +82,7 @@ p { display:block;margin:13px 0; }
 <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
 <tr><td align="left" style="font-size:0px;padding:0px 20px;word-break:break-word;">
 <div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
-<p style="text-align: center; margin: 10px 0;"><span style="font-size:13px;text-align:center;color:#55575d;font-family:Arial;line-height:22px;"><a href="mailto:hello@open-emr.org" style="color:inherit;text-decoration:none;" target="_blank">Click here to unsubscribe</a>.</span></p>
+<p style="text-align: center; margin: 10px 0;"><span style="font-size:13px;text-align:center;color:#55575d;font-family:Arial;line-height:22px;">To unsubscribe, email <a href="mailto:hello@open-emr.org" style="color:inherit;" target="_blank">hello@open-emr.org</a>.</span></p>
 </div>
 </td></tr>
 </table>

--- a/tools/release/templates/announcements/mail.html.twig
+++ b/tools/release/templates/announcements/mail.html.twig
@@ -1,0 +1,95 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+<title>OpenEMR {{ version }} Released</title>
+<!--[if !mso]><!-- --><meta http-equiv="X-UA-Compatible" content="IE=edge"><!--<![endif]-->
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style type="text/css">
+#outlook a { padding:0; }
+body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+img { border:0;height:auto;line-height:100%;outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+p { display:block;margin:13px 0; }
+</style>
+<!--[if mso]>
+<xml><o:OfficeDocumentSettings><o:AllowPNG/><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml>
+<![endif]-->
+<style type="text/css">
+@media only screen and (min-width:480px) {
+  .mj-column-per-100 { width:100% !important; max-width: 100%; }
+}
+</style>
+</head>
+<body style="background-color:#F4F4F4;">
+<div style="background-color:#F4F4F4;">
+
+<div style="margin:0px auto;max-width:600px;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+<tbody><tr><td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+<div class="mj-column-per-100" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+<tr><td align="center" style="background:#00509d;font-size:0px;padding:20px 50px;word-break:break-word;">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+<tbody><tr><td style="width:500px;">
+<img alt="OpenEMR Logo" height="auto" src="https://www.open-emr.org/images/openemr_email_logo.png" style="border:none;border-radius:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" width="500">
+</td></tr></tbody></table>
+</td></tr>
+</table>
+</div>
+</td></tr></tbody></table>
+</div>
+
+<div style="background:#ffffff;background-color:#ffffff;margin:0px auto;max-width:600px;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ffffff;background-color:#ffffff;width:100%;">
+<tbody><tr><td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+<div class="mj-column-per-100" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+
+<tr><td align="left" style="font-size:0px;padding:0px 25px;word-break:break-word;">
+<div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
+<h1 style="text-align:left; margin: 10px 0; font-weight: normal;">
+<span style="text-align:left;font-size:20px;color:#55575d;font-family:Arial;line-height:22px;"><b>OpenEMR {{ version }} Released!</b></span>
+</h1>
+</div>
+</td></tr>
+
+<tr><td align="left" style="font-size:0px;padding:0px 25px;word-break:break-word;">
+<div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">The <a href="https://www.open-emr.org">OpenEMR</a> community has released version {{ version }}. OpenEMR {{ version }} includes <a href="{{ release_notes_url }}">new features, improvements, and fixes</a>.</span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">OpenEMR {{ version }} can be downloaded from the OpenEMR Project website at <a href="https://www.open-emr.org">www.open-emr.org</a>.</span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">Thanks goes to <a href="https://www.open-emr.org/wiki/index.php/OpenEMR_Acknowledgments">the OpenEMR community</a> for producing this release.</span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:18px;">See here for more details on downloading and installing the new {{ version }} release: <a href="{{ forum_url }}">{{ forum_url }}</a></span></p>
+</div>
+</td></tr>
+
+<tr><td align="left" style="font-size:0px;padding:0px 25px;word-break:break-word;">
+<div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:15px;">OpenEMR needs donations for funding of critical features like maintaining ONC 2015 certification, API, FHIR, and a huge amount of other cool stuff. So please donate to the OpenEMR project: <a href="https://www.open-emr.org/donate/">https://www.open-emr.org/donate/</a></span></p>
+<p style="text-align: left; margin: 10px 0;"><span style="text-align:left;font-size:13px;color:#55575d;font-family:Arial;line-height:15px;"><b>For only $1 per month you can be an Official OpenEMR Sponsor on github! You can sign up at: <a href="https://github.com/sponsors/openemr">https://github.com/sponsors/openemr</a></b></span></p>
+</div>
+</td></tr>
+
+</table>
+</div>
+</td></tr></tbody></table>
+</div>
+
+<div style="margin:0px auto;max-width:600px;">
+<table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+<tbody><tr><td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+<div class="mj-column-per-100" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+<table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+<tr><td align="left" style="font-size:0px;padding:0px 20px;word-break:break-word;">
+<div style="font-family:Arial, sans-serif;font-size:13px;letter-spacing:normal;line-height:1;text-align:left;color:#000000;">
+<p style="text-align: center; margin: 10px 0;"><span style="font-size:13px;text-align:center;color:#55575d;font-family:Arial;line-height:22px;"><a href="mailto:hello@open-emr.org" style="color:inherit;text-decoration:none;" target="_blank">Click here to unsubscribe</a>.</span></p>
+</div>
+</td></tr>
+</table>
+</div>
+</td></tr></tbody></table>
+</div>
+
+</div>
+</body>
+</html>

--- a/tools/release/templates/announcements/mail.subject.txt.twig
+++ b/tools/release/templates/announcements/mail.subject.txt.twig
@@ -1,0 +1,1 @@
+OpenEMR {{ version }} Released

--- a/tools/release/templates/announcements/step-summary.md.twig
+++ b/tools/release/templates/announcements/step-summary.md.twig
@@ -1,0 +1,23 @@
+# Release announcement drafts — OpenEMR {{ version }} ({{ tag }})
+
+{% if forum_url == placeholder %}
+> **Forum URL placeholder.** Find/replace `{{ placeholder }}` in the rendered output once you create the Discourse thread.
+
+{% endif %}
+{% for channel in short_copy_channels %}
+## {{ channel.heading }}
+
+```{{ channel.fence }}
+{{ channel.body }}
+```
+
+{% endfor %}
+## Mailing list
+
+Three artifacts are uploaded with the workflow run:
+
+- `mail.subject.txt` — pass to `oe-sender.js -s`
+- `mail.html` — pass to `oe-sender.js -f`
+- `mail.eml` — preview in a mail client; not used by the sender
+
+Production sender lives in [openemr-registration/oe-sender.js](https://github.com/openemr/openemr-registration/blob/master/oe-sender.js); recipients come from the DynamoDB scan, not from the `.eml` headers.

--- a/tools/release/templates/announcements/x.txt.twig
+++ b/tools/release/templates/announcements/x.txt.twig
@@ -1,0 +1,1 @@
+OpenEMR {{ version }} is out! Open source EHR & practice management. Release notes & download: {{ release_url }} #OpenEMR #OpenSource #HealthIT

--- a/tools/release/tests/AnnouncementDispatchPayloadTest.php
+++ b/tools/release/tests/AnnouncementDispatchPayloadTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\AnnouncementDispatchPayload;
+use PHPUnit\Framework\TestCase;
+
+final class AnnouncementDispatchPayloadTest extends TestCase
+{
+    private const VALID_DATA = ['version' => '8.1.0', 'tag' => 'v8_1_0', 'branch' => 'rel-810'];
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function envelope(string $event = 'openemr-tag', mixed $data = self::VALID_DATA): array
+    {
+        return [
+            'event' => $event,
+            'repo' => 'openemr/openemr',
+            'sha' => str_repeat('a', 40),
+            'actor' => 'openemr-release-bot[bot]',
+            'dispatched_at' => '2026-04-29T12:00:00Z',
+            'data' => $data,
+        ];
+    }
+
+    public function testParsesValidEnvelope(): void
+    {
+        $payload = AnnouncementDispatchPayload::fromEnvelope($this->envelope());
+
+        self::assertSame('8.1.0', $payload->version);
+        self::assertSame('v8_1_0', $payload->tag);
+        self::assertSame('rel-810', $payload->branch);
+    }
+
+    public function testAcceptsTestTagSuffix(): void
+    {
+        $envelope = $this->envelope(data: [
+            'version' => '8.1.0',
+            'tag' => 'v8_1_0-test.abcdef0',
+            'branch' => 'rel-test',
+        ]);
+        $payload = AnnouncementDispatchPayload::fromEnvelope($envelope);
+
+        self::assertSame('v8_1_0-test.abcdef0', $payload->tag);
+        self::assertSame('rel-test', $payload->branch);
+    }
+
+    public function testRejectsNonObjectEnvelope(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not a JSON object');
+        AnnouncementDispatchPayload::fromEnvelope('not-an-object');
+    }
+
+    public function testRejectsWrongEvent(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Expected event=openemr-tag');
+        AnnouncementDispatchPayload::fromEnvelope($this->envelope('openemr-rel-cut'));
+    }
+
+    public function testRejectsMissingDataObject(): void
+    {
+        $envelope = $this->envelope();
+        unset($envelope['data']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing data object');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsMissingVersionField(): void
+    {
+        $envelope = $this->envelope(data: ['tag' => 'v8_1_0', 'branch' => 'rel-810']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing or empty field: data.version');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsEmptyTagField(): void
+    {
+        $envelope = $this->envelope(data: ['version' => '8.1.0', 'tag' => '', 'branch' => 'rel-810']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing or empty field: data.tag');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsNullField(): void
+    {
+        // jq -r emits literal "null" for missing fields, so simulate the same
+        // shape getting through to PHP — null in the typed array.
+        $envelope = $this->envelope(data: ['version' => '8.1.0', 'tag' => 'v8_1_0', 'branch' => null]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing or empty field: data.branch');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsMalformedVersion(): void
+    {
+        $envelope = $this->envelope(data: ['version' => '8.1', 'tag' => 'v8_1_0', 'branch' => 'rel-810']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('field version does not match expected shape');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsMalformedTag(): void
+    {
+        $envelope = $this->envelope(data: ['version' => '8.1.0', 'tag' => 'v8.1.0', 'branch' => 'rel-810']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('field tag does not match expected shape');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+
+    public function testRejectsMalformedBranch(): void
+    {
+        $envelope = $this->envelope(data: ['version' => '8.1.0', 'tag' => 'v8_1_0', 'branch' => 'master']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('field branch does not match expected shape');
+        AnnouncementDispatchPayload::fromEnvelope($envelope);
+    }
+}

--- a/tools/release/tests/AnnouncementRendererTest.php
+++ b/tools/release/tests/AnnouncementRendererTest.php
@@ -29,7 +29,7 @@ final class AnnouncementRendererTest extends TestCase
      *     forum_url: string,
      * }
      */
-    private function context(string $forumUrl = '{{FORUM_URL}}'): array
+    private function context(string $forumUrl = AnnouncementRenderer::FORUM_URL_PLACEHOLDER): array
     {
         return [
             'version' => '8.1.0',

--- a/tools/release/tests/AnnouncementRendererTest.php
+++ b/tools/release/tests/AnnouncementRendererTest.php
@@ -54,14 +54,20 @@ final class AnnouncementRendererTest extends TestCase
         }
     }
 
+    /**
+     * Channels that link to the forum and should preserve / substitute the
+     * placeholder. Mailing-list .subject doesn't link to the forum, and the
+     * X channel can't fit the URL within 280 chars, so they're excluded.
+     */
+    private const FORUM_LINKING_CHANNELS = ['chat.md', 'facebook.txt', 'linkedin.txt', 'mail.html'];
+
     public function testForumUrlPlaceholderRoundTrips(): void
     {
         $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
 
-        // Channels that link to the forum should preserve the placeholder for
-        // maintainer find/replace once the Discourse thread URL is known.
-        self::assertStringContainsString('{{FORUM_URL}}', $rendered['chat.md']);
-        self::assertStringContainsString('{{FORUM_URL}}', $rendered['mail.html']);
+        foreach (self::FORUM_LINKING_CHANNELS as $channel) {
+            self::assertStringContainsString('{{FORUM_URL}}', $rendered[$channel], "{$channel} dropped placeholder");
+        }
     }
 
     public function testForumUrlSubstitutesWhenProvided(): void
@@ -69,10 +75,10 @@ final class AnnouncementRendererTest extends TestCase
         $url = 'https://community.open-emr.org/t/openemr-8-1-0-released/12345';
         $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context($url));
 
-        self::assertStringContainsString($url, $rendered['chat.md']);
-        self::assertStringContainsString($url, $rendered['mail.html']);
-        self::assertStringNotContainsString('{{FORUM_URL}}', $rendered['chat.md']);
-        self::assertStringNotContainsString('{{FORUM_URL}}', $rendered['mail.html']);
+        foreach (self::FORUM_LINKING_CHANNELS as $channel) {
+            self::assertStringContainsString($url, $rendered[$channel], "{$channel} missing forum URL");
+            self::assertStringNotContainsString('{{FORUM_URL}}', $rendered[$channel], "{$channel} kept placeholder");
+        }
     }
 
     public function testXFitsCharacterLimit(): void

--- a/tools/release/tests/AnnouncementRendererTest.php
+++ b/tools/release/tests/AnnouncementRendererTest.php
@@ -79,8 +79,12 @@ final class AnnouncementRendererTest extends TestCase
     {
         $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
 
-        // X allows 280 characters in a single tweet.
-        self::assertLessThanOrEqual(280, mb_strlen(trim($rendered['x.txt'])));
+        // X counts URLs as a fixed 23 characters via t.co shortening, so
+        // approximate the real limit by replacing each URL with 23 chars
+        // before measuring. This is a loose sanity check, not an exact
+        // reproduction of X's character-counting rules.
+        $approx = preg_replace('#https?://\S+#', str_repeat('x', 23), trim($rendered['x.txt']));
+        self::assertLessThanOrEqual(280, mb_strlen($approx ?? ''));
     }
 
     public function testMailSubjectIsSingleLine(): void
@@ -88,7 +92,9 @@ final class AnnouncementRendererTest extends TestCase
         $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
 
         $subject = trim($rendered['mail.subject.txt']);
+        // CR and LF both enable header injection in the .eml — reject either.
         self::assertStringNotContainsString("\n", $subject);
+        self::assertStringNotContainsString("\r", $subject);
         self::assertStringContainsString('8.1.0', $subject);
     }
 

--- a/tools/release/tests/AnnouncementRendererTest.php
+++ b/tools/release/tests/AnnouncementRendererTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\AnnouncementRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class AnnouncementRendererTest extends TestCase
+{
+    private const TEMPLATE_DIR = __DIR__ . '/../templates';
+
+    /**
+     * @return array{
+     *     version: string,
+     *     tag: string,
+     *     branch: string,
+     *     release_url: string,
+     *     release_notes_url: string,
+     *     forum_url: string,
+     * }
+     */
+    private function context(string $forumUrl = '{{FORUM_URL}}'): array
+    {
+        return [
+            'version' => '8.1.0',
+            'tag' => 'v8_1_0',
+            'branch' => 'rel-810',
+            'release_url' => 'https://github.com/openemr/openemr/releases/tag/v8_1_0',
+            'release_notes_url' => 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            'forum_url' => $forumUrl,
+        ];
+    }
+
+    public function testRendersAllChannels(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        self::assertSame(
+            array_keys(AnnouncementRenderer::CHANNELS),
+            array_keys($rendered),
+        );
+        foreach ($rendered as $channel => $body) {
+            self::assertNotSame('', trim($body), "{$channel} rendered empty");
+        }
+    }
+
+    public function testForumUrlPlaceholderRoundTrips(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        // Channels that link to the forum should preserve the placeholder for
+        // maintainer find/replace once the Discourse thread URL is known.
+        self::assertStringContainsString('{{FORUM_URL}}', $rendered['chat.md']);
+        self::assertStringContainsString('{{FORUM_URL}}', $rendered['mail.html']);
+    }
+
+    public function testForumUrlSubstitutesWhenProvided(): void
+    {
+        $url = 'https://community.open-emr.org/t/openemr-8-1-0-released/12345';
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context($url));
+
+        self::assertStringContainsString($url, $rendered['chat.md']);
+        self::assertStringContainsString($url, $rendered['mail.html']);
+        self::assertStringNotContainsString('{{FORUM_URL}}', $rendered['chat.md']);
+        self::assertStringNotContainsString('{{FORUM_URL}}', $rendered['mail.html']);
+    }
+
+    public function testXFitsCharacterLimit(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        // X allows 280 characters in a single tweet.
+        self::assertLessThanOrEqual(280, mb_strlen(trim($rendered['x.txt'])));
+    }
+
+    public function testMailSubjectIsSingleLine(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        $subject = trim($rendered['mail.subject.txt']);
+        self::assertStringNotContainsString("\n", $subject);
+        self::assertStringContainsString('8.1.0', $subject);
+    }
+
+    public function testMailHtmlIncludesVersionAndReleaseNotesLink(): void
+    {
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll($this->context());
+
+        self::assertStringContainsString('OpenEMR 8.1.0 Released', $rendered['mail.html']);
+        self::assertStringContainsString(
+            'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            $rendered['mail.html'],
+        );
+    }
+
+    public function testRenderIsDeterministic(): void
+    {
+        $renderer = new AnnouncementRenderer(self::TEMPLATE_DIR);
+
+        self::assertSame($renderer->renderAll($this->context()), $renderer->renderAll($this->context()));
+    }
+
+    public function testThrowsOnMissingTemplateDir(): void
+    {
+        $renderer = new AnnouncementRenderer('/no/such/dir');
+
+        $this->expectException(\RuntimeException::class);
+        $renderer->renderAll($this->context());
+    }
+}

--- a/tools/release/tests/AnnouncementStepSummaryRendererTest.php
+++ b/tools/release/tests/AnnouncementStepSummaryRendererTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\AnnouncementRenderer;
+use OpenEMR\Release\AnnouncementStepSummaryRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class AnnouncementStepSummaryRendererTest extends TestCase
+{
+    private const TEMPLATE_DIR = __DIR__ . '/../templates';
+
+    private string $outputDir = '';
+
+    protected function setUp(): void
+    {
+        $this->outputDir = sys_get_temp_dir() . '/openemr-step-summary-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->outputDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->outputDir);
+        }
+        // Render the real per-channel files into the tmp dir using the
+        // production renderer — keeps the summary test honest about what
+        // it's summarizing.
+        $rendered = (new AnnouncementRenderer(self::TEMPLATE_DIR))->renderAll([
+            'version' => '8.1.0',
+            'tag' => 'v8_1_0',
+            'branch' => 'rel-810',
+            'release_url' => 'https://github.com/openemr/openemr/releases/tag/v8_1_0',
+            'release_notes_url' => 'https://www.open-emr.org/wiki/index.php/Release_Features#Version_8.1.0',
+            'forum_url' => AnnouncementRenderer::FORUM_URL_PLACEHOLDER,
+        ]);
+        foreach ($rendered as $name => $body) {
+            file_put_contents($this->outputDir . '/' . $name, $body);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->outputDir . '/*');
+        foreach ($files === false ? [] : $files as $path) {
+            @unlink($path);
+        }
+        @rmdir($this->outputDir);
+    }
+
+    public function testRendersEachShortCopyChannel(): void
+    {
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+
+        self::assertStringContainsString('# Release announcement drafts — OpenEMR 8.1.0 (v8_1_0)', $summary);
+        foreach (['Forum (Discourse)', 'Chat', 'X', 'Facebook', 'LinkedIn', 'Mailing list'] as $heading) {
+            self::assertStringContainsString('## ' . $heading, $summary);
+        }
+    }
+
+    public function testEmitsPlaceholderHintWhenForumUrlMissing(): void
+    {
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+
+        self::assertStringContainsString('Forum URL placeholder', $summary);
+    }
+
+    public function testSuppressesPlaceholderHintWhenForumUrlProvided(): void
+    {
+        $url = 'https://community.open-emr.org/t/openemr-8-1-0-released/12345';
+        $summary = (new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR))
+            ->render($this->outputDir, '8.1.0', 'v8_1_0', $url);
+
+        self::assertStringNotContainsString('Forum URL placeholder', $summary);
+    }
+
+    public function testThrowsOnMissingChannelFile(): void
+    {
+        unlink($this->outputDir . '/x.txt');
+        $renderer = new AnnouncementStepSummaryRenderer(self::TEMPLATE_DIR);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Rendered channel missing');
+        $renderer->render($this->outputDir, '8.1.0', 'v8_1_0', AnnouncementRenderer::FORUM_URL_PLACEHOLDER);
+    }
+}

--- a/tools/release/tests/DeriveAnnouncementInputsCliTest.php
+++ b/tools/release/tests/DeriveAnnouncementInputsCliTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * The release-announcements workflow appends derive-announcement-inputs.php
+ * stdout directly to $GITHUB_OUTPUT. Errors must therefore not leak into
+ * stdout, or a failing run will write `<error>...</error>` lines into the
+ * runner's output file and trigger an "Invalid format" step failure that
+ * obscures the real error.
+ */
+final class DeriveAnnouncementInputsCliTest extends TestCase
+{
+    private const BIN = __DIR__ . '/../bin/derive-announcement-inputs.php';
+
+    public function testValidFlagsWriteKeyValueLinesToStdoutOnly(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=v8_1_0',
+            '--release-branch=rel-810',
+            '--forum-url=https://example.com/thread',
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), 'expected success exit code');
+        self::assertSame('', $process->getErrorOutput(), 'no stderr on success');
+        self::assertSame(
+            "version=8.1.0\ntag=v8_1_0\nbranch=rel-810\nforum_url=https://example.com/thread\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testValidationErrorsGoToStderrAndStdoutStaysEmpty(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=BAD',
+            '--release-branch=rel-810',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode(), 'expected failure exit code');
+        self::assertSame('', $process->getOutput(), 'stdout must stay empty so $GITHUB_OUTPUT is not corrupted');
+        self::assertStringContainsString('field tag does not match expected shape', $process->getErrorOutput());
+    }
+
+    public function testMissingRequiredFlagsGoToStderr(): void
+    {
+        $process = new Process(['php', self::BIN]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('Provide either --payload-file', $process->getErrorOutput());
+    }
+
+    public function testMutuallyExclusiveSourcesRejected(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--payload-file=-',
+            '--release-version=8.1.0',
+        ]);
+        $process->setInput('{}');
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('mutually exclusive', $process->getErrorOutput());
+    }
+}


### PR DESCRIPTION
Closes #719.

## Summary

A workflow that consumes `openemr-tag` (and `workflow_dispatch`) and renders per-channel release-announcement drafts to a workflow artifact + step summary. The drafts-only first phase of the #711 fan-out — no posting, no SMTP, no OAuth.

## What ships

- **Per-channel Twig templates** under `tools/release/templates/announcements/` for forum (Discourse), chat, X, Facebook, LinkedIn, and the mailing list (HTML body + subject). Mailing list HTML is adapted from the 7.0.4 MJML-rendered template @bradymiller archived in #719.
- **`AnnouncementRenderer`** + **`bin/render-announcements.php`** — mirrors the existing `DockerHubOverviewRenderer` pattern (PHP + Twig + Symfony Console).
- **`.github/workflows/release-announcements.yml`** — derives version/tag/branch from the dispatch payload (or workflow_dispatch inputs), runs the renderer, writes a per-channel step summary, uploads `release-announcements` artifact (8 files: 5 short-copy + `mail.html` + `mail.subject.txt` + `mail.eml` preview).
- **PHPUnit coverage** for the renderer.

## Maintainer flow

1. Tag fires → workflow runs → step summary shows ready-to-paste copy for forum / chat / X / Facebook / LinkedIn.
2. Maintainer creates the Discourse thread, then re-runs the workflow via `workflow_dispatch` with `forum_url` set (or find/replaces `{{FORUM_URL}}` in the rendered output).
3. Maintainer downloads the `release-announcements` artifact and runs the production sender from [openemr-registration](https://github.com/openemr/openemr-registration):
   ```
   node oe-sender.js -s "$(cat mail.subject.txt)" -f mail.html
   ```
   `oe-sender.js` hard-codes `Source: no-reply@open-emr.org` and pulls recipients from the DynamoDB `oe_registration` scan. The `.eml` is preview-only — drag it into a mail client to confirm the HTML renders correctly.

## Out of scope (deferred to per-channel follow-ons under #711)

- Actual posting to any channel (Discourse, X, Facebook, LinkedIn, chat).
- SMTP / SES integration (lives in `openemr-registration`, not here).
- Discourse thread auto-creation.

## Test plan

- [x] `composer -d tools/release check` (phpcs / phpstan / rector / require-checker / phpunit) — all pass.
- [x] `actionlint` — clean.
- [x] Local CLI smoke test:
      ```
      php tools/release/bin/render-announcements.php \
          --output-dir=/tmp/announce-810 \
          --release-version=8.1.0 --release-tag=v8_1_0 --release-branch=rel-810
      ```
      Inspected each output file; `{{FORUM_URL}}` placeholder appears where expected; X copy is well under 280 chars; `.eml` opens in a mail client.
- [ ] `gh workflow run release-announcements.yml -F version=8.1.0 -F tag=v8_1_0 -F branch=rel-810` against this branch on the upstream repo (after merge it triggers off real tags).