### PR TITLE
ci(build-release): auto-detect conductor prep, skip legacy version bump

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -128,7 +128,31 @@ jobs:
         SKIP_MILESTONE='${{ (inputs.skip_milestone_check || inputs.milestone == '') && '1' || '' }}'
         SKIP_GHSA='${{ inputs.skip_ghsa_check && '1' || '' }}'
 
+    - name: Detect existing prep
+      id: detect-prep
+      working-directory: openemr
+      run: |
+        # `task release:version-bump MODE=full` performs two mutations
+        # (see tools/release/bin/version-bump.php): clears `-dev` from
+        # $v_tag in version.php, and sets the allow_debug_language
+        # globals default to '0'. $v_tag is the canonical signal: a
+        # `-dev` suffix means full-mode prep hasn't run yet (under
+        # either the legacy path or the openemr/openemr conductor).
+        # shellcheck disable=SC2016 # PHP variables, not shell
+        v_tag=$(php -r 'include "version.php"; echo $v_tag;')
+        case "$v_tag" in
+          *-dev*)
+            printf 'v_tag=%q contains -dev — running legacy prep\n' "$v_tag"
+            printf 'prep_done=false\n' >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            printf 'v_tag=%q is clean — skipping legacy prep\n' "$v_tag"
+            printf 'prep_done=true\n' >> "$GITHUB_OUTPUT"
+            ;;
+        esac
+
     - name: Version bump (full mode)
+      if: "steps.detect-prep.outputs.prep_done != 'true'"
       working-directory: devops-tools
       run: >-
         task release:version-bump
@@ -136,7 +160,7 @@ jobs:
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 
     - name: Commit and push version changes
-      if: '!inputs.dry_run'
+      if: "!inputs.dry_run && steps.detect-prep.outputs.prep_done != 'true'"
       working-directory: openemr
       run: |
         git config user.name 'github-actions[bot]'


### PR DESCRIPTION
## Summary

`build-release.yml` re-runs version-bump mutators and pushes a `chore: prepare X for release` commit directly to the release branch. With the openemr/openemr release-prep conductor (release-prep/<rel-branch> PR) now owning version constants, that legacy step:

1. Produces a different mutation than the conductor's (2267 ins / 4090 del across `version.php` + `library/globals.inc.php` for 8.1.0), and
2. Fails the push with `GH013: Cannot update this protected ref. Changes must be made through a pull request.`

This blocked the 8.1.0 release.

## Fix

Add a `Detect existing prep` step that reads `$v_major`/`$v_minor`/`$v_patch` from `version.php`. When they already match `inputs.version`, gate off the legacy version-bump and the direct push.

- Conductor-prepped branches (rel-810 and forward) — detection trips, legacy prep is skipped, workflow proceeds to changelog, tag (no-op if exists), release, archives, checksums.
- Older branches not yet under the conductor — detection reports a mismatch, legacy path runs unchanged.

No new inputs; behavior is automatic. Honors the post-tag idempotency contract: re-running must make forward progress, not abort because an upstream step already succeeded.

## Test plan

- [ ] After merge, dispatch `build-release.yml` with `version_branch=rel-810 version=8.1.0 release_tag=v8_1_0 base_ref=v8_0_0 milestone=8.1.0 dry_run=false`
- [ ] `Detect existing prep` step logs `version.php already at 8.1.0 — skipping legacy prep`
- [ ] `Version bump (full mode)` and `Commit and push version changes` show as skipped
- [ ] Tag step finds existing tag (no-op), GH Release is created with notes, source archives downloaded, checksums uploaded
- [ ] Older non-conductor branch (no plans to run this, but logically): detect step would log a mismatch and legacy path would run as before

## Context

Blocks: openemr/openemr#12285 (8.1.0 release).
Related: openemr/openemr#12117 (release process docs), openemr/openemr-devops#748 (PHP version fix).
