### PR TITLE
fix(release): provide build.xml to the staged-tree phing prune

### DIFF
--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -120,9 +120,17 @@ final readonly class PackageAssembler
             null,
             $composerEnv,
         );
+        // build.xml is export-ignore'd in openemr's .gitattributes, so git
+        // archive strips it from the staged tree. Its prune targets resolve
+        // ${project.basedir}/vendor and .../public/assets against the staged
+        // tree (phing runs there), so copy the buildfile in for the prune run
+        // and remove it afterward — it must not ship in the distribution.
+        $buildXml = "{$stageDir}/build.xml";
+        copy("{$this->openemrDir}/build.xml", $buildXml);
         $phing = "{$composerHome}/vendor/bin/phing";
         $this->run([$phing, 'vendor-clean'], $stageDir);
         $this->run([$phing, 'assets-clean'], $stageDir);
+        unlink($buildXml);
         $this->run(['rm', '-rf', $composerHome]);
 
         // Drop node_modules and regenerate the optimized production autoloader.

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -136,7 +136,7 @@ final readonly class PackageAssembler
         // Fail hard if the staged copy can't be removed: otherwise it would ship
         // in the archives below, defeating the export-ignore intent.
         if (!unlink($buildXml)) {
-            $this->output->writeln("<error>Failed to remove staged build.xml; refusing to ship it: {$buildXml}</error>");
+            $this->output->writeln("<error>Failed to remove staged build.xml; refusing to ship: {$buildXml}</error>");
             return 1;
         }
         $this->run(['rm', '-rf', $composerHome]);

--- a/tools/release/src/PackageAssembler.php
+++ b/tools/release/src/PackageAssembler.php
@@ -126,11 +126,19 @@ final readonly class PackageAssembler
         // tree (phing runs there), so copy the buildfile in for the prune run
         // and remove it afterward — it must not ship in the distribution.
         $buildXml = "{$stageDir}/build.xml";
-        copy("{$this->openemrDir}/build.xml", $buildXml);
+        if (!copy("{$this->openemrDir}/build.xml", $buildXml)) {
+            $this->output->writeln("<error>Failed to stage build.xml for prune: {$buildXml}</error>");
+            return 1;
+        }
         $phing = "{$composerHome}/vendor/bin/phing";
         $this->run([$phing, 'vendor-clean'], $stageDir);
         $this->run([$phing, 'assets-clean'], $stageDir);
-        unlink($buildXml);
+        // Fail hard if the staged copy can't be removed: otherwise it would ship
+        // in the archives below, defeating the export-ignore intent.
+        if (!unlink($buildXml)) {
+            $this->output->writeln("<error>Failed to remove staged build.xml; refusing to ship it: {$buildXml}</error>");
+            return 1;
+        }
         $this->run(['rm', '-rf', $composerHome]);
 
         // Drop node_modules and regenerate the optimized production autoloader.


### PR DESCRIPTION
## Summary

Follow-up to #771. With the output-dir bug fixed, the release package build now runs through `git archive` → `composer install` → `npm ci` → `npm run build`, then fails at the phing prune step:

```
$ .../openemr-8.1.0-composer-home/vendor/bin/phing vendor-clean
Buildfile: build.xml does not exist!
```

`PackageAssembler` runs openemr's `build.xml` prune targets (`vendor-clean`/`assets-clean`) from the **staged tree**, but `build.xml` is `export-ignore`d in openemr's `.gitattributes`, so `git archive` strips it from that tree. The targets resolve `${project.basedir}/vendor` and `.../public/assets` against the staged tree (phing's cwd), so the buildfile must be present there.

## Fix

Copy `build.xml` from the openemr checkout into the staged tree for the prune run, then `unlink` it afterward so it never ships in the distribution (matching the export-ignore intent).

## Test plan

- [x] `composer test` — all 175 tests pass
- [ ] `build-release.yml` dry-run reaches "Generate checksums" / "Upload artifacts (dry run)" (the real integration gate; previously blocked at this step)