### PR TITLE
ci(deps): migrate dependabot-auto-merge to client-id / vars

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AUTO_MERGE_APP_ID }}
+          client-id: ${{ vars.AUTO_MERGE_APP_CLIENT_ID }}
           private-key: ${{ secrets.AUTO_MERGE_APP_PRIVATE_KEY }}
 
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Summary

- `actions/create-github-app-token@v3.1.0` (2026-04-11) deprecated the `app-id` input in favor of `client-id`. The `dependabot-auto-merge.yml` workflow emits a `Input 'app-id' has been deprecated` warning on every Dependabot PR run.
- Switch to the Client ID identifier (string of the form `Iv23li...`) and store it as a **repo variable** instead of a secret. The Client ID is a public value visible on the App's settings page and present in plain text in JWT headers — it isn't sensitive. Only the private key needs to stay a secret.
- This aligns with the convention already in use by `release-permissions-check.yml` in this repo, which stores its App identifier in `vars.RELEASE_APP_CLIENT_ID`.

A companion PR (openemr/openemr#12372) applies the identical edit to that repo's auto-merge workflow.

## One-time setup required before merge

This PR is **inert until the new repo variable is configured**. The workflow currently uses `secrets.AUTO_MERGE_APP_ID`; after merge it expects `vars.AUTO_MERGE_APP_CLIENT_ID`. If the variable is missing, the next eligible Dependabot PR will fail at the token-mint step with `actions/create-github-app-token` reporting empty inputs.

Maintainer steps:

1. On the auto-merge GitHub App's settings page (`Org → Developer settings → GitHub Apps → <app-name> → General`), copy the **Client ID** (visible directly under the App ID).
2. Add a repo **variable** at `openemr/openemr-devops → Settings → Secrets and variables → Actions → Variables tab → New repository variable`:
   - Name: `AUTO_MERGE_APP_CLIENT_ID`
   - Value: the Client ID string
3. Merge this PR (and the openemr companion openemr/openemr#12372).
4. Optionally delete the now-unused `AUTO_MERGE_APP_ID` secret. (The `AUTO_MERGE_APP_PRIVATE_KEY` secret stays — still required for App auth.)

## Test plan

- [ ] Maintainer adds `AUTO_MERGE_APP_CLIENT_ID` repo variable per steps above
- [ ] Merge this PR
- [ ] Wait for next Dependabot PR matching the Kubernetes Docker auto-merge criteria (or trigger one by re-running an existing eligible Dependabot run)
- [ ] Verify the `Input 'app-id' has been deprecated` warning no longer appears in the workflow log
- [ ] Verify Dependabot PR is still auto-merged as expected
- [ ] Optionally delete `AUTO_MERGE_APP_ID` secret