### PR TITLE
feat(openemr-cmd): add worktree prune + graceful remove + list hint

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1352
+OC_SCRIPT_FUNCS_END=1446
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others
@@ -92,4 +92,30 @@ oc_init_repo() {
     : > "${dir}/.placeholder"
     git -C "${dir}" add .placeholder
     git -C "${dir}" commit --quiet -m "init" >/dev/null
+}
+
+# Register a new git worktree on a new branch under <wt-parent>/<dirname>.
+# After this, <wt-parent>/<dirname> exists on disk and
+# 'git -C <repo> worktree list --porcelain' shows it.
+# Useful for setting up "partial" / "valid" fixtures where the worktree
+# is a real registered git worktree but lacks the compose files that
+# `openemr-cmd worktree add` would normally generate.
+#
+# Usage:
+#   oc_add_registered_worktree "${REPO}" "${WT_PARENT}" feature/foo
+# Args:
+#   $1 repo (an OPENEMR_ROOT — must already be oc_init_repo'd)
+#   $2 worktree parent directory (where the worktree subdir lands)
+#   $3 branch name to create (passed verbatim to `git worktree add -b`)
+oc_add_registered_worktree() {
+    local repo=$1 wt_parent=$2 branch=$3
+    # Slugify branch for the dirname so 'feature/foo' becomes 'feature-foo'
+    # (the script's wt_slug rule). This is just for the on-disk path; the
+    # branch name registered with git stays as-is.
+    local slug
+    # shellcheck disable=SC2312
+    slug=$(echo "${branch}" | tr '/' '-' | tr -cd 'a-zA-Z0-9_-' | tr '[:upper:]' '[:lower:]')
+    local wt_dir="${wt_parent}/openemr-wt-${slug}"
+    git -C "${repo}" worktree add --quiet -b "${branch}" "${wt_dir}" >/dev/null
+    echo "${wt_dir}"
 }

--- a/tests/bats/openemr-cmd/list_status.bats
+++ b/tests/bats/openemr-cmd/list_status.bats
@@ -1,0 +1,118 @@
+# BATS: 'openemr-cmd worktree list' status split + two-message footer.
+#
+# Context: PR #766 split the old single "missing" status into three:
+#   missing  — dir gone from disk (prunable)
+#   partial  — dir intact + registered as git worktree, compose files gone
+#              (regen-able — NOT prunable)
+#   invalid  — wt_validate_dir_safe rejects for other reasons (prunable)
+#
+# The list footer now emits up to TWO independent advisories:
+#   - "(N stale state entries ...prune... left intact)"  for missing+invalid
+#   - "(N entries have missing compose files ...regen...)" for partial
+#
+# These tests pin the row status text AND the footer behavior so a future
+# refactor cannot silently re-merge the three statuses or drop the regen
+# advisory.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+
+    TMP_WT_PARENT=$(oc_mktempdir)
+    TMP_OPENEMR_ROOT="${TMP_WT_PARENT}/repo"
+    mkdir -p "${TMP_OPENEMR_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_OPENEMR_ROOT}/.worktrees.json"
+
+    oc_init_repo "${TMP_OPENEMR_ROOT}"
+}
+
+teardown() {
+    [[ -n "${TMP_WT_PARENT:-}" ]] && rm -rf "${TMP_WT_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]]      && rm -rf "${STUB_DIR}"
+}
+
+oc_run_list() {
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree list
+}
+
+# --- partial: regen footer, NOT prune footer --------------------------------
+
+@test "list partial entry: row shows 'partial', emits regen footer only (no prune footer)" {
+    # A 'partial' fixture: dir exists, is a registered git worktree, but
+    # the docker/development-easy/.env and docker-compose.override.yml
+    # files are absent.
+    local wt_dir
+    wt_dir=$(oc_add_registered_worktree "${TMP_OPENEMR_ROOT}" "${TMP_WT_PARENT}" "feature/partial")
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/partial": {"offset": 1, "dir": "${wt_dir}", "env": "easy"}
+}
+JSON
+
+    oc_run_list
+    assert_success
+    # Row's STATUS column should be 'partial'.
+    echo "$output" | grep -E '^feature/partial[[:space:]]+easy[[:space:]]+1[[:space:]]+partial[[:space:]]' \
+        || fail "expected 'feature/partial easy 1 partial' row not found in output"
+    # Regen footer present.
+    assert_output --partial 'entries have missing compose files'
+    assert_output --partial 'openemr-cmd worktree regen'
+    # Prune footer must NOT be present — partial entries are not prunable.
+    refute_output --partial 'stale state entries'
+}
+
+# --- missing: prune footer (with 'left intact' note), NOT regen footer ------
+
+@test "list missing entry: row shows 'missing', emits prune footer with 'left intact' note" {
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/missing": {"offset": 1, "dir": "${TMP_WT_PARENT}/gone", "env": "easy"}
+}
+JSON
+
+    oc_run_list
+    assert_success
+    echo "$output" | grep -E '^feature/missing[[:space:]]+easy[[:space:]]+1[[:space:]]+missing[[:space:]]' \
+        || fail "expected 'feature/missing easy 1 missing' row not found in output"
+    # Prune footer text + the explicit 'directories on disk are left intact'
+    # note that distinguishes prune-state from a destructive 'rm'.
+    assert_output --partial 'stale state entries'
+    assert_output --partial 'directories on disk are left intact'
+    # Regen footer must NOT appear: no partial entries here.
+    refute_output --partial 'missing compose files'
+}
+
+# --- both: both footers, each with count 1 ----------------------------------
+
+@test "list one missing + one partial: BOTH footers, each with count 1" {
+    local wt_partial
+    wt_partial=$(oc_add_registered_worktree "${TMP_OPENEMR_ROOT}" "${TMP_WT_PARENT}" "feature/partial")
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/missing": {"offset": 1, "dir": "${TMP_WT_PARENT}/gone", "env": "easy"},
+  "feature/partial": {"offset": 2, "dir": "${wt_partial}",         "env": "easy"}
+}
+JSON
+
+    oc_run_list
+    assert_success
+    # Both rows present with the right status.
+    echo "$output" | grep -E '^feature/missing[[:space:]]+easy[[:space:]]+1[[:space:]]+missing[[:space:]]' \
+        || fail "expected 'feature/missing ... missing' row not found"
+    echo "$output" | grep -E '^feature/partial[[:space:]]+easy[[:space:]]+2[[:space:]]+partial[[:space:]]' \
+        || fail "expected 'feature/partial ... partial' row not found"
+    # Prune footer present with count 1.
+    assert_output --partial '(1 stale state entries'
+    # Regen footer present with count 1.
+    assert_output --partial '(1 entries have missing compose files'
+}

--- a/tests/bats/openemr-cmd/prune.bats
+++ b/tests/bats/openemr-cmd/prune.bats
@@ -1,0 +1,183 @@
+# BATS: 'openemr-cmd worktree prune' — state-entry hygiene for stale rows.
+#
+# Contract covered:
+#   - empty state (file missing OR '{}') prints '(no stale entries)' and exits 0
+#   - a state entry whose dir is gone from disk is pruned
+#   - a 'partial' entry (dir intact + registered as git worktree, but compose
+#     files missing) is NOT pruned — it is regen-able, not prunable. This is
+#     the key correctness contract of the missing/partial split.
+#   - --dry-run announces would-be prunes without mutating the state file
+#   - mixed populations prune ONLY the stale row, leaving partial + valid
+#     entries intact
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+
+    # Per-test scratch parent — avoids cross-test races on fixed-name
+    # subdirs under a shared /tmp parent (see PR #765 fix to the
+    # regression file).
+    TMP_WT_PARENT=$(oc_mktempdir)
+    TMP_OPENEMR_ROOT="${TMP_WT_PARENT}/repo"
+    mkdir -p "${TMP_OPENEMR_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_OPENEMR_ROOT}/.worktrees.json"
+
+    # OPENEMR_ROOT must be a real git repo: cmd_worktree_prune calls
+    # 'git -C "${OPENEMR_ROOT}" worktree list --porcelain' via
+    # wt_validate_dir_safe.
+    oc_init_repo "${TMP_OPENEMR_ROOT}"
+}
+
+teardown() {
+    [[ -n "${TMP_WT_PARENT:-}" ]] && rm -rf "${TMP_WT_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]]      && rm -rf "${STUB_DIR}"
+}
+
+# Convenience runner — fills in all env vars the script needs.
+oc_run_prune() {
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree prune "$@"
+}
+
+# --- empty cases -------------------------------------------------------------
+
+@test "prune with no .worktrees.json present prints '(no stale entries)' and exits 0" {
+    # wt_init_state will create an empty {} file, then the empty branch fires.
+    rm -f "${STATE_FILE}"
+    oc_run_prune
+    assert_success
+    assert_output --partial "(no stale entries)"
+}
+
+@test "prune with empty state object '{}' prints '(no stale entries)' and exits 0" {
+    echo '{}' > "${STATE_FILE}"
+    oc_run_prune
+    assert_success
+    assert_output --partial "(no stale entries)"
+}
+
+# --- single stale entry ------------------------------------------------------
+
+@test "prune removes a single stale entry (dir missing on disk)" {
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/stale": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist", "env": "easy"}
+}
+JSON
+    oc_run_prune
+    assert_success
+    assert_output --partial "Pruned stale entry: 'feature/stale'"
+    assert_output --partial "Pruned 1 stale worktree entries."
+    # The entry must actually be gone from the state file.
+    run jq -r 'has("feature/stale")' "${STATE_FILE}"
+    assert_success
+    assert_output "false"
+}
+
+# --- the key correctness test -----------------------------------------------
+
+@test "prune does NOT remove a partial entry (dir intact + registered, compose files missing)" {
+    # Register a real git worktree under WORKTREE_PARENT. This makes
+    # wt_validate_dir_safe pass: the dir exists, is inside WORKTREE_PARENT,
+    # and shows up in `git worktree list --porcelain`. We deliberately do
+    # NOT create the docker/development-easy/* compose files — that is
+    # the 'partial' state.
+    local wt_dir
+    wt_dir=$(oc_add_registered_worktree "${TMP_OPENEMR_ROOT}" "${TMP_WT_PARENT}" "feature/partial")
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/partial": {"offset": 1, "dir": "${wt_dir}", "env": "easy"}
+}
+JSON
+    # Snapshot the state file before invocation so we can assert it is
+    # byte-identical afterwards.
+    local before
+    before=$(cat "${STATE_FILE}")
+
+    oc_run_prune
+    assert_success
+    assert_output --partial "(no stale entries)"
+
+    # State file unchanged.
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] \
+        || fail "state file mutated by prune of a partial entry"
+    # The entry must still be present.
+    run jq -r 'has("feature/partial")' "${STATE_FILE}"
+    assert_success
+    assert_output "true"
+}
+
+# --- --dry-run --------------------------------------------------------------
+
+@test "prune --dry-run announces would-be prunes without mutating state" {
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/stale": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist", "env": "easy"}
+}
+JSON
+    local before
+    before=$(cat "${STATE_FILE}")
+
+    oc_run_prune --dry-run
+    assert_success
+    assert_output --partial "Would prune stale entry:"
+    assert_output --partial "Would prune 1 stale worktree entries."
+
+    # State file unchanged.
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] \
+        || fail "state file mutated by --dry-run prune"
+    run jq -r 'has("feature/stale")' "${STATE_FILE}"
+    assert_success
+    assert_output "true"
+}
+
+# --- mixed populations ------------------------------------------------------
+
+@test "prune mixed: one stale + one partial + one valid → only the stale entry removed" {
+    # Two registered worktrees: one we leave bare (partial), one we'll
+    # fully populate with compose files (valid). Plus one entry pointing
+    # at a nonexistent dir (stale).
+    local wt_partial wt_valid
+    wt_partial=$(oc_add_registered_worktree "${TMP_OPENEMR_ROOT}" "${TMP_WT_PARENT}" "feature/partial")
+    wt_valid=$(oc_add_registered_worktree   "${TMP_OPENEMR_ROOT}" "${TMP_WT_PARENT}" "feature/valid")
+    # Populate the valid one's compose files so list would show status
+    # other than 'partial'. prune doesn't actually care about these files
+    # (only wt_validate_dir_safe), but populating them keeps the fixture
+    # honest about what 'valid' means.
+    mkdir -p "${wt_valid}/docker/development-easy"
+    : > "${wt_valid}/docker/development-easy/.env"
+    : > "${wt_valid}/docker/development-easy/docker-compose.override.yml"
+
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/stale":   {"offset": 1, "dir": "${TMP_WT_PARENT}/gone",   "env": "easy"},
+  "feature/partial": {"offset": 2, "dir": "${wt_partial}",           "env": "easy"},
+  "feature/valid":   {"offset": 3, "dir": "${wt_valid}",             "env": "easy"}
+}
+JSON
+
+    oc_run_prune
+    assert_success
+    assert_output --partial "Pruned stale entry: 'feature/stale'"
+    assert_output --partial "Pruned 1 stale worktree entries."
+
+    # Only the stale entry should be gone.
+    run jq -r 'has("feature/stale")' "${STATE_FILE}"
+    assert_success
+    assert_output "false"
+    run jq -r 'has("feature/partial")' "${STATE_FILE}"
+    assert_success
+    assert_output "true"
+    run jq -r 'has("feature/valid")' "${STATE_FILE}"
+    assert_success
+    assert_output "true"
+}

--- a/tests/bats/openemr-cmd/remove_graceful.bats
+++ b/tests/bats/openemr-cmd/remove_graceful.bats
@@ -1,0 +1,67 @@
+# BATS: 'openemr-cmd worktree remove <branch>' graceful path when the
+# worktree dir is already gone from disk.
+#
+# Contract (added in PR #766): when the on-disk dir is missing, skip the
+# 'Continue? [y/N]' prompt and the destructive teardown steps; just clean
+# up the state entry and emit a hint about leftover docker resources.
+# Exit 0.
+#
+# Rationale: dirs frequently disappear out-of-band (manual rm -rf, IDE
+# clean, etc.); failing fast or prompting for confirmation in that case
+# blocks the user from clearing state without giving them a useful option.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    command -v jq >/dev/null 2>&1 || skip "jq not installed"
+
+    TMP_WT_PARENT=$(oc_mktempdir)
+    TMP_OPENEMR_ROOT="${TMP_WT_PARENT}/repo"
+    mkdir -p "${TMP_OPENEMR_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_OPENEMR_ROOT}/.worktrees.json"
+
+    oc_init_repo "${TMP_OPENEMR_ROOT}"
+}
+
+teardown() {
+    [[ -n "${TMP_WT_PARENT:-}" ]] && rm -rf "${TMP_WT_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]]      && rm -rf "${STUB_DIR}"
+}
+
+@test "remove <branch> when dir is gone: no prompt, exit 0, prints docker-cleanup hint, state entry removed" {
+    # State entry whose dir is intentionally not created on disk.
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/gone": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist", "env": "easy"}
+}
+JSON
+
+    # No stdin redirection: the graceful path skips `read -rp` entirely.
+    # If it ever regressed and prompted again, this run would block
+    # forever (BATS would kill it on timeout). The fast pass IS the
+    # "no prompt" assertion.
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        "$SCRIPT" worktree remove feature/gone
+    assert_success
+
+    # The graceful-path 'wt_info' messages must be present.
+    assert_output --partial "Worktree dir was already gone"
+    # Docker-cleanup hint uses the slugified branch name. wt_slug
+    # turns 'feature/gone' into 'feature-gone'.
+    assert_output --partial "docker compose -p openemr-feature-gone down -v"
+    # And we must NOT have seen the destructive-path prompt.
+    refute_output --partial "Continue? [y/N]"
+
+    # State entry actually removed.
+    run jq -r 'has("feature/gone")' "${STATE_FILE}"
+    assert_success
+    assert_output "false"
+}

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.35"
+VERSION="1.0.36"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -548,6 +548,18 @@ cmd_worktree_remove() {
     dir=$(wt_state_get "${branch}" dir)
     if [[ -z "${dir}" ]]; then wt_die "No worktree found for branch '${branch}'"; fi
 
+    # If the dir is already gone (deleted out-of-band), skip the destructive
+    # steps and just clean up the state entry. Only the "missing" case is
+    # graceful here — for dirs that exist but fail validation (outside parent,
+    # not a registered worktree, etc.) keep the existing fatal behavior, since
+    # that might be in-progress user work we should not silently abandon.
+    if [[ ! -e "${dir}" ]]; then
+        wt_state_remove "${branch}"
+        git -C "${OPENEMR_ROOT}" worktree prune 2>/dev/null || true
+        wt_info "Worktree dir was already gone; cleaned up state entry for '${branch}'."
+        return 0
+    fi
+
     echo "This will remove worktree '${branch}' at ${dir}."
     if ! ${purge}; then echo "  --keep-volumes: Docker volumes will be preserved."; fi
     read -rp "Continue? [y/N] " confirm
@@ -632,6 +644,7 @@ cmd_worktree_list() {
     fi
 
     check_docker_compose_install
+    local stale_count=0
     jq_output=$(jq -r 'to_entries[] | [.key, (.value.offset|tostring), .value.dir, .value.env] | @tsv' "${WT_STATE_FILE}")
     while IFS=$'\t' read -r branch offset dir env; do
         status="none"
@@ -646,8 +659,10 @@ cmd_worktree_list() {
            [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
            [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
             status="missing"
+            stale_count=$((stale_count + 1))
         elif [[ "${validate_result}" -ne 0 ]]; then
             status="invalid"
+            stale_count=$((stale_count + 1))
         else
             ps_running=$("${DOCKER_COMPOSE_CMD[@]}" \
                 --env-file "${dir}/${compose_subdir}/.env" \
@@ -671,6 +686,10 @@ cmd_worktree_list() {
         fi
         printf "%-30s %-12s %-8s %-10s %s\n" "${branch}" "${env}" "${offset}" "${status}" "${dir}"
     done <<< "${jq_output}"
+
+    if [[ "${stale_count}" -gt 0 ]]; then
+        echo "(${stale_count} stale entries detected — run \"openemr-cmd worktree prune\" to clean up)"
+    fi
 }
 
 cmd_worktree_regen() {
@@ -818,6 +837,56 @@ cmd_worktree_set_env() {
     echo "Run 'openemr-cmd worktree up ${branch}' to start with the new env."
 }
 
+cmd_worktree_prune() {
+    local dry_run=false
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --dry-run) dry_run=true; shift ;;
+            -*) wt_die "Unknown option: $1" ;;
+            *)  wt_die "Unexpected argument: $1" ;;
+        esac
+    done
+
+    wt_require_cmd jq
+    wt_init_state
+
+    local state_content
+    state_content=$(cat "${WT_STATE_FILE}")
+    if [[ "${state_content}" == "{}" ]]; then
+        echo "(no stale entries)"
+        return 0
+    fi
+
+    local jq_output pruned=0 validate_result
+    jq_output=$(jq -r 'to_entries[] | [.key, .value.dir] | @tsv' "${WT_STATE_FILE}")
+    while IFS=$'\t' read -r branch dir; do
+        [[ -z "${branch}" ]] && continue
+        # set +e around wt_validate_dir_safe so a non-zero return (the
+        # whole point of the "safe" variant) does not abort under set -e.
+        set +e
+        wt_validate_dir_safe "${dir}"
+        validate_result=$?
+        set -e
+        if [[ "${validate_result}" -ne 0 ]]; then
+            if ${dry_run}; then
+                wt_info "Would prune stale entry: '${branch}' (${dir})"
+            else
+                wt_state_remove "${branch}"
+                wt_info "Pruned stale entry: '${branch}' (${dir})"
+            fi
+            pruned=$((pruned + 1))
+        fi
+    done <<< "${jq_output}"
+
+    if [[ "${pruned}" -eq 0 ]]; then
+        echo "(no stale entries)"
+    elif ${dry_run}; then
+        echo "Would prune ${pruned} stale worktree entries."
+    else
+        echo "Pruned ${pruned} stale worktree entries."
+    fi
+}
+
 cmd_worktree() {
     local action=${1:-}
     case "${action}" in
@@ -831,8 +900,9 @@ cmd_worktree() {
         list)    cmd_worktree_list             ;;
         regen)   cmd_worktree_regen   "${@:2}" ;;
         set-env) cmd_worktree_set_env "${@:2}" ;;
+        prune)   cmd_worktree_prune   "${@:2}" ;;
         *)
-            echo "Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen|set-env> [options]"
+            echo "Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen|set-env|prune> [options]"
             echo ""
             echo "  add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]"
             echo "                            Create worktree (-b creates new branch, default env: easy)"
@@ -845,6 +915,7 @@ cmd_worktree() {
             echo "  exec <branch> <cmd> [args...]   Run an openemr-cmd command against the worktree's openemr container"
             echo "  list                      List all worktrees and status"
             echo "  regen <branch>            Regenerate override/env files"
+            echo "  prune [--dry-run]         Remove state entries whose worktree dir is gone or invalid"
             echo "  wt                        Alias for worktree"
             exit 1
             ;;
@@ -1405,6 +1476,7 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo "  worktree exec <branch> <cmd> [args...]   Run an openemr-cmd command against the worktree's openemr container"
     echo "  worktree list                      List all worktrees and their running status"
     echo "  worktree regen <branch>            Regenerate override/env files for a worktree"
+    echo "  worktree prune [--dry-run]         Remove state entries whose worktree dir is gone or invalid"
     echo "  wt                                 Alias for worktree"
     echo 'docker-management:'
     echo "  up                                 Execute: docker-compose up -d"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -554,9 +554,13 @@ cmd_worktree_remove() {
     # not a registered worktree, etc.) keep the existing fatal behavior, since
     # that might be in-progress user work we should not silently abandon.
     if [[ ! -e "${dir}" ]]; then
+        local slug
+        slug=$(wt_slug "${branch}")
         wt_state_remove "${branch}"
         git -C "${OPENEMR_ROOT}" worktree prune 2>/dev/null || true
         wt_info "Worktree dir was already gone; cleaned up state entry for '${branch}'."
+        wt_info "Note: docker resources (containers, volumes) for this stack may still exist."
+        wt_info "  Clean them manually: docker compose -p openemr-${slug} down -v"
         return 0
     fi
 
@@ -847,7 +851,7 @@ cmd_worktree_prune() {
         esac
     done
 
-    wt_require_cmd jq
+    wt_require_cmd jq git realpath
     wt_init_state
 
     local state_content
@@ -877,6 +881,14 @@ cmd_worktree_prune() {
             pruned=$((pruned + 1))
         fi
     done <<< "${jq_output}"
+
+    # Keep git's internal worktree admin in sync with what we just removed from
+    # state. Without this, 'git worktree list --porcelain' may still report the
+    # removed worktrees as prunable, which can block a later 'worktree add' of
+    # the same branch.
+    if ! ${dry_run} && [[ "${pruned}" -gt 0 ]]; then
+        git -C "${OPENEMR_ROOT}" worktree prune 2>/dev/null || true
+    fi
 
     if [[ "${pruned}" -eq 0 ]]; then
         echo "(no stale entries)"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.36"
+VERSION="1.0.37"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -648,7 +648,7 @@ cmd_worktree_list() {
     fi
 
     check_docker_compose_install
-    local stale_count=0
+    local stale_count=0 partial_count=0
     jq_output=$(jq -r 'to_entries[] | [.key, (.value.offset|tostring), .value.dir, .value.env] | @tsv' "${WT_STATE_FILE}")
     while IFS=$'\t' read -r branch offset dir env; do
         status="none"
@@ -659,11 +659,19 @@ cmd_worktree_list() {
         wt_validate_dir_safe "${dir}"
         validate_result=$?
         set -e
-        if [[ ! -d "${dir}" ]] || \
-           [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
-           [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
+        # Split between "dir gone" (prunable), "compose files gone but dir
+        # intact" (regen-able), and "validate failed" (prunable). Earlier
+        # versions lumped all three under "missing" and suggested prune for
+        # all of them, but prune only removes state entries that
+        # wt_validate_dir_safe rejects — the compose-files-missing case
+        # validates fine and stays put after prune.
+        if [[ ! -d "${dir}" ]]; then
             status="missing"
             stale_count=$((stale_count + 1))
+        elif [[ ! -f "${dir}/${compose_subdir}/.env" ]] || \
+             [[ ! -f "${dir}/${compose_subdir}/docker-compose.override.yml" ]]; then
+            status="partial"
+            partial_count=$((partial_count + 1))
         elif [[ "${validate_result}" -ne 0 ]]; then
             status="invalid"
             stale_count=$((stale_count + 1))
@@ -692,7 +700,10 @@ cmd_worktree_list() {
     done <<< "${jq_output}"
 
     if [[ "${stale_count}" -gt 0 ]]; then
-        echo "(${stale_count} stale entries detected — run \"openemr-cmd worktree prune\" to clean up)"
+        echo "(${stale_count} stale state entries — run \"openemr-cmd worktree prune\" to clean up; directories on disk are left intact)"
+    fi
+    if [[ "${partial_count}" -gt 0 ]]; then
+        echo "(${partial_count} entries have missing compose files — run \"openemr-cmd worktree regen <branch>\" to regenerate)"
     fi
 }
 


### PR DESCRIPTION
## Summary
Three coupled UX improvements so users never need to hand-edit `.worktrees.json` to recover from a worktree directory deleted out-of-band (which the docs explicitly discourage).

- **`worktree prune [--dry-run]`** — new subcommand. Walks state, removes entries that fail `wt_validate_dir_safe` (missing dir, outside parent, no longer a registered git worktree). Reports each entry pruned and a summary count.
- **`worktree remove`** — graceful path when the dir is already gone. Previously errored before the state-removal step; now skips the destructive `git worktree remove` / `docker compose down` steps (nothing to remove) and just cleans the state entry. The "dir exists but suspect" case is intentionally still fatal — that may be in-progress user work.
- **`worktree list`** — when one or more entries print as `missing`/`invalid`, append a one-line footer suggesting `worktree prune`. No mutation in `list` itself; nudge, don't auto-clean.

Bumps `VERSION` to `1.0.36`.

## Test plan
- [x] `shellcheck --check-sourced --external-sources utilities/openemr-cmd/openemr-cmd` → exit 0
- [x] Seeded a stale entry into a fixture state file; verified:
  - `worktree list` shows status `missing` + footer
  - `worktree prune --dry-run` previews without mutating
  - `worktree prune` removes the entry and prints `Pruned 1 stale worktree entries.`
  - `worktree list` post-prune: entry gone, no footer
  - `worktree prune` repeat: `(no stale entries)`
  - `worktree remove <stale-branch>` cleans state without prompting / shelling out to docker

## Notes
- Designed to pair naturally with #TBD (BATS test infrastructure for `openemr-cmd`). If that lands first, follow-up tests for the new commands will plug into the same `tests/bats/openemr-cmd/` directory.

Assisted-by: Claude Code