### PR TITLE
ci(build-release): bump PHP to 8.5 to match release tools

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.4'
+        php-version: '8.5'
 
     - name: Install Taskfile
       uses: arduino/setup-task@v2


### PR DESCRIPTION
## Summary

`build-release.yml` pins `php-version: '8.4'` (line 109) but `tools/release/composer.json` (line 7) requires `php: ^8.5`. `composer install` aborts before any build step runs:

```
Root composer.json requires php ^8.5 but your php version (8.4.21) does not satisfy that requirement.
```

Failing run: https://github.com/openemr/openemr-devops/actions/runs/26536165174

## Impact

Blocks v8_1_0 publication. The tag `v8_1_0` exists but the Release object cannot be created until this workflow succeeds.

## Test plan

- [ ] CI green
- [ ] Re-run `build-release.yml` against v8_1_0 after merge; verify `composer install` succeeds and the workflow proceeds past `release:setup`