### PR TITLE
Build full distribution package in build-release

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -204,8 +204,8 @@ jobs:
     - name: Generate checksums
       working-directory: devops-tools
       run: |
-        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.tar.gz"
-        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.zip"
+        task release:checksum FILE="openemr-${{ inputs.version }}.tar.gz"
+        task release:checksum FILE="openemr-${{ inputs.version }}.zip"
 
     - name: Create annotated tag and GitHub release
       if: '!inputs.dry_run'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -179,6 +179,27 @@ jobs:
         HEAD_REF='${{ inputs.version_branch }}'
         TITLE='${{ inputs.version }}'
 
+    # Build and checksum the package before creating the tag/release. If any
+    # build step fails, the job aborts before a release exists — never publish
+    # a release that has no distribution assets attached.
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Build distribution package
+      working-directory: devops-tools
+      run: >-
+        task release:package:assemble
+        VERSION='${{ inputs.version }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
+
+    - name: Generate checksums
+      working-directory: devops-tools
+      run: |
+        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.tar.gz"
+        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.zip"
+
     - name: Create annotated tag and GitHub release
       if: '!inputs.dry_run'
       working-directory: openemr
@@ -226,24 +247,6 @@ jobs:
             --notes-file "${output_dir}/changelog.md" \
             --verify-tag
         fi
-
-    - name: Setup Node
-      uses: actions/setup-node@v6
-      with:
-        node-version: '24'
-
-    - name: Build distribution package
-      working-directory: devops-tools
-      run: >-
-        task release:package:assemble
-        VERSION='${{ inputs.version }}'
-        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
-
-    - name: Generate checksums
-      working-directory: devops-tools
-      run: |
-        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.tar.gz"
-        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.zip"
 
     - name: Upload package and checksums to release
       if: '!inputs.dry_run'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -227,29 +227,25 @@ jobs:
             --verify-tag
         fi
 
-    - name: Download source archives and generate checksums
-      if: '!inputs.dry_run'
-      env:
-        GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+    - name: Setup Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+
+    - name: Build distribution package
+      working-directory: devops-tools
+      run: >-
+        task release:package:assemble
+        VERSION='${{ inputs.version }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
+
+    - name: Generate checksums
+      working-directory: devops-tools
       run: |
-        tag='${{ inputs.release_tag }}'
-        output_dir='${{ env.DEVOPS_DIR }}/tools/release/release-output'
+        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.tar.gz"
+        task release:checksum FILE="release-output/openemr-${{ inputs.version }}.zip"
 
-        gh release download "$tag" \
-          --repo openemr/openemr \
-          --pattern '*.tar.gz' \
-          --pattern '*.zip' \
-          --dir "$output_dir"
-
-        cd "$output_dir"
-        for archive in *.tar.gz *.zip; do
-          [ -f "$archive" ] || continue
-          md5sum "$archive" > "${archive}.md5"
-          sha256sum "$archive" > "${archive}.sha256"
-          sha512sum "$archive" > "${archive}.sha512"
-        done
-
-    - name: Upload checksums to release
+    - name: Upload package and checksums to release
       if: '!inputs.dry_run'
       env:
         GH_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
@@ -260,6 +256,8 @@ jobs:
         gh release upload "$tag" \
           --repo openemr/openemr \
           --clobber \
+          "${output_dir}/openemr-${{ inputs.version }}.tar.gz" \
+          "${output_dir}/openemr-${{ inputs.version }}.zip" \
           "${output_dir}"/*.md5 \
           "${output_dir}"/*.sha256 \
           "${output_dir}"/*.sha512 \
@@ -275,13 +273,16 @@ jobs:
         RELEASE_TAG='${{ inputs.release_tag }}'
         DRY_RUN='${{ inputs.dry_run }}'
 
-    - name: Upload changelog artifact (dry run)
+    - name: Upload artifacts (dry run)
       if: inputs.dry_run
       uses: actions/upload-artifact@v7
       with:
         name: release-${{ inputs.version }}
         path: |
           ${{ env.TOOLS_DIR }}/release-output/changelog.md
+          ${{ env.TOOLS_DIR }}/release-output/*.md5
+          ${{ env.TOOLS_DIR }}/release-output/*.sha256
+          ${{ env.TOOLS_DIR }}/release-output/*.sha512
         retention-days: 7
 
     - name: Create CHANGELOG PRs

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -159,15 +159,22 @@ jobs:
         MODE=full
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 
-    - name: Commit and push version changes
-      if: "!inputs.dry_run && steps.detect-prep.outputs.prep_done != 'true'"
+    # Commit the bump locally in every run (dry included) so the package build's
+    # `git archive HEAD` ships the exact bumped tree. The push to the release
+    # branch is gated on a real release below.
+    - name: Commit version changes
+      if: "steps.detect-prep.outputs.prep_done != 'true'"
       working-directory: openemr
       run: |
         git config user.name 'github-actions[bot]'
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
         git add version.php library/globals.inc.php
         git commit -m 'chore: prepare ${{ inputs.version }} for release'
-        git push origin HEAD:'${{ inputs.version_branch }}'
+
+    - name: Push version changes
+      if: "!inputs.dry_run && steps.detect-prep.outputs.prep_done != 'true'"
+      working-directory: openemr
+      run: git push origin HEAD:'${{ inputs.version_branch }}'
 
     - name: Generate changelog
       working-directory: devops-tools

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -65,6 +65,11 @@ tasks:
     desc: Generate checksum sidecar files
     requires:
       vars: [FILE]
+    # Run from OUTPUT_DIR and checksum the basename FILE so the sidecar records
+    # `openemr-x.tar.gz`, not `release-output/openemr-x.tar.gz`. Otherwise
+    # `sha256sum -c` fails once users download the assets into a flat directory
+    # and the recorded path's `release-output/` prefix is absent.
+    dir: '{{.OUTPUT_DIR}}'
     cmds:
       - md5sum {{shellQuote .FILE}} > {{shellQuote .FILE}}.md5
       - sha256sum {{shellQuote .FILE}} > {{shellQuote .FILE}}.sha256

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -133,6 +133,18 @@ tasks:
         --output-dir={{shellQuote .OUTPUT_DIR}}
         {{if .COPY_STYLES}}--copy-styles{{end}}
 
+  package:assemble:
+    desc: Build the full distribution tarball + zip for an official release
+    requires:
+      vars: [VERSION, OPENEMR_DIR]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/package-assemble.php
+        --version={{shellQuote .VERSION}}
+        --openemr-dir={{shellQuote .OPENEMR_DIR}}
+        --output-dir={{shellQuote .OUTPUT_DIR}}
+
   release:rotate:
     desc: Apply 3-slot rotation per versions.yml (idempotent)
     deps: [setup]

--- a/tools/release/bin/package-assemble.php
+++ b/tools/release/bin/package-assemble.php
@@ -1,0 +1,57 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Build the full distribution tarball + zip for an official OpenEMR release.
+ *
+ * Thin CLI wrapper around OpenEMR\Release\PackageAssembler; see that class for
+ * the build steps and rationale.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\PackageAssembler;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('package-assemble')
+    ->setDescription('Build the full distribution tarball + zip for an official release')
+    ->addOption('version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g., 8.1.0)')
+    ->addOption('openemr-dir', null, InputOption::VALUE_REQUIRED, 'Path to the checked-out openemr release branch')
+    ->addOption('output-dir', null, InputOption::VALUE_REQUIRED, 'Output directory', './release-output')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $versionOption = $input->getOption('version');
+        $openemrDirOption = $input->getOption('openemr-dir');
+        $outputDirOption = $input->getOption('output-dir');
+
+        if (!is_string($versionOption) || $versionOption === '') {
+            $output->writeln('<error>--version is required</error>');
+            return 1;
+        }
+        if (!is_string($openemrDirOption) || $openemrDirOption === '') {
+            $output->writeln('<error>--openemr-dir is required</error>');
+            return 1;
+        }
+        $outputDir = is_string($outputDirOption) && $outputDirOption !== ''
+            ? rtrim($outputDirOption, '/')
+            : './release-output';
+
+        return (new PackageAssembler(
+            $versionOption,
+            rtrim($openemrDirOption, '/'),
+            $outputDir,
+            $output,
+        ))->assemble();
+    })
+    ->run();

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -3,10 +3,15 @@
 /**
  * Build the full distribution tarball + zip for an official OpenEMR release.
  *
- * Ports the long-standing manual release-package process: take a checked-out
+ * Ports the long-standing manual release-package process: export a checked-out
  * release branch, install production-only dependencies, build front-end assets,
  * prune dev/test cruft, and emit `openemr-<version>.tar.gz` and
  * `openemr-<version>.zip` ready to attach to the GitHub release.
+ *
+ * The staging tree is produced with `git archive`, so `export-ignore` entries in
+ * openemr/openemr's .gitattributes (.github, ci, docker, tests, tools, large
+ * docs, …) are the single source of truth for what ships — no exclude list is
+ * duplicated here.
  *
  * Unlike PatchAssembler (a changed-files overlay), this produces a complete,
  * standalone install that end users extract and run without composer or npm.
@@ -57,10 +62,18 @@ final readonly class PackageAssembler
             mkdir($this->outputDir, 0755, true);
         }
 
-        // Copy the pristine checkout (minus VCS metadata) so the build never
-        // mutates the caller's working tree and the archive's top-level
-        // directory is openemr-<version>/.
-        $this->run(['rsync', '-a', '--exclude', '.git', "{$this->openemrDir}/", "{$stageDir}/"]);
+        // Export the committed tree (honoring .gitattributes export-ignore) into
+        // a fresh openemr-<version>/ staging dir. git archive can't pipe through
+        // our no-shell Process runner, so stage via an intermediate tar. HEAD is
+        // the release commit — in a real release the version bump is already
+        // committed before this step runs.
+        $sourceTar = "{$this->outputDir}/{$packageName}-source.tar";
+        $this->run(
+            ['git', 'archive', '--format=tar', '--prefix', "{$packageName}/", '-o', $sourceTar, 'HEAD'],
+            $this->openemrDir,
+        );
+        $this->run(['tar', '-xf', $sourceTar, '-C', $this->outputDir]);
+        unlink($sourceTar);
 
         // Production dependencies + built front-end assets.
         $this->run(['composer', 'install', '--no-dev', '--no-interaction', '--no-progress'], $stageDir);

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Build the full distribution tarball + zip for an official OpenEMR release.
+ *
+ * Ports the long-standing manual release-package process: take a checked-out
+ * release branch, install production-only dependencies, build front-end assets,
+ * prune dev/test cruft, and emit `openemr-<version>.tar.gz` and
+ * `openemr-<version>.zip` ready to attach to the GitHub release.
+ *
+ * Unlike PatchAssembler (a changed-files overlay), this produces a complete,
+ * standalone install that end users extract and run without composer or npm.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+final readonly class PackageAssembler
+{
+    public function __construct(
+        private string $version,
+        private string $openemrDir,
+        private string $outputDir,
+        private OutputInterface $output,
+    ) {
+    }
+
+    public function assemble(): int
+    {
+        if (!is_dir($this->openemrDir)) {
+            $this->output->writeln("<error>OpenEMR directory not found: {$this->openemrDir}</error>");
+            return 1;
+        }
+        if (!is_file("{$this->openemrDir}/build.xml")) {
+            $this->output->writeln("<error>build.xml not found in {$this->openemrDir} — wrong checkout?</error>");
+            return 1;
+        }
+
+        $packageName = "openemr-{$this->version}";
+        $stageDir = "{$this->outputDir}/{$packageName}";
+
+        // Fresh staging directory.
+        if (is_dir($stageDir)) {
+            $this->run(['rm', '-rf', $stageDir]);
+        }
+        if (!is_dir($this->outputDir)) {
+            mkdir($this->outputDir, 0755, true);
+        }
+
+        // Copy the pristine checkout (minus VCS metadata) so the build never
+        // mutates the caller's working tree and the archive's top-level
+        // directory is openemr-<version>/.
+        $this->run(['rsync', '-a', '--exclude', '.git', "{$this->openemrDir}/", "{$stageDir}/"]);
+
+        // Production dependencies + built front-end assets.
+        $this->run(['composer', 'install', '--no-dev', '--no-interaction', '--no-progress'], $stageDir);
+        $this->run(['npm', 'ci'], $stageDir);
+        $this->run(['npm', 'run', 'build'], $stageDir);
+
+        // Prune vendor/asset cruft via the openemr build.xml targets. Driving
+        // these through phing keeps the prune list owned by openemr/openemr
+        // (single source of truth) rather than duplicated here.
+        $this->run(['composer', 'global', 'require', 'phing/phing', '--no-interaction', '--no-progress']);
+        $homeProcess = new Process(['composer', 'global', 'config', 'home']);
+        $homeProcess->mustRun();
+        $phing = trim($homeProcess->getOutput()) . '/vendor/bin/phing';
+        $this->run([$phing, 'vendor-clean'], $stageDir);
+        $this->run([$phing, 'assets-clean'], $stageDir);
+        $this->run(['composer', 'global', 'remove', 'phing/phing', '--no-interaction', '--no-progress']);
+
+        // Drop node_modules and regenerate the optimized production autoloader.
+        $this->run(['rm', '-rf', "{$stageDir}/node_modules"]);
+        $this->run(['composer', 'dump-autoload', '--optimize', '--no-dev'], $stageDir);
+
+        // Standardize permissions; make the install-writable paths writable.
+        $this->run(['chmod', '-R', 'u+w', $stageDir]);
+        $documentsDir = "{$stageDir}/sites/default/documents";
+        if (is_dir($documentsDir)) {
+            $this->run(['chmod', '-R', 'a+w', $documentsDir]);
+        }
+        $sqlconf = "{$stageDir}/sites/default/sqlconf.php";
+        if (is_file($sqlconf)) {
+            $this->run(['chmod', 'a+w', $sqlconf]);
+        }
+
+        // Build archives from the output dir so each unpacks to openemr-<version>/.
+        $this->run(['tar', '-zcpf', "{$packageName}.tar.gz", $packageName], $this->outputDir);
+        $this->run(['zip', '-r', '-q', "{$packageName}.zip", $packageName], $this->outputDir);
+
+        // Drop the staging tree; only the archives need to survive.
+        $this->run(['rm', '-rf', $stageDir]);
+
+        foreach (["{$packageName}.tar.gz", "{$packageName}.zip"] as $artifact) {
+            $path = "{$this->outputDir}/{$artifact}";
+            $size = filesize($path);
+            $this->output->writeln(sprintf(
+                '<info>Built</info> %s (%s bytes)',
+                $path,
+                is_int($size) ? number_format($size) : '?',
+            ));
+        }
+
+        return 0;
+    }
+
+    /**
+     * Run a command, streaming its output. No timeout — builds are slow.
+     *
+     * @param list<string> $command
+     */
+    private function run(array $command, ?string $cwd = null): void
+    {
+        $this->output->writeln('<comment>$ ' . implode(' ', $command) . '</comment>');
+        $process = new Process($command, $cwd, null, null, null);
+        $process->mustRun(function (string $type, string $buffer): void {
+            $this->output->write($buffer);
+        });
+    }
+}

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -82,14 +82,22 @@ final readonly class PackageAssembler
 
         // Prune vendor/asset cruft via the openemr build.xml targets. Driving
         // these through phing keeps the prune list owned by openemr/openemr
-        // (single source of truth) rather than duplicated here.
-        $this->run(['composer', 'global', 'require', 'phing/phing', '--no-interaction', '--no-progress']);
-        $homeProcess = new Process(['composer', 'global', 'config', 'home']);
-        $homeProcess->mustRun();
-        $phing = trim($homeProcess->getOutput()) . '/vendor/bin/phing';
+        // (single source of truth) rather than duplicated here. Point
+        // COMPOSER_HOME at a throwaway dir so `composer global` installs phing
+        // there instead of mutating the caller's real global environment — no
+        // `remove` cleanup step that could be skipped on a clean-target failure.
+        $composerHome = "{$this->outputDir}/{$packageName}-composer-home";
+        mkdir($composerHome, 0755, true);
+        $composerEnv = ['COMPOSER_HOME' => $composerHome];
+        $this->run(
+            ['composer', 'global', 'require', 'phing/phing', '--no-interaction', '--no-progress'],
+            null,
+            $composerEnv,
+        );
+        $phing = "{$composerHome}/vendor/bin/phing";
         $this->run([$phing, 'vendor-clean'], $stageDir);
         $this->run([$phing, 'assets-clean'], $stageDir);
-        $this->run(['composer', 'global', 'remove', 'phing/phing', '--no-interaction', '--no-progress']);
+        $this->run(['rm', '-rf', $composerHome]);
 
         // Drop node_modules and regenerate the optimized production autoloader.
         $this->run(['rm', '-rf', "{$stageDir}/node_modules"]);
@@ -129,12 +137,13 @@ final readonly class PackageAssembler
     /**
      * Run a command, streaming its output. No timeout — builds are slow.
      *
-     * @param list<string> $command
+     * @param list<string>              $command
+     * @param array<string, string>|null $env extra environment, merged over the inherited environment
      */
-    private function run(array $command, ?string $cwd = null): void
+    private function run(array $command, ?string $cwd = null, ?array $env = null): void
     {
         $this->output->writeln('<comment>$ ' . implode(' ', $command) . '</comment>');
-        $process = new Process($command, $cwd, null, null, null);
+        $process = new Process($command, $cwd, $env, null, null);
         $process->mustRun(function (string $type, string $buffer): void {
             $this->output->write($buffer);
         });

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -51,6 +51,19 @@ final readonly class PackageAssembler
             return 1;
         }
 
+        // `git archive HEAD` below ships the committed tree, so an uncommitted
+        // version bump would silently package stale content. Fail fast on a dirty
+        // checkout. (The workflow commits the bump locally before this step, even
+        // in dry runs, so the package validates the exact tree a release ships.)
+        $status = new Process(['git', 'status', '--porcelain'], $this->openemrDir);
+        $status->mustRun();
+        $dirty = trim($status->getOutput());
+        if ($dirty !== '') {
+            $this->output->writeln("<error>Refusing to package a dirty checkout in {$this->openemrDir}:</error>");
+            $this->output->writeln($dirty);
+            return 1;
+        }
+
         $packageName = "openemr-{$this->version}";
         $stageDir = "{$this->outputDir}/{$packageName}";
 
@@ -65,8 +78,8 @@ final readonly class PackageAssembler
         // Export the committed tree (honoring .gitattributes export-ignore) into
         // a fresh openemr-<version>/ staging dir. git archive can't pipe through
         // our no-shell Process runner, so stage via an intermediate tar. HEAD is
-        // the release commit — in a real release the version bump is already
-        // committed before this step runs.
+        // the release commit — the dirty-checkout guard above guarantees the
+        // version bump is committed (in every run, dry included).
         $sourceTar = "{$this->outputDir}/{$packageName}-source.tar";
         $this->run(
             ['git', 'archive', '--format=tar', '--prefix', "{$packageName}/", '-o', $sourceTar, 'HEAD'],

--- a/tools/release/tests/PackageAssemblerTest.php
+++ b/tools/release/tests/PackageAssemblerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\PackageAssembler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+final class PackageAssemblerTest extends TestCase
+{
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-package-assembler-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tmpDir)) {
+            rmdir($this->tmpDir);
+        }
+    }
+
+    public function testMissingOpenemrDirReturnsError(): void
+    {
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $this->tmpDir . '/does-not-exist', $this->tmpDir, $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('OpenEMR directory not found', $output->fetch());
+    }
+
+    public function testMissingBuildXmlReturnsError(): void
+    {
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $this->tmpDir, $this->tmpDir, $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('build.xml not found', $output->fetch());
+    }
+}

--- a/tools/release/tests/PackageAssemblerTest.php
+++ b/tools/release/tests/PackageAssemblerTest.php
@@ -15,6 +15,7 @@ namespace OpenEMR\Release\Tests;
 use OpenEMR\Release\PackageAssembler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Process\Process;
 
 final class PackageAssemblerTest extends TestCase
 {
@@ -31,7 +32,7 @@ final class PackageAssemblerTest extends TestCase
     protected function tearDown(): void
     {
         if (is_dir($this->tmpDir)) {
-            rmdir($this->tmpDir);
+            (new Process(['rm', '-rf', $this->tmpDir]))->run();
         }
     }
 
@@ -51,5 +52,33 @@ final class PackageAssemblerTest extends TestCase
 
         self::assertSame(1, $assembler->assemble());
         self::assertStringContainsString('build.xml not found', $output->fetch());
+    }
+
+    public function testDirtyCheckoutReturnsError(): void
+    {
+        $repo = $this->tmpDir . '/openemr';
+        mkdir($repo, 0700, true);
+        $this->git($repo, ['init', '-q']);
+        $this->git($repo, ['config', 'user.email', 'test@example.com']);
+        $this->git($repo, ['config', 'user.name', 'Test']);
+        file_put_contents("{$repo}/build.xml", "<project/>\n");
+        $this->git($repo, ['add', 'build.xml']);
+        $this->git($repo, ['commit', '-qm', 'init']);
+        // Leave an uncommitted change, mimicking an uncommitted version bump.
+        file_put_contents("{$repo}/build.xml", "<project name=\"dirty\"/>\n");
+
+        $output = new BufferedOutput();
+        $assembler = new PackageAssembler('8.1.0', $repo, $this->tmpDir . '/out', $output);
+
+        self::assertSame(1, $assembler->assemble());
+        self::assertStringContainsString('dirty checkout', $output->fetch());
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function git(string $cwd, array $args): void
+    {
+        (new Process(['git', ...$args], $cwd))->mustRun();
     }
 }


### PR DESCRIPTION
## Summary

`build-release.yml` previously assumed a distribution package was already attached to the GitHub release: its "Download source archives" step fetched `*.tar.gz`/`*.zip` that nothing in the pipeline produced. The package-build automation was never finished (alongside the SourceForge/Docker/website placeholders), so the website Download link 404'd.

This ports the long-standing manual release-package process into the release tooling:

- **`src/PackageAssembler.php`** — export the committed tree via `git archive` (honoring `.gitattributes export-ignore`, so what ships is owned by openemr/openemr's `.gitattributes` rather than a duplicated exclude list), install production-only composer + npm deps, build front-end assets, prune dev/test cruft via the openemr `build.xml` phing targets (`vendor-clean`/`assets-clean`), regenerate the optimized autoloader, and emit `openemr-<version>.tar.gz` and `openemr-<version>.zip`.
- **`bin/package-assemble.php`** — thin CLI wrapper.
- **`tests/PackageAssemblerTest.php`** — guard-path coverage.
- **`Taskfile.yml`** — new `release:package:assemble` task.
- **`build-release.yml`** — replace the broken download step with Setup Node → Build package → Generate checksums → Upload. The build runs in dry-run too, so a dry run validates the full package build without writing the release.

## Companion PR

Because the package is now produced with `git archive`, large generated docs are excluded from the install package via `.gitattributes export-ignore`. openemr/openemr#12317 marks the ~140M generated EHI SchemaSpy documentation `export-ignore` (keeping the two runtime XMLs), so the packaged `Documentation/` tree drops from ~150M to ~10.5M.

## Test plan

- [ ] `composer check` passes (phpcs, PHPStan L10, rector, require-checker, phpunit)
- [ ] `workflow_dispatch` of build-release with `dry_run=true` builds `openemr-<version>.tar.gz`/`.zip` and uploads checksums as artifacts