### PR TITLE
ci: checkout repo before invoking local push-dockerhub-readme action

### DIFF
--- a/.github/workflows/build-704.yml
+++ b/.github/workflows/build-704.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr-devops' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/build-800.yml
+++ b/.github/workflows/build-800.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.repository_owner == 'openemr' && github.repository == 'openemr/openemr-devops' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx

--- a/.github/workflows/build-810.yml
+++ b/.github/workflows/build-810.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Download digests
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build-811.yml
+++ b/.github/workflows/build-811.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
       - name: Download digests
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary

The nightly build workflows (`build-704.yml`, `build-800.yml`, `build-810.yml`, `build-811.yml`) reference a local composite action at `./.github/actions/push-dockerhub-readme` but never run `actions/checkout`, so the action file isn't present on the runner and the step fails:

> Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/push-dockerhub-readme'. Did you forget to run actions/checkout before running your local action?

Example failure: https://github.com/openemr/openemr-devops/actions/runs/26011145231

This adds an `actions/checkout@v6` step at the top of each job that uses the local action — `build` for 704/800, `merge` for 810/811 (the 810/811 `build` job builds from the remote git context `{{defaultContext}}:docker/openemr/8.1.x` and doesn't need a local checkout).

## Test plan

- [ ] Re-run the affected nightly workflows via `workflow_dispatch` after merge and verify the "Push Docker Hub readme" step succeeds.