### PR TITLE
ci(build-release): check remote for existing tag, not local checkout

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -191,8 +191,14 @@ jobs:
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-        if git rev-parse "$tag" > /dev/null 2>&1; then
-          echo "Tag $tag already exists, skipping tag creation"
+        # Check the remote, not the local checkout: the checkout step
+        # uses fetch-depth: 1 and does not fetch tags, so a local
+        # rev-parse always misses an already-published tag. That made
+        # `git push origin "$tag"` fail with "tag already exists in the
+        # remote" when re-firing after the openemr/openemr conductor
+        # had already tagged via its finalize job.
+        if git ls-remote --tags --exit-code origin "refs/tags/$tag" > /dev/null 2>&1; then
+          echo "Tag $tag already exists on origin, skipping tag creation"
         else
           git tag -a -m "Release $tag" "$tag" '${{ inputs.version_branch }}'
           git push origin "$tag"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -197,12 +197,26 @@ jobs:
         # `git push origin "$tag"` fail with "tag already exists in the
         # remote" when re-firing after the openemr/openemr conductor
         # had already tagged via its finalize job.
-        if git ls-remote --tags --exit-code origin "refs/tags/$tag" > /dev/null 2>&1; then
-          echo "Tag $tag already exists on origin, skipping tag creation"
-        else
-          git tag -a -m "Release $tag" "$tag" '${{ inputs.version_branch }}'
-          git push origin "$tag"
-        fi
+        #
+        # `git ls-remote --exit-code` returns 0 when the tag exists and 2
+        # when it does not. Any other status is a real lookup failure
+        # (auth, transport) and must abort rather than fall through to a
+        # tag push that would mask the underlying error.
+        tag_lookup_status=0
+        git ls-remote --tags --exit-code origin "refs/tags/$tag" > /dev/null 2>&1 || tag_lookup_status=$?
+        case "$tag_lookup_status" in
+          0)
+            echo "Tag $tag already exists on origin, skipping tag creation"
+            ;;
+          2)
+            git tag -a -m "Release $tag" "$tag" '${{ inputs.version_branch }}'
+            git push origin "$tag"
+            ;;
+          *)
+            echo "::error::Failed to query origin for tag $tag (git ls-remote exit $tag_lookup_status)" >&2
+            exit "$tag_lookup_status"
+            ;;
+        esac
 
         if ! gh release view "$tag" --repo openemr/openemr > /dev/null 2>&1; then
           echo "Creating release $tag"


### PR DESCRIPTION
## Summary

`build-release.yml`'s tag precheck looks at the local checkout, but the checkout step uses `fetch-depth: 1` and does not fetch tags. So `git rev-parse "$tag"` always reports the tag missing, the workflow runs `git tag -a` locally (succeeds), and then `git push origin "$tag"` fails when the tag already exists upstream:

```
! [rejected]        v8_1_0 -> v8_1_0 (already exists)
hint: Updates were rejected because the tag already exists in the remote.
```

Reproduction: openemr/openemr-devops/actions/runs/26538663407 (re-fire after the openemr/openemr conductor's finalize job had already created and pushed `v8_1_0`).

## Fix

Replace the local check with `git ls-remote --tags --exit-code origin refs/tags/$tag`. This goes to the source of truth and is independent of how the local checkout was configured.

## Test plan

- [ ] Re-fire `build-release.yml` for 8.1.0 (tag `v8_1_0` already exists on origin from #12285's finalize job). New run takes the "tag already exists on origin" branch, skips `git tag -a` + `git push`, and proceeds to GH Release creation, archive download, and checksum upload.

## Context

Discovered re-firing build-release for 8.1.0 after openemr-devops#749 merged. The §C idempotency audit had this row marked "OK" but only inspected the precheck's shape, not its scope.
