### PR TITLE
ci: run InstallerAuto.php as apache, not root

### DIFF
--- a/.github/actions/test-actions-core/action.yml
+++ b/.github/actions/test-actions-core/action.yml
@@ -76,7 +76,13 @@ runs:
 
     - name: Install
       run: |
+        # Run as apache, not root: openemr/openemr#12267 added RootCliGuard,
+        # which aborts the installer when it runs as root (UID 0). apache owns
+        # the baked source in every slot's Dockerfile, so it can write sqlconf.php
+        # and generated keys. --user is portable across all slots (unlike su-exec,
+        # which #743 only added to flex/8.1.1/binary).
         docker compose exec \
+          --user apache \
           --env OPENEMR_ENABLE_INSTALLER_AUTO=1 \
           --workdir /var/www/localhost/htdocs/openemr/contrib/util/installScripts \
           "${OPENEMR_SERVICE_NAME}" sh -c 'sed -e "s@^exit;@ @" InstallerAuto.php |


### PR DESCRIPTION
## What

Add `--user apache` to the **Install** step in `test-actions-core/action.yml` so `InstallerAuto.php` runs as the `apache` user instead of root.

## Why

[openemr/openemr#12267](https://github.com/openemr/openemr/pull/12267) added `RootCliGuard`, which aborts the installer when it runs as a root CLI (UID 0). The CI harness runs `InstallerAuto.php` via `docker compose exec`, which defaults to root in every slot, so every install-driven test slot now fails the guard.

## Approach

The Install step is **shared across all slots** (7.0.4, 8.0.0, 8.1.0, 8.1.1, binary, flex). `--user apache` is portable: the `apache` user (uid 1000) and an apache-owned `openemr/` tree exist in every slot's Dockerfile. `su-exec` was **not** an option — #743 only added it to flex/8.1.1/binary, so hardcoding it would break 7.0.4/8.0.0/8.1.0 with "su-exec: not found".

phpunit steps are unaffected: `interface/globals.php` skips the guard under `PHPUNIT_COMPOSER_INSTALL`, so those bootstraps stay exempt even as root.

## Validation

- **8.1.1 (production path)** validated locally: patched install on a fresh DB exits 0 with no `RootCliGuard`/`RuntimeException`, writes `sqlconf.php` as `apache:apache` with `$config = 1`, web returns HTTP 302; `phpunit --testsuite unit` → 275 tests pass.
- flex **prod** mode is structurally identical (baked, apache-owned) → covered by the 8.1.1 result.
- flex **dev** mode relies on the already-merged #743 entrypoint, which (running as root) chowns the mounted source to apache before the `--user apache` exec — exercised by CI here.

Unblocks #777, which only needs a rebase once this lands.

Assisted-by: Claude Code