### PR TITLE
fix(release): fetch target branch before changelog PR checkout

### DIFF
--- a/tools/release/bin/changelog-pr.php
+++ b/tools/release/bin/changelog-pr.php
@@ -78,6 +78,16 @@ use Symfony\Component\Process\Process;
                 continue;
             }
 
+            // Fetch the target branch's ref. The release build checks out only
+            // the release branch (fetch-depth: 1), so sibling targets like
+            // master have no origin/<branch> ref yet. Use an explicit refspec
+            // so origin/<branch> is created regardless of the checkout's
+            // configured fetch refspec.
+            (new Process(
+                ['git', 'fetch', '--depth=1', 'origin', "{$branch}:refs/remotes/origin/{$branch}"],
+                $openemrDir,
+            ))->mustRun();
+
             // Create branch from target
             (new Process(['git', 'checkout', '-b', $prBranch, "origin/{$branch}"], $openemrDir))->mustRun();
 


### PR DESCRIPTION
## Summary

Follow-up to #771 / #772. With the package build fixed, the real `build-release.yml` run created the `v8_1_0` Release object successfully, then the "Create CHANGELOG PRs" step half-failed:

- Created `changelog-8.1.0-rel-810 → rel-810` (openemr/openemr#12352)
- Failed on master: `git checkout -b changelog-8.1.0-master origin/master` → `fatal: 'origin/master' is not a commit and a branch 'changelog-8.1.0-master' cannot be created from it`

**Root cause:** the workflow checks out the openemr **release branch** with `fetch-depth: 1` (`build-release.yml` "Checkout openemr release branch"), so `origin/master` is never fetched into that checkout. The rel-810 PR worked because it's the checked-out branch; master had no ref.

## Fix

Fetch the target branch's ref before `git checkout -b`. Uses an explicit refspec (`<branch>:refs/remotes/origin/<branch>`) so `origin/<branch>` is created regardless of the checkout's configured fetch refspec.

After this lands, re-running `build-release.yml` is idempotent (tag/release skip-if-exists, `--clobber` upload, and changelog-pr already skips branches whose PR exists), so it will skip the rel-810 PR and create only the missing master CHANGELOG PR.

## Test plan

- [x] `composer test` — 175 tests pass
- [x] `composer phpcs` — clean
- [ ] Re-run `build-release.yml` (dry_run=false) creates the master CHANGELOG PR and skips already-done steps