### PR TITLE
test(openemr-cmd): add BATS regression + helper tests, wire into CI

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd.yml
+++ b/.github/workflows/test-bats-openemr-cmd.yml
@@ -1,0 +1,34 @@
+name: BATS openemr-cmd
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/workflows/test-bats-openemr-cmd.yml'
+      - 'utilities/openemr-cmd/**'
+      - 'tests/bats/openemr-cmd/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/workflows/test-bats-openemr-cmd.yml'
+      - 'utilities/openemr-cmd/**'
+      - 'tests/bats/openemr-cmd/**'
+
+jobs:
+  bats-openemr-cmd:
+    name: BATS openemr-cmd
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Bats
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          /tmp/bats-core/install.sh "$HOME/bats"
+          echo "$HOME/bats/bin" >> "$GITHUB_PATH"
+          echo "PATH=$HOME/bats/bin:$PATH" >> "$GITHUB_ENV"
+      - name: Install Bats assertion libraries
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-support.git tests/bats/test_helper/bats-support
+          git clone --depth 1 https://github.com/bats-core/bats-assert.git tests/bats/test_helper/bats-assert
+      - name: Run BATS tests (openemr-cmd)
+        run: bats tests/bats/openemr-cmd/

--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -1,8 +1,7 @@
-# Run BATS tests for bash scripts in 8.1.0, binary, and flex Docker contexts,
-# plus the host-side utilities/openemr-cmd/openemr-cmd CLI.
+# Run BATS tests for bash scripts in 8.1.0, binary, and flex Docker contexts.
 # Ensures all scripts have valid syntax and expected structure.
 
-name: BATS Tests (8.1.0, binary, flex, openemr-cmd)
+name: BATS Tests (8.1.0, binary, flex)
 
 on:
   push:
@@ -13,8 +12,6 @@ on:
       - 'docker/openemr/8.1.0/**'
       - 'docker/openemr/binary/**'
       - 'docker/openemr/flex/**'
-      - 'utilities/openemr-cmd/**'
-      - 'tests/bats/openemr-cmd/**'
   pull_request:
     branches: [master]
     paths:
@@ -23,8 +20,6 @@ on:
       - 'docker/openemr/8.1.0/**'
       - 'docker/openemr/binary/**'
       - 'docker/openemr/flex/**'
-      - 'utilities/openemr-cmd/**'
-      - 'tests/bats/openemr-cmd/**'
 
 jobs:
   bats-810:
@@ -80,21 +75,3 @@ jobs:
           git clone --depth 1 https://github.com/bats-core/bats-assert.git tests/bats/test_helper/bats-assert
       - name: Run BATS tests (flex)
         run: bats tests/bats/flex/
-
-  bats-openemr-cmd:
-    name: BATS openemr-cmd
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install Bats
-        run: |
-          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
-          /tmp/bats-core/install.sh "$HOME/bats"
-          echo "$HOME/bats/bin" >> "$GITHUB_PATH"
-          echo "PATH=$HOME/bats/bin:$PATH" >> "$GITHUB_ENV"
-      - name: Install Bats assertion libraries
-        run: |
-          git clone --depth 1 https://github.com/bats-core/bats-support.git tests/bats/test_helper/bats-support
-          git clone --depth 1 https://github.com/bats-core/bats-assert.git tests/bats/test_helper/bats-assert
-      - name: Run BATS tests (openemr-cmd)
-        run: bats tests/bats/openemr-cmd/

--- a/.github/workflows/test-bats.yml
+++ b/.github/workflows/test-bats.yml
@@ -1,7 +1,8 @@
-# Run BATS tests for bash scripts in 8.1.0, binary, and flex Docker contexts.
+# Run BATS tests for bash scripts in 8.1.0, binary, and flex Docker contexts,
+# plus the host-side utilities/openemr-cmd/openemr-cmd CLI.
 # Ensures all scripts have valid syntax and expected structure.
 
-name: BATS Tests (8.1.0, binary, flex)
+name: BATS Tests (8.1.0, binary, flex, openemr-cmd)
 
 on:
   push:
@@ -12,6 +13,8 @@ on:
       - 'docker/openemr/8.1.0/**'
       - 'docker/openemr/binary/**'
       - 'docker/openemr/flex/**'
+      - 'utilities/openemr-cmd/**'
+      - 'tests/bats/openemr-cmd/**'
   pull_request:
     branches: [master]
     paths:
@@ -20,6 +23,8 @@ on:
       - 'docker/openemr/8.1.0/**'
       - 'docker/openemr/binary/**'
       - 'docker/openemr/flex/**'
+      - 'utilities/openemr-cmd/**'
+      - 'tests/bats/openemr-cmd/**'
 
 jobs:
   bats-810:
@@ -75,3 +80,21 @@ jobs:
           git clone --depth 1 https://github.com/bats-core/bats-assert.git tests/bats/test_helper/bats-assert
       - name: Run BATS tests (flex)
         run: bats tests/bats/flex/
+
+  bats-openemr-cmd:
+    name: BATS openemr-cmd
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Bats
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          /tmp/bats-core/install.sh "$HOME/bats"
+          echo "$HOME/bats/bin" >> "$GITHUB_PATH"
+          echo "PATH=$HOME/bats/bin:$PATH" >> "$GITHUB_ENV"
+      - name: Install Bats assertion libraries
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-support.git tests/bats/test_helper/bats-support
+          git clone --depth 1 https://github.com/bats-core/bats-assert.git tests/bats/test_helper/bats-assert
+      - name: Run BATS tests (openemr-cmd)
+        run: bats tests/bats/openemr-cmd/

--- a/tests/bats/openemr-cmd/cli_smoke.bats
+++ b/tests/bats/openemr-cmd/cli_smoke.bats
@@ -30,15 +30,15 @@ teardown() {
     expected=$(grep -E '^VERSION=' "$SCRIPT" | head -1 | sed -E 's/^VERSION="([^"]+)".*/\1/')
     [[ -n "$expected" ]]
     run env PATH="${STUB_DIR}:$PATH" "$SCRIPT" --version
-    [[ "$status" -eq 14 ]]
     assert_output "openemr-cmd ${expected}"
+    [[ "$status" -eq 14 ]]
 }
 
 @test "openemr-cmd -v is equivalent to --version" {
     expected=$(grep -E '^VERSION=' "$SCRIPT" | head -1 | sed -E 's/^VERSION="([^"]+)".*/\1/')
     run env PATH="${STUB_DIR}:$PATH" "$SCRIPT" -v
-    [[ "$status" -eq 14 ]]
     assert_output "openemr-cmd ${expected}"
+    [[ "$status" -eq 14 ]]
 }
 
 # --- worktree subcommand dispatch -------------------------------------------
@@ -48,8 +48,8 @@ teardown() {
         OPENEMR_ROOT="${TMP_ROOT}" \
         WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
         "$SCRIPT" worktree
-    [[ "$status" -ne 0 ]]
     assert_output --partial "Usage: openemr-cmd worktree"
+    [[ "$status" -ne 0 ]]
 }
 
 @test "openemr-cmd wt (alias, no subcommand) prints usage and exits non-zero" {
@@ -57,8 +57,8 @@ teardown() {
         OPENEMR_ROOT="${TMP_ROOT}" \
         WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
         "$SCRIPT" wt
-    [[ "$status" -ne 0 ]]
     assert_output --partial "Usage: openemr-cmd worktree"
+    [[ "$status" -ne 0 ]]
 }
 
 # --- worktree list empty cases ---------------------------------------------

--- a/tests/bats/openemr-cmd/cli_smoke.bats
+++ b/tests/bats/openemr-cmd/cli_smoke.bats
@@ -1,0 +1,90 @@
+# BATS: openemr-cmd CLI smoke tests — top-level argument handling.
+# These tests invoke the script as a subprocess (real CLI surface) rather
+# than sourcing it, so they catch regressions in dispatch and exit codes.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_ROOT=$(oc_mktempdir)
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    # Init a real repo so worktree subcommands' git calls succeed.
+    oc_init_repo "${TMP_ROOT}"
+}
+
+teardown() {
+    [[ -n "${TMP_ROOT:-}" ]]  && rm -rf "${TMP_ROOT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+}
+
+# --- --version ---------------------------------------------------------------
+
+@test "openemr-cmd --version prints VERSION and exits 14 (VERSION_EXIT_CODE)" {
+    # The script defines VERSION_EXIT_CODE=14 and exits with it after
+    # printing 'openemr-cmd <VERSION>'. We assert the printed string
+    # matches the VERSION= line in the script, so this test self-updates
+    # as VERSION bumps.
+    expected=$(grep -E '^VERSION=' "$SCRIPT" | head -1 | sed -E 's/^VERSION="([^"]+)".*/\1/')
+    [[ -n "$expected" ]]
+    run env PATH="${STUB_DIR}:$PATH" "$SCRIPT" --version
+    [[ "$status" -eq 14 ]]
+    assert_output "openemr-cmd ${expected}"
+}
+
+@test "openemr-cmd -v is equivalent to --version" {
+    expected=$(grep -E '^VERSION=' "$SCRIPT" | head -1 | sed -E 's/^VERSION="([^"]+)".*/\1/')
+    run env PATH="${STUB_DIR}:$PATH" "$SCRIPT" -v
+    [[ "$status" -eq 14 ]]
+    assert_output "openemr-cmd ${expected}"
+}
+
+# --- worktree subcommand dispatch -------------------------------------------
+
+@test "openemr-cmd worktree (no subcommand) prints usage and exits non-zero" {
+    run env \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "$SCRIPT" worktree
+    [[ "$status" -ne 0 ]]
+    assert_output --partial "Usage: openemr-cmd worktree"
+}
+
+@test "openemr-cmd wt (alias, no subcommand) prints usage and exits non-zero" {
+    run env \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "$SCRIPT" wt
+    [[ "$status" -ne 0 ]]
+    assert_output --partial "Usage: openemr-cmd worktree"
+}
+
+# --- worktree list empty cases ---------------------------------------------
+
+@test "openemr-cmd worktree list with no .worktrees.json prints '(no worktrees)' and exits 0" {
+    # Ensure no state file is present.
+    rm -f "${TMP_ROOT}/.worktrees.json"
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "$SCRIPT" worktree list
+    # cmd_worktree_list calls wt_init_state which CREATES an empty {} file
+    # if missing, then the empty-{} branch kicks in. Either way exit 0 and
+    # the '(no worktrees)' line must appear.
+    assert_success
+    assert_output --partial "(no worktrees)"
+}
+
+@test "openemr-cmd worktree list with {} state prints '(no worktrees)' and exits 0" {
+    echo '{}' > "${TMP_ROOT}/.worktrees.json"
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "$SCRIPT" worktree list
+    assert_success
+    assert_output --partial "(no worktrees)"
+}

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -1,0 +1,95 @@
+# Helpers for BATS tests of utilities/openemr-cmd/openemr-cmd.
+# Source this in test files: load 'helpers'
+#
+# Kept separate from tests/bats/helpers.bash so we don't pollute the
+# per-image test infrastructure with host-CLI concerns.
+#
+# shellcheck shell=bash
+
+# Repo root (directory containing utilities/openemr-cmd/openemr-cmd).
+oc_repo_root() {
+    local dir
+    # BATS_TEST_FILENAME is set by the bats runner before sourcing.
+    # shellcheck disable=SC2154
+    dir="${BATS_TEST_FILENAME%/*}"
+    while [[ -n "${dir}" ]] && [[ "${dir}" != "/" ]]; do
+        [[ -f "${dir}/utilities/openemr-cmd/openemr-cmd" ]] && echo "${dir}" && return 0
+        dir="${dir%/*}"
+    done
+    return 1
+}
+
+# Absolute path to the script under test.
+oc_script_path() {
+    local root
+    root=$(oc_repo_root) || return 1
+    echo "${root}/utilities/openemr-cmd/openemr-cmd"
+}
+
+# Make a per-test scratch directory. Caller owns cleanup (use trap or teardown).
+oc_mktempdir() {
+    mktemp -d "${BATS_TMPDIR:-/tmp}/openemr-cmd-XXXXXX"
+}
+
+# Build a PATH-stubs directory containing a 'docker' shim that responds to
+# 'docker compose' (no args, plugin probe) with exit 0 and ignores everything
+# else with empty output and exit 0. The shim does NOT shell out anywhere.
+#
+# Usage:
+#   stub_dir=$(oc_make_docker_stub_dir)
+#   PATH="${stub_dir}:$PATH" run "$SCRIPT" worktree list
+oc_make_docker_stub_dir() {
+    local d
+    d=$(oc_mktempdir)
+    cat > "${d}/docker" <<'STUB'
+#!/bin/sh
+# Predictable stub of 'docker' used by openemr-cmd BATS tests.
+# 'docker compose' (plugin probe) must succeed so check_docker_compose_install
+# picks the plugin path; everything else returns empty/0.
+if [ "${1-}" = "compose" ]; then
+    exit 0
+fi
+exit 0
+STUB
+    chmod +x "${d}/docker"
+    echo "${d}"
+}
+
+# Line number that marks the end of function definitions in the script
+# (the last '}' before USAGE_EXIT_CODE=13 and the dispatch logic). Sourcing
+# only the first OC_SCRIPT_FUNCS_END lines gives us a library-like view of
+# the script: every function defined, no main-line dispatch executed.
+# If the script is restructured, bump this constant — the test
+# 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
+# will fail loudly when it drifts.
+OC_SCRIPT_FUNCS_END=1352
+
+# Source ONLY the function definitions of openemr-cmd into the current shell.
+# Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others
+# as needed) BEFORE calling, since the script's top-level OPENEMR_ROOT
+# assignment runs while sourcing.
+#
+# Usage (inside a 'bash -c' inside @test):
+#   oc_source_funcs
+#   wt_slug feature/foo
+oc_source_funcs() {
+    local script
+    script=$(oc_script_path) || return 1
+    # shellcheck disable=SC1090,SC2312
+    source <(head -n "${OC_SCRIPT_FUNCS_END}" "${script}")
+}
+
+# Initialize $1 as a real git repo with one commit, so commands like
+# 'git -C <dir> worktree list --porcelain' and
+# 'git -C <dir> symbolic-ref --short HEAD' work.
+oc_init_repo() {
+    local dir=$1
+    git -C "${dir}" init --quiet --initial-branch=master >/dev/null 2>&1 \
+        || git -C "${dir}" init --quiet >/dev/null 2>&1
+    git -C "${dir}" config user.email "bats@example.com"
+    git -C "${dir}" config user.name "bats"
+    git -C "${dir}" config commit.gpgsign false
+    : > "${dir}/.placeholder"
+    git -C "${dir}" add .placeholder
+    git -C "${dir}" commit --quiet -m "init" >/dev/null
+}

--- a/tests/bats/openemr-cmd/helpers_pure.bats
+++ b/tests/bats/openemr-cmd/helpers_pure.bats
@@ -1,0 +1,124 @@
+# BATS: pure helper tests for openemr-cmd worktree primitives.
+# wt_slug, wt_compose_subdir, wt_validate_env have no I/O dependencies
+# beyond a benign OPENEMR_ROOT — exercise them in a subshell with the
+# function definitions sourced from the script.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_ROOT=$(oc_mktempdir)
+    export TMP_ROOT
+}
+
+teardown() {
+    [[ -n "${TMP_ROOT:-}" ]] && rm -rf "${TMP_ROOT}"
+}
+
+# Run a snippet with the script's function defs sourced. Stdout of the
+# snippet is captured by 'run'; OPENEMR_ROOT is forced to a benign tmpdir
+# so the script's top-level git-rev-parse fallback never fires.
+oc_run_in_funcs() {
+    local snippet=$1
+    local script_path=$2
+    local funcs_end=$3
+    local tmp_root=$4
+    run env OPENEMR_ROOT="${tmp_root}" bash -c "
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        source <(head -n ${funcs_end} '${script_path}')
+        ${snippet}
+    "
+}
+
+# --- wt_slug -----------------------------------------------------------------
+
+@test "wt_slug: slash becomes dash" {
+    oc_run_in_funcs 'wt_slug feature/foo' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "feature-foo"
+}
+
+@test "wt_slug: uppercase is lowercased" {
+    oc_run_in_funcs 'wt_slug UPPER' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "upper"
+}
+
+@test "wt_slug: spaces and special chars are stripped" {
+    oc_run_in_funcs "wt_slug 'with spaces!'" "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "withspaces"
+}
+
+@test "wt_slug: mixed case + slash + special chars" {
+    oc_run_in_funcs "wt_slug 'Feature/My-Thing!'" "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "feature-my-thing"
+}
+
+# --- wt_compose_subdir -------------------------------------------------------
+
+@test "wt_compose_subdir: easy" {
+    oc_run_in_funcs 'wt_compose_subdir easy' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "docker/development-easy"
+}
+
+@test "wt_compose_subdir: easy-light" {
+    oc_run_in_funcs 'wt_compose_subdir easy-light' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "docker/development-easy-light"
+}
+
+@test "wt_compose_subdir: easy-redis" {
+    oc_run_in_funcs 'wt_compose_subdir easy-redis' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "docker/development-easy-redis"
+}
+
+# --- wt_validate_env ---------------------------------------------------------
+
+@test "wt_validate_env: accepts easy" {
+    oc_run_in_funcs 'wt_validate_env easy && echo ok' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "ok"
+}
+
+@test "wt_validate_env: accepts easy-light" {
+    oc_run_in_funcs 'wt_validate_env easy-light && echo ok' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "ok"
+}
+
+@test "wt_validate_env: accepts easy-redis" {
+    oc_run_in_funcs 'wt_validate_env easy-redis && echo ok' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_success
+    assert_output "ok"
+}
+
+@test "wt_validate_env: rejects bogus env with error message" {
+    oc_run_in_funcs 'wt_validate_env bogus 2>&1' "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_failure
+    assert_output --partial "Invalid env 'bogus'"
+}
+
+@test "wt_validate_env: rejects empty env" {
+    oc_run_in_funcs "wt_validate_env '' 2>&1" "$SCRIPT" "${OC_SCRIPT_FUNCS_END}" "$TMP_ROOT"
+    assert_failure
+}
+
+# --- oc_funcs_source_line is current ----------------------------------------
+# If someone restructures openemr-cmd and our OC_SCRIPT_FUNCS_END constant
+# drifts (e.g. someone adds another function above the dispatch), this test
+# catches it loudly: line OC_SCRIPT_FUNCS_END+1 must be 'USAGE_EXIT_CODE=13'
+# or very close to it, signalling the end of the function-defs section.
+
+@test "OC_SCRIPT_FUNCS_END points at end of function defs (USAGE_EXIT_CODE follows)" {
+    run sed -n "$((OC_SCRIPT_FUNCS_END+1)),$((OC_SCRIPT_FUNCS_END+3))p" "$SCRIPT"
+    assert_success
+    assert_output --partial "USAGE_EXIT_CODE="
+}

--- a/tests/bats/openemr-cmd/regression_worktree_list_missing_dir.bats
+++ b/tests/bats/openemr-cmd/regression_worktree_list_missing_dir.bats
@@ -16,8 +16,11 @@ setup() {
     SCRIPT="$(oc_script_path)"
     [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
 
-    TMP_OPENEMR_ROOT=$(oc_mktempdir)
-    TMP_WT_PARENT=$(dirname "${TMP_OPENEMR_ROOT}")
+    # Per-test scratch parent so fixed-name subdirs (e.g. 'present-but-incomplete')
+    # cannot collide between concurrent test runs.
+    TMP_WT_PARENT=$(oc_mktempdir)
+    TMP_OPENEMR_ROOT="${TMP_WT_PARENT}/repo"
+    mkdir -p "${TMP_OPENEMR_ROOT}"
     STUB_DIR=$(oc_make_docker_stub_dir)
 
     # OPENEMR_ROOT must be a real git repo: cmd_worktree_list calls
@@ -36,8 +39,9 @@ JSON
 }
 
 teardown() {
-    [[ -n "${TMP_OPENEMR_ROOT:-}" ]] && rm -rf "${TMP_OPENEMR_ROOT}"
-    [[ -n "${STUB_DIR:-}" ]]        && rm -rf "${STUB_DIR}"
+    # TMP_WT_PARENT now contains TMP_OPENEMR_ROOT plus any fixture subdirs.
+    [[ -n "${TMP_WT_PARENT:-}" ]] && rm -rf "${TMP_WT_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]]      && rm -rf "${STUB_DIR}"
 }
 
 @test "regression(028d9b7): worktree list prints all entries even when a dir is deleted" {
@@ -62,8 +66,10 @@ teardown() {
     # Each branch row must include 'missing' as its status column.
     # Use grep to confirm both rows independently — assert_output --partial
     # only proves the string appears somewhere.
-    echo "$output" | grep -E '^feature/alpha[[:space:]]+easy[[:space:]]+1[[:space:]]+missing[[:space:]]'
-    echo "$output" | grep -E '^feature/beta[[:space:]]+easy-light[[:space:]]+2[[:space:]]+missing[[:space:]]'
+    echo "$output" | grep -E '^feature/alpha[[:space:]]+easy[[:space:]]+1[[:space:]]+missing[[:space:]]' \
+        || fail "expected 'feature/alpha easy 1 missing' row not found in output"
+    echo "$output" | grep -E '^feature/beta[[:space:]]+easy-light[[:space:]]+2[[:space:]]+missing[[:space:]]' \
+        || fail "expected 'feature/beta easy-light 2 missing' row not found in output"
 }
 
 @test "regression(028d9b7): worktree list exits 0 with mixed present+missing entries" {
@@ -89,6 +95,4 @@ JSON
     assert_output --partial "feature/alpha"
     assert_output --partial "feature/present"
     assert_output --partial "feature/beta"
-
-    rm -rf "${TMP_WT_PARENT}/present-but-incomplete"
 }

--- a/tests/bats/openemr-cmd/regression_worktree_list_missing_dir.bats
+++ b/tests/bats/openemr-cmd/regression_worktree_list_missing_dir.bats
@@ -1,0 +1,94 @@
+# BATS: regression for commit 028d9b7 — 'openemr-cmd worktree list' must not
+# abort mid-loop when a state entry's dir has been deleted on disk.
+#
+# Bug: cmd_worktree_list called wt_validate_dir_safe directly. Under
+# 'set -euo pipefail', a non-zero return (deleted dir -> realpath -e fails)
+# killed the entire list command before subsequent entries were printed.
+# Fix wrapped the call with 'set +e' / 'set -e'. This test guards that
+# contract: every branch in .worktrees.json must appear in the output,
+# entries whose dir is missing must show status 'missing', exit 0.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+
+    TMP_OPENEMR_ROOT=$(oc_mktempdir)
+    TMP_WT_PARENT=$(dirname "${TMP_OPENEMR_ROOT}")
+    STUB_DIR=$(oc_make_docker_stub_dir)
+
+    # OPENEMR_ROOT must be a real git repo: cmd_worktree_list calls
+    # 'git -C "${OPENEMR_ROOT}" symbolic-ref --short HEAD' early.
+    oc_init_repo "${TMP_OPENEMR_ROOT}"
+
+    # Fixture: two entries, neither dir exists on disk. The buggy code
+    # would print the header and then exit on the first iteration; the
+    # fixed code prints both rows with status=missing.
+    cat > "${TMP_OPENEMR_ROOT}/.worktrees.json" <<JSON
+{
+  "feature/alpha": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist-alpha", "env": "easy"},
+  "feature/beta":  {"offset": 2, "dir": "${TMP_WT_PARENT}/does-not-exist-beta",  "env": "easy-light"}
+}
+JSON
+}
+
+teardown() {
+    [[ -n "${TMP_OPENEMR_ROOT:-}" ]] && rm -rf "${TMP_OPENEMR_ROOT}"
+    [[ -n "${STUB_DIR:-}" ]]        && rm -rf "${STUB_DIR}"
+}
+
+@test "regression(028d9b7): worktree list prints all entries even when a dir is deleted" {
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree list
+    assert_success
+    assert_output --partial "feature/alpha"
+    assert_output --partial "feature/beta"
+    assert_output --partial "missing"
+}
+
+@test "regression(028d9b7): worktree list shows status 'missing' for the deleted-dir row" {
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree list
+    assert_success
+    # Each branch row must include 'missing' as its status column.
+    # Use grep to confirm both rows independently — assert_output --partial
+    # only proves the string appears somewhere.
+    echo "$output" | grep -E '^feature/alpha[[:space:]]+easy[[:space:]]+1[[:space:]]+missing[[:space:]]'
+    echo "$output" | grep -E '^feature/beta[[:space:]]+easy-light[[:space:]]+2[[:space:]]+missing[[:space:]]'
+}
+
+@test "regression(028d9b7): worktree list exits 0 with mixed present+missing entries" {
+    # Add a third 'present' entry: dir exists but is NOT a registered git
+    # worktree, so wt_validate_dir_safe returns non-zero. The compose-files
+    # check fires first (no .env / docker-compose.override.yml), so status
+    # is 'missing' regardless. This exercises the loop continuing past
+    # multiple non-zero wt_validate_dir_safe returns.
+    mkdir -p "${TMP_WT_PARENT}/present-but-incomplete"
+    cat > "${TMP_OPENEMR_ROOT}/.worktrees.json" <<JSON
+{
+  "feature/alpha":   {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist-alpha",  "env": "easy"},
+  "feature/present": {"offset": 2, "dir": "${TMP_WT_PARENT}/present-but-incomplete", "env": "easy"},
+  "feature/beta":    {"offset": 3, "dir": "${TMP_WT_PARENT}/does-not-exist-beta",   "env": "easy-light"}
+}
+JSON
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree list
+    assert_success
+    assert_output --partial "feature/alpha"
+    assert_output --partial "feature/present"
+    assert_output --partial "feature/beta"
+
+    rm -rf "${TMP_WT_PARENT}/present-but-incomplete"
+}

--- a/tests/bats/openemr-cmd/state.bats
+++ b/tests/bats/openemr-cmd/state.bats
@@ -1,0 +1,121 @@
+# BATS: state plumbing — wt_state_set/get/remove and wt_next_offset
+# operate purely on WT_STATE_FILE (a JSON file written by jq). Tests use
+# a per-test temp state file with WT_STATE_FILE overridden via env.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+    TMP_ROOT=$(oc_mktempdir)
+    TMP_STATE="${TMP_ROOT}/.worktrees.json"
+    echo '{}' > "${TMP_STATE}"
+}
+
+teardown() {
+    [[ -n "${TMP_ROOT:-}" ]] && rm -rf "${TMP_ROOT}"
+}
+
+# Run a snippet with the script's function defs sourced; override
+# WT_STATE_FILE so the helpers act on our temp file.
+oc_run_state() {
+    local snippet=$1
+    run env \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WT_STATE_FILE="${TMP_STATE}" \
+        bash -c "
+            set -euo pipefail
+            # shellcheck disable=SC1090
+            source <(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')
+            # Re-export WT_STATE_FILE after sourcing: the script's top-level
+            # WT_STATE_FILE=... line overrides our env var when sourced.
+            WT_STATE_FILE='${TMP_STATE}'
+            ${snippet}
+        "
+}
+
+# --- wt_state_set / wt_state_get round-trip ---------------------------------
+
+@test "wt_state_set then wt_state_get returns fields" {
+    oc_run_state '
+        wt_state_set "feature/foo" 5 "/tmp/worktree-foo" "easy"
+        echo "offset=$(wt_state_get feature/foo offset)"
+        echo "dir=$(wt_state_get feature/foo dir)"
+        echo "env=$(wt_state_get feature/foo env)"
+    '
+    assert_success
+    assert_output --partial "offset=5"
+    assert_output --partial "dir=/tmp/worktree-foo"
+    assert_output --partial "env=easy"
+}
+
+@test "wt_state_get returns empty for unknown branch" {
+    oc_run_state '
+        result=$(wt_state_get nonexistent offset)
+        echo "[$result]"
+    '
+    assert_success
+    assert_output "[]"
+}
+
+# --- wt_state_remove ---------------------------------------------------------
+
+@test "wt_state_remove removes the entry" {
+    oc_run_state '
+        wt_state_set "feature/foo" 5 "/tmp/foo" "easy"
+        wt_state_set "feature/bar" 6 "/tmp/bar" "easy-light"
+        wt_state_remove "feature/foo"
+        # foo gone, bar remains
+        foo_offset=$(wt_state_get feature/foo offset)
+        bar_offset=$(wt_state_get feature/bar offset)
+        echo "foo=[${foo_offset}]"
+        echo "bar=[${bar_offset}]"
+    '
+    assert_success
+    assert_output --partial "foo=[]"
+    assert_output --partial "bar=[6]"
+}
+
+# --- wt_next_offset ----------------------------------------------------------
+
+@test "wt_next_offset returns 1 on empty state" {
+    oc_run_state 'wt_next_offset'
+    assert_success
+    assert_output "1"
+}
+
+@test "wt_next_offset fills gap: used=[1,3] -> 2" {
+    oc_run_state '
+        wt_state_set "b1" 1 "/tmp/a" "easy"
+        wt_state_set "b3" 3 "/tmp/c" "easy"
+        wt_next_offset
+    '
+    assert_success
+    assert_output "2"
+}
+
+@test "wt_next_offset returns next int: used=[1,2,3] -> 4" {
+    oc_run_state '
+        wt_state_set "b1" 1 "/tmp/a" "easy"
+        wt_state_set "b2" 2 "/tmp/b" "easy"
+        wt_state_set "b3" 3 "/tmp/c" "easy"
+        wt_next_offset
+    '
+    assert_success
+    assert_output "4"
+}
+
+@test "wt_next_offset fills lowest gap when multiple: used=[1,2,4,5] -> 3" {
+    oc_run_state '
+        wt_state_set "b1" 1 "/tmp/a" "easy"
+        wt_state_set "b2" 2 "/tmp/b" "easy"
+        wt_state_set "b4" 4 "/tmp/d" "easy"
+        wt_state_set "b5" 5 "/tmp/e" "easy"
+        wt_next_offset
+    '
+    assert_success
+    assert_output "3"
+}


### PR DESCRIPTION
## Summary
- Adds `tests/bats/openemr-cmd/` with 29 BATS tests covering the host-side `utilities/openemr-cmd/openemr-cmd` CLI: pure helpers (`wt_slug`, `wt_compose_subdir`, `wt_validate_env`), state plumbing (`wt_state_*`, `wt_next_offset`), CLI smoke (`--version`, usage errors, empty-state list), and — most importantly — a **regression test for #762** that fails on pre-fix code with the exact "loop dies mid-iteration" symptom.
- Adds a **standalone workflow file** `.github/workflows/test-bats-openemr-cmd.yml` (not a new job in `test-bats.yml`) with `paths:` scoped narrowly to `utilities/openemr-cmd/**` + `tests/bats/openemr-cmd/**`. Installs bats-core + bats-support + bats-assert using the exact pattern of the three existing per-image BATS jobs.
- No changes to `openemr-cmd` itself.

## Why a separate workflow file?
GitHub Actions `paths:` filters operate at the workflow trigger level, not per-job. Adding `bats-openemr-cmd` as a 4th job inside `test-bats.yml` would mean any change to `utilities/openemr-cmd/**` (a host-CLI concern with no docker-image dependency) would trigger the 3 docker BATS jobs too, and vice versa. A standalone workflow file precisely scopes when each job runs — code-only changes to the host CLI no longer drag the per-image jobs in.

Deliberate trade-off: `test-bats.yml`'s pre-existing `tests/bats/**` filter (broad) is left as-is, so test-only changes under `tests/bats/openemr-cmd/**` still trigger the 3 docker BATS jobs. Narrowing it to per-flavor paths would require pinning every new flavor subdir explicitly (same forgetting-risk problem) and would also break the natural inclusion of shared infrastructure like `tests/bats/helpers.bash`. BATS jobs are short (~10-15s) and "test changes touch all tests" is a defensible posture, so accepting that over-trigger is the cheaper choice.

## Test plan
- [x] `bats tests/bats/openemr-cmd/` → 29/29 pass
- [x] Regression test verified to fail on the pre-#762 script with the original bug symptom (loop truncates at header, exit 1)
- [x] `shellcheck --check-sourced --external-sources tests/bats/openemr-cmd/helpers.bash` → exit 0
- [x] Workflow YAML validates; both BATS workflows trigger correctly per their path filters

## Notes
- `tests/bats/openemr-cmd/helpers.bash` sources only the first N lines of the script (function definitions) for direct-call unit tests. The line number is a constant `OC_SCRIPT_FUNCS_END` with a drift-guard test that fails loudly with a clear message if the script is restructured.
- `tests/bats/test_helper/` (bats-support + bats-assert clones) is untracked, matching the existing per-image convention — CI installs them fresh per run.

Assisted-by: Claude Code