### PR TITLE
feat(build-release): create GitHub Release automatically on openemr-tag

### DIFF
--- a/.github/workflows/build-release-on-tag.yml
+++ b/.github/workflows/build-release-on-tag.yml
@@ -1,0 +1,89 @@
+name: Build Release on Tag
+
+# Consumer of the openemr/openemr `openemr-tag` repository_dispatch for
+# openemr/openemr-devops#756. When a release-prep PR merges, the conductor
+# in openemr/openemr mints a tag and fans out `openemr-tag` to owner repos
+# including this one. This workflow derives the build inputs from the
+# dispatch payload, looks up the previous release tag for the changelog
+# base_ref, and calls the reusable `build-release.yml` to produce the
+# distribution packages and GitHub Release that the manual workflow_dispatch
+# path already produces.
+
+on:
+  repository_dispatch:
+    types: [openemr-tag]
+
+permissions:
+  contents: read
+
+concurrency:
+  # Distinct from the reusable build-release.yml group on purpose. This
+  # only collapses duplicate openemr-tag dispatches for the same tag.
+  # Serializing the actual build against a manual build-release.yml run is
+  # build-release.yml's own concurrency group's job — both entry paths run
+  # through it. Sharing its group here would deadlock: this run holds the
+  # group while waiting on the called workflow, which would queue behind it.
+  group: build-release-on-tag-${{ github.event.client_payload.data.tag }}
+  cancel-in-progress: false
+
+jobs:
+  derive:
+    name: Derive build inputs
+    runs-on: ubuntu-24.04
+    outputs:
+      version: ${{ steps.inputs.outputs.version }}
+      version_branch: ${{ steps.inputs.outputs.version_branch }}
+      release_tag: ${{ steps.inputs.outputs.release_tag }}
+      base_ref: ${{ steps.base.outputs.base_ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.5'
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+
+      - name: Install release-tools dependencies
+        working-directory: tools/release
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Derive build inputs
+        id: inputs
+        working-directory: tools/release
+        env:
+          CLIENT_PAYLOAD: ${{ toJSON(github.event.client_payload) }}
+        run: |
+          printf '%s' "${CLIENT_PAYLOAD}" \
+              | task release:derive-build-inputs PAYLOAD_FILE='-' \
+              >> "${GITHUB_OUTPUT}"
+
+      - name: Derive base_ref from previous release
+        id: base
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Pass the tag through jq --arg, never interpolated into the
+          # command, so the value cannot break out of the jq filter.
+          RELEASE_TAG: ${{ steps.inputs.outputs.release_tag }}
+        run: |
+          base_ref=$(gh release list --repo openemr/openemr --exclude-drafts --json tagName,createdAt \
+              | jq -r --arg cur "${RELEASE_TAG}" 'map(select(.tagName != $cur)) | sort_by(.createdAt) | last.tagName')
+          printf 'base_ref=%s\n' "${base_ref}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: Build release
+    needs: derive
+    uses: ./.github/workflows/build-release.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.derive.outputs.version }}
+      version_branch: ${{ needs.derive.outputs.version_branch }}
+      release_tag: ${{ needs.derive.outputs.release_tag }}
+      base_ref: ${{ needs.derive.outputs.base_ref }}
+      dry_run: false
+      milestone: ''
+      skip_milestone_check: true
+      skip_ghsa_check: false

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,6 +52,60 @@ on:
         description: Create PR in website-openemr repo
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version_branch:
+        description: Release branch (e.g., rel-800)
+        required: true
+        type: string
+      version:
+        description: Human-readable version (e.g., 8.0.0)
+        required: true
+        type: string
+      release_tag:
+        description: Git tag (e.g., v8_0_0). Required unless dry run.
+        required: false
+        type: string
+      base_ref:
+        description: Previous release tag for changelog (e.g., v7_3_7)
+        required: true
+        type: string
+      milestone:
+        description: GitHub milestone name for preflight check (e.g., 8.0.0)
+        required: false
+        type: string
+      dry_run:
+        description: Dry run — build only, skip release
+        type: boolean
+        default: true
+      validate_token:
+        description: Generate and verify the app token (use with dry run to test permissions)
+        type: boolean
+        default: false
+      skip_milestone_check:
+        description: Skip milestone open-items check
+        type: boolean
+        default: false
+      skip_ghsa_check:
+        description: Skip unpublished GHSA check
+        type: boolean
+        default: false
+      upload_sourceforge:
+        description: Upload to SourceForge (requires SF secrets)
+        type: boolean
+        default: false
+      docker_prep:
+        description: Create PR for Docker version bumps in openemr-devops
+        type: boolean
+        default: false
+      update_website:
+        description: Create PR in website-openemr repo
+        type: boolean
+        default: false
+
+concurrency:
+  group: build-release-${{ inputs.release_tag || inputs.version }}
+  cancel-in-progress: false
 
 jobs:
   build-release:

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -234,6 +234,17 @@ tasks:
         {{if .BRANCH}}--release-branch={{shellQuote .BRANCH}}{{end}}
         {{if .FORUM_URL}}--forum-url={{shellQuote .FORUM_URL}}{{end}}
 
+  release:derive-build-inputs:
+    desc: Emit version/version_branch/release_tag lines for the build-release workflow
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/derive-build-inputs.php
+        {{if .PAYLOAD_FILE}}--payload-file={{shellQuote .PAYLOAD_FILE}}{{end}}
+        {{if .VERSION}}--release-version={{shellQuote .VERSION}}{{end}}
+        {{if .TAG}}--release-tag={{shellQuote .TAG}}{{end}}
+        {{if .BRANCH}}--release-branch={{shellQuote .BRANCH}}{{end}}
+
   release:render-announcements:
     desc: Render per-channel release-announcement drafts to a directory
     requires:

--- a/tools/release/bin/derive-build-inputs.php
+++ b/tools/release/bin/derive-build-inputs.php
@@ -2,11 +2,11 @@
 <?php
 
 /**
- * Emit the `version=` / `tag=` / `branch=` / `forum_url=` lines the
- * release-announcements workflow appends to $GITHUB_OUTPUT, regardless
- * of whether the trigger was an `openemr-tag` repository_dispatch
+ * Emit the `version=` / `version_branch=` / `release_tag=` lines the
+ * build-release workflow appends to $GITHUB_OUTPUT, regardless of
+ * whether the trigger was an `openemr-tag` repository_dispatch
  * (--payload-file) or a manual workflow_dispatch (--release-version /
- * --release-tag / --release-branch / --forum-url).
+ * --release-tag / --release-branch).
  *
  * Validation lives in TagDispatchPayload (mirrors the canonical
  * dispatch.schema.json patterns); a missing or malformed field aborts
@@ -31,8 +31,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\SingleCommandApplication;
 
 (new SingleCommandApplication())
-    ->setName('derive-announcement-inputs')
-    ->setDescription('Emit version/tag/branch/forum_url lines for the announcements workflow')
+    ->setName('derive-build-inputs')
+    ->setDescription('Emit version/version_branch/release_tag lines for the build-release workflow')
     ->addOption(
         'payload-file',
         null,
@@ -42,13 +42,6 @@ use Symfony\Component\Console\SingleCommandApplication;
     ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g. 8.1.0)')
     ->addOption('release-tag', null, InputOption::VALUE_REQUIRED, 'Annotated release tag (e.g. v8_1_0)')
     ->addOption('release-branch', null, InputOption::VALUE_REQUIRED, 'Release branch (e.g. rel-810)')
-    ->addOption(
-        'forum-url',
-        null,
-        InputOption::VALUE_REQUIRED,
-        'Per-release Discourse thread URL; empty value falls back to the placeholder',
-        '',
-    )
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         // Stdout is reserved for the GITHUB_OUTPUT key=value lines the
         // workflow appends with `>>`. Errors must not pollute it.
@@ -92,15 +85,9 @@ use Symfony\Component\Console\SingleCommandApplication;
             return 1;
         }
 
-        // Emit forum_url verbatim (possibly empty); downstream renderers
-        // substitute their own placeholder when the maintainer hasn't
-        // supplied a real URL. Keeping the placeholder string out of the
-        // pipeline avoids Taskfile/Go-template confusion over the literal
-        // braces.
         $output->writeln(sprintf('version=%s', $payload->version));
-        $output->writeln(sprintf('tag=%s', $payload->tag));
-        $output->writeln(sprintf('branch=%s', $payload->branch));
-        $output->writeln(sprintf('forum_url=%s', $str('forum-url')));
+        $output->writeln(sprintf('version_branch=%s', $payload->branch));
+        $output->writeln(sprintf('release_tag=%s', $payload->tag));
         return 0;
     })
     ->run();

--- a/tools/release/src/TagDispatchPayload.php
+++ b/tools/release/src/TagDispatchPayload.php
@@ -1,8 +1,11 @@
 <?php
 
 /**
- * Parsed `openemr-tag` repository_dispatch payload for the announcement
- * workflow.
+ * Parsed `openemr-tag` repository_dispatch payload.
+ *
+ * The generic value object for the `openemr-tag` envelope: any consumer
+ * (announcements, build-release) reuses it to normalize the dispatch into
+ * {version, tag, branch}.
  *
  * Validates each field against the canonical pattern from
  * tools/release/contracts/dispatch.schema.json so a malformed envelope
@@ -20,7 +23,7 @@ declare(strict_types=1);
 
 namespace OpenEMR\Release;
 
-final readonly class AnnouncementDispatchPayload
+final readonly class TagDispatchPayload
 {
     // Patterns mirror dispatch.schema.json's tag/branch/version definitions.
     private const VERSION_PATTERN = '/^\d+\.\d+\.\d+$/';

--- a/tools/release/tests/DeriveBuildInputsCliTest.php
+++ b/tools/release/tests/DeriveBuildInputsCliTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+/**
+ * The build-release workflow appends derive-build-inputs.php stdout
+ * directly to $GITHUB_OUTPUT. Errors must therefore not leak into
+ * stdout, or a failing run will write `<error>...</error>` lines into
+ * the runner's output file and trigger an "Invalid format" step failure
+ * that obscures the real error.
+ */
+final class DeriveBuildInputsCliTest extends TestCase
+{
+    private const BIN = __DIR__ . '/../bin/derive-build-inputs.php';
+
+    public function testValidFlagsWriteKeyValueLinesToStdoutOnly(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=v8_1_0',
+            '--release-branch=rel-810',
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), 'expected success exit code');
+        self::assertSame('', $process->getErrorOutput(), 'no stderr on success');
+        self::assertSame(
+            "version=8.1.0\nversion_branch=rel-810\nrelease_tag=v8_1_0\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testPayloadFileStdinWritesKeyValueLinesToStdoutOnly(): void
+    {
+        // The openemr-tag dispatch path: the workflow pipes the
+        // client_payload envelope on stdin via --payload-file=-.
+        $process = new Process(['php', self::BIN, '--payload-file=-']);
+        $process->setInput((string) json_encode([
+            'event' => 'openemr-tag',
+            'data' => ['version' => '8.1.0', 'tag' => 'v8_1_0', 'branch' => 'rel-810'],
+        ]));
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), 'expected success exit code');
+        self::assertSame('', $process->getErrorOutput(), 'no stderr on success');
+        self::assertSame(
+            "version=8.1.0\nversion_branch=rel-810\nrelease_tag=v8_1_0\n",
+            $process->getOutput(),
+        );
+    }
+
+    public function testValidationErrorsGoToStderrAndStdoutStaysEmpty(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--release-tag=BAD',
+            '--release-branch=rel-810',
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode(), 'expected failure exit code');
+        self::assertSame('', $process->getOutput(), 'stdout must stay empty so $GITHUB_OUTPUT is not corrupted');
+        self::assertStringContainsString('field tag does not match expected shape', $process->getErrorOutput());
+    }
+
+    public function testMalformedJsonPayloadGoesToStderrAndStdoutStaysEmpty(): void
+    {
+        // A truncated or garbled client_payload must abort cleanly, not
+        // append `<error>` lines to the runner's $GITHUB_OUTPUT file.
+        $process = new Process(['php', self::BIN, '--payload-file=-']);
+        $process->setInput('this is not json');
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode(), 'expected failure exit code');
+        self::assertSame('', $process->getOutput(), 'stdout must stay empty so $GITHUB_OUTPUT is not corrupted');
+        self::assertStringContainsString('Payload is not valid JSON', $process->getErrorOutput());
+    }
+
+    public function testMissingRequiredFlagsGoToStderr(): void
+    {
+        $process = new Process(['php', self::BIN]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('Provide either --payload-file', $process->getErrorOutput());
+    }
+
+    public function testMutuallyExclusiveSourcesRejected(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--payload-file=-',
+            '--release-version=8.1.0',
+        ]);
+        $process->setInput('{}');
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertSame('', $process->getOutput());
+        self::assertStringContainsString('mutually exclusive', $process->getErrorOutput());
+    }
+}

--- a/tools/release/tests/TagDispatchPayloadTest.php
+++ b/tools/release/tests/TagDispatchPayloadTest.php
@@ -12,10 +12,10 @@ declare(strict_types=1);
 
 namespace OpenEMR\Release\Tests;
 
-use OpenEMR\Release\AnnouncementDispatchPayload;
+use OpenEMR\Release\TagDispatchPayload;
 use PHPUnit\Framework\TestCase;
 
-final class AnnouncementDispatchPayloadTest extends TestCase
+final class TagDispatchPayloadTest extends TestCase
 {
     private const VALID_DATA = ['version' => '8.1.0', 'tag' => 'v8_1_0', 'branch' => 'rel-810'];
 
@@ -36,7 +36,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
     public function testParsesValidEnvelope(): void
     {
-        $payload = AnnouncementDispatchPayload::fromEnvelope($this->envelope());
+        $payload = TagDispatchPayload::fromEnvelope($this->envelope());
 
         self::assertSame('8.1.0', $payload->version);
         self::assertSame('v8_1_0', $payload->tag);
@@ -50,7 +50,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
             'tag' => 'v8_1_0-test.abcdef0',
             'branch' => 'rel-test',
         ]);
-        $payload = AnnouncementDispatchPayload::fromEnvelope($envelope);
+        $payload = TagDispatchPayload::fromEnvelope($envelope);
 
         self::assertSame('v8_1_0-test.abcdef0', $payload->tag);
         self::assertSame('rel-test', $payload->branch);
@@ -60,14 +60,14 @@ final class AnnouncementDispatchPayloadTest extends TestCase
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('not a JSON object');
-        AnnouncementDispatchPayload::fromEnvelope('not-an-object');
+        TagDispatchPayload::fromEnvelope('not-an-object');
     }
 
     public function testRejectsWrongEvent(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Expected event=openemr-tag');
-        AnnouncementDispatchPayload::fromEnvelope($this->envelope('openemr-rel-cut'));
+        TagDispatchPayload::fromEnvelope($this->envelope('openemr-rel-cut'));
     }
 
     public function testRejectsMissingDataObject(): void
@@ -77,7 +77,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('missing data object');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsMissingVersionField(): void
@@ -86,7 +86,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('missing or empty field: data.version');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsEmptyTagField(): void
@@ -95,7 +95,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('missing or empty field: data.tag');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsNullField(): void
@@ -106,7 +106,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('missing or empty field: data.branch');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsMalformedVersion(): void
@@ -115,7 +115,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('field version does not match expected shape');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsMalformedTag(): void
@@ -124,7 +124,7 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('field tag does not match expected shape');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 
     public function testRejectsMalformedBranch(): void
@@ -133,6 +133,6 @@ final class AnnouncementDispatchPayloadTest extends TestCase
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('field branch does not match expected shape');
-        AnnouncementDispatchPayload::fromEnvelope($envelope);
+        TagDispatchPayload::fromEnvelope($envelope);
     }
 }


### PR DESCRIPTION
## Summary

- Makes `build-release.yml` callable as a reusable workflow (`workflow_call` mirrors the existing `workflow_dispatch` inputs; job body unchanged) and adds a top-level `concurrency` group keyed on the release tag.
- Adds `build-release-on-tag.yml`, an `openemr-tag` `repository_dispatch` consumer that derives the build inputs + changelog `base_ref` and calls the reusable workflow with `secrets: inherit`.
- Generalizes the `openemr-tag` payload parser (`AnnouncementDispatchPayload` → `TagDispatchPayload`) and adds a `derive-build-inputs` CLI + Taskfile task mirroring the announcement consumer.

## Why

When a `release-prep/*` PR merges in `openemr/openemr`, the conductor mints the annotated tag and emits an `openemr-tag` dispatch — but nothing then built the distribution packages or created the GitHub Release. `build-release.yml` was `workflow_dispatch`-only, so a merged release yielded a tag with **no Release** (the v8.1.0 symptom): the website's `/downloads/` buttons 404 until someone ran the build by hand. This wires `build-release.yml` up as an `openemr-tag` consumer so the Release is created automatically.

The wrapper's concurrency group matches the reusable workflow's, so a manual run and a tag-driven run for the same tag serialize.

Closes #756

## Test plan

- [x] `composer test` in `tools/release` — 147 tests, 396 assertions, OK (renamed `TagDispatchPayloadTest`, new `DeriveBuildInputsCliTest`).
- [x] `php -l` on `derive-build-inputs.php`; `actionlint` clean on both workflows; `yq .` parses both.
- [ ] Build-only dry run: existing `build-release.yml` `workflow_dispatch` with `dry_run: true` still works unchanged.
- [ ] End-to-end (test mode): conductor `release-prep.yml` with `test=true` → `openemr-tag` → `build-release-on-tag.yml` fires, derives params + base_ref, calls `build-release.yml`, produces a Release with `openemr-<version>.tar.gz`/`.zip` + checksums + changelog.