### PR TITLE
ci(actionlint): ignore stale create-github-app-token input errors

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+# Workaround for stale bundled metadata for actions/create-github-app-token.
+# actionlint ships pre-v3.1.0 inputs, so it wrongly rejects `client-id` and
+# demands the now-deprecated `app-id`. Remove once the fix lands upstream:
+# https://github.com/rhysd/actionlint/pull/652
+paths:
+  .github/workflows/*.yml:
+    ignore:
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -3,7 +3,7 @@
 # demands the now-deprecated `app-id`. Remove once the fix lands upstream:
 # https://github.com/rhysd/actionlint/pull/652
 paths:
-  .github/workflows/*.yml:
+  .github/workflows/*.{yml,yaml}:
     ignore:
       - 'missing input "app-id" which is required by action "actions/create-github-app-token@[^"]+"'
       - 'input "client-id" is not defined in action "actions/create-github-app-token@[^"]+"'

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,5 +5,5 @@
 paths:
   .github/workflows/*.yml:
     ignore:
-      - 'missing input "app-id" which is required by action "actions/create-github-app-token'
-      - 'input "client-id" is not defined in action "actions/create-github-app-token'
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@[^"]+"'
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@[^"]+"'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -5,12 +5,14 @@ on:
     branches:
       - master
     paths:
+      - '.github/actionlint.yaml'
       - '.github/actions/**'
       - '.github/workflows/**'
   pull_request:
     branches:
       - master
     paths:
+      - '.github/actionlint.yaml'
       - '.github/actions/**'
       - '.github/workflows/**'
 


### PR DESCRIPTION
## Summary

actionlint ships pre-v3.1.0 bundled metadata for `actions/create-github-app-token`, so it wrongly rejects the current `client-id` input and demands the now-deprecated `app-id`. This adds a `.github/actionlint.yaml` that scopes an ignore to just that action's two error messages, keeping every other actionlint check active.

The errors silenced (across all workflows using `client-id`):
- `missing input "app-id" which is required by action "actions/create-github-app-token..."`
- `input "client-id" is not defined in action "actions/create-github-app-token..."`

Auto-discovered by both local runs and the `reviewdog/action-actionlint` CI job — no flag changes needed. Remove once the upstream fix lands: https://github.com/rhysd/actionlint/pull/652

## Test plan

- [ ] actionlint CI job passes (no create-github-app-token errors, other checks intact)