### PR TITLE
feat(flex): install pdo_sqlite at runtime when DEVELOPER_TOOLS=yes

### DIFF
--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -152,6 +152,12 @@ fi
 #                                     -> actionlint-system at invocation time
 #                                     because DinD is not available from inside
 #                                     this container
+#   php${ABBR}-pdo_sqlite             for in-process SQLite via Doctrine DBAL.
+#                                     HolidayServiceTest in the isolated test
+#                                     suite builds an in-memory ':memory:'
+#                                     SQLite connection in setUp; without
+#                                     pdo_sqlite the whole class fatals with
+#                                     'could not find driver' at driver init.
 #
 # Runs at top of script (not inside NEED_COMPOSER_BUILD) because apk packages
 # live in the container's writable rootfs, not in any named volume. A
@@ -162,12 +168,14 @@ fi
 # Idempotent: 'apk info -e' guards short-circuit when everything is already
 # installed. Tolerant of network failures.
 if [[ "${DEVELOPER_TOOLS}" = "yes" ]] && {
-       ! apk info -e chromium             >/dev/null 2>&1 || \
-       ! apk info -e chromium-chromedriver >/dev/null 2>&1 || \
-       ! apk info -e py3-codespell         >/dev/null 2>&1 || \
-       ! apk info -e pre-commit            >/dev/null 2>&1 || \
-       ! apk info -e actionlint            >/dev/null 2>&1; }; then
+       ! apk info -e chromium                                   >/dev/null 2>&1 || \
+       ! apk info -e chromium-chromedriver                      >/dev/null 2>&1 || \
+       ! apk info -e py3-codespell                              >/dev/null 2>&1 || \
+       ! apk info -e pre-commit                                 >/dev/null 2>&1 || \
+       ! apk info -e actionlint                                 >/dev/null 2>&1 || \
+       ! apk info -e "php${PHP_VERSION_ABBR}-pdo_sqlite"        >/dev/null 2>&1; }; then
     apk add --no-cache chromium chromium-chromedriver py3-codespell pre-commit actionlint \
+        "php${PHP_VERSION_ABBR}-pdo_sqlite" \
         || echo "dev apk packages: install failed; some openemr-cmd subcommands may be unavailable" >&2
 fi
 

--- a/docker/openemr/flex/openemr.sh
+++ b/docker/openemr/flex/openemr.sh
@@ -152,7 +152,7 @@ fi
 #                                     -> actionlint-system at invocation time
 #                                     because DinD is not available from inside
 #                                     this container
-#   php${ABBR}-pdo_sqlite             for in-process SQLite via Doctrine DBAL.
+#   php${PHP_VERSION_ABBR}-pdo_sqlite for in-process SQLite via Doctrine DBAL.
 #                                     HolidayServiceTest in the isolated test
 #                                     suite builds an in-memory ':memory:'
 #                                     SQLite connection in setUp; without
@@ -173,9 +173,9 @@ if [[ "${DEVELOPER_TOOLS}" = "yes" ]] && {
        ! apk info -e py3-codespell                              >/dev/null 2>&1 || \
        ! apk info -e pre-commit                                 >/dev/null 2>&1 || \
        ! apk info -e actionlint                                 >/dev/null 2>&1 || \
-       ! apk info -e "php${PHP_VERSION_ABBR}-pdo_sqlite"        >/dev/null 2>&1; }; then
+       ! apk info -e "php${PHP_VERSION_ABBR?}-pdo_sqlite"        >/dev/null 2>&1; }; then
     apk add --no-cache chromium chromium-chromedriver py3-codespell pre-commit actionlint \
-        "php${PHP_VERSION_ABBR}-pdo_sqlite" \
+        "php${PHP_VERSION_ABBR?}-pdo_sqlite" \
         || echo "dev apk packages: install failed; some openemr-cmd subcommands may be unavailable" >&2
 fi
 


### PR DESCRIPTION
## Summary

Adds `php${ABBR}-pdo_sqlite` to the runtime apk-add block in `docker/openemr/flex/openemr.sh` that runs when `DEVELOPER_TOOLS=yes`. Matches the existing idempotent pattern (chromium, py3-codespell, pre-commit, actionlint) — `apk info -e` guards short-circuit on already-installed containers, network failures are tolerated.

## Why

`tests/Tests/Isolated/Services/HolidayServiceTest` (25 tests in openemr/openemr) builds an in-memory SQLite database via `Doctrine\DBAL\Connection` in `setUp()`:

```php
$this->connection = DriverManager::getConnection([
    'driver' => 'pdo_sqlite',
    'memory' => true,
]);
```

The flex image doesn't currently include `pdo_sqlite`, so every test method in that class crashes with `Doctrine\DBAL\Exception\DriverException: could not find driver` when developers run `openemr-cmd pit` locally. CI's isolated job is unaffected because it runs directly on the host runner via `shivammathur/setup-php@v2` (which loads pdo_sqlite by default), masking the gap. This change restores local-vs-CI parity.

Strategic value: in-memory SQLite via Doctrine DBAL is the right design for service-layer tests that want real SQL semantics without external infrastructure — fast, idempotent (`':memory:'` dies with the connection at tearDown), no shared state across runs. Making the extension available makes that pattern reusable for future tests.

## Test plan

- [x] Validated locally: started a flex dev container, confirmed pdo_sqlite was *not* in `php -m` initially, ran `apk add --no-cache php85-pdo_sqlite` (simulating the new runtime install path), ran HolidayServiceTest → 25/25 pass.
- [ ] CI builds flex image; downstream openemr CI jobs still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)