### PR TITLE
docs: warn current.patch is legacy, drop at 8.1.0 rotation

### DIFF
--- a/.github/workflows/build-800.yml
+++ b/.github/workflows/build-800.yml
@@ -29,6 +29,9 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: "{{defaultContext}}:docker/openemr/8.0.0"
+          # DROP the `:8.0.0.3` and `:8.0.0.3-<date>` tags when current moves
+          # off 8.0.0. 8.1.x onward uses plain semver; the 4-part patch tag is
+          # legacy quaternary versioning. See tools/release/versions.yml and #746.
           tags: openemr/openemr:8.0.0, openemr/openemr:8.0.0.3, openemr/openemr:8.0.0.3-${{ steps.build_date.outputs.date }}, openemr/openemr:latest
           platforms: linux/amd64,linux/arm64
           push: true

--- a/tools/release/versions.yml
+++ b/tools/release/versions.yml
@@ -21,6 +21,11 @@ slots:
   current:
     minor: "8.0"
     full: "8.0.0"
+    # DROP THIS LINE when current moves off 8.0.0. The 4-part patch field is
+    # legacy quaternary versioning; 8.1.x onward uses plain semver (8.1.1 is
+    # the next release after 8.1.0, not a 4-part patch). When the 8.1.0 tag
+    # rotation PR opens, remove this line and the `:8.0.0.3` docker tags in
+    # .github/workflows/build-800.yml as part of PR review. See #746.
     patch: "8.0.0.3"
     branch: "rel-800"
     docker_dir: "8.0.0"


### PR DESCRIPTION
## Summary

- Adds a comment next to `current.patch: "8.0.0.3"` in `tools/release/versions.yml` flagging it as legacy quaternary versioning that must be dropped when `current` slides off 8.0.0.
- Adds a matching comment next to the `:8.0.0.3` and `:8.0.0.3-<date>` docker tags in `.github/workflows/build-800.yml`.

8.1.x onward uses plain semver (8.1.1 is the next release after 8.1.0, not a 4-part patch), so the slot system has no concept of `patch` going forward. The transition is one-shot: when the 8.1.0 tag rotation PR opens, a human edits these two spots out as part of review. Teaching the rotator to handle key-removal isn't worth a permanent feature with no second use case.

Closes #746.

## Test plan

- [ ] Confirm the comments render legibly in both files.
- [ ] No code paths touched — no functional tests needed.