### PR TITLE
fix(openemr-cmd): avoid SIGPIPE in worktree validation under pipefail

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1460
+OC_SCRIPT_FUNCS_END=1466
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1466
+OC_SCRIPT_FUNCS_END=1467
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.39"
+VERSION="1.0.40"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -150,9 +150,14 @@ wt_validate_dir() {
         wt_die "Worktree path '${dir_real}' is not within expected parent '${worktree_parent_real}'"
     fi
 
-    # 3. Ensure it is a registered git worktree of OPENEMR_ROOT
-    if ! git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null \
-            | grep -Fqx "worktree ${dir_real}"; then
+    # 3. Ensure it is a registered git worktree of OPENEMR_ROOT.
+    # Capture the listing first rather than piping into grep: under pipefail,
+    # 'grep -q' exits on first match and SIGPIPEs git mid-write, which git
+    # reports as failure (141) once its output exceeds the pipe buffer (many
+    # worktrees). A herestring avoids the pipe entirely.
+    local worktrees
+    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null)
+    if ! grep -Fqx "worktree ${dir_real}" <<< "${worktrees}"; then
         wt_die "Path '${dir_real}' is not a registered git worktree of '${OPENEMR_ROOT}'"
     fi
 }
@@ -171,7 +176,9 @@ wt_validate_dir_safe() {
         return 1
     fi
 
-    if ! git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null             | grep -Fqx "worktree ${dir_real}"; then
+    local worktrees
+    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null)
+    if ! grep -Fqx "worktree ${dir_real}" <<< "${worktrees}"; then
         return 1
     fi
 }

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -156,7 +156,8 @@ wt_validate_dir() {
     # reports as failure (141) once its output exceeds the pipe buffer (many
     # worktrees). A herestring avoids the pipe entirely.
     local worktrees
-    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null)
+    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null) \
+        || wt_die "Cannot list git worktrees of '${OPENEMR_ROOT}'"
     if ! grep -Fqx "worktree ${dir_real}" <<< "${worktrees}"; then
         wt_die "Path '${dir_real}' is not a registered git worktree of '${OPENEMR_ROOT}'"
     fi
@@ -177,7 +178,7 @@ wt_validate_dir_safe() {
     fi
 
     local worktrees
-    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null)
+    worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null) || return 1
     if ! grep -Fqx "worktree ${dir_real}" <<< "${worktrees}"; then
         return 1
     fi


### PR DESCRIPTION
## Summary

`openemr-cmd worktree list` and `worktree remove` can fail on setups with many git worktrees: `list` shows `(no worktrees)` even when entries exist, and `remove` aborts with `Path '...' is not a registered git worktree`.

## Root cause

`wt_validate_dir` and `wt_validate_dir_safe` validate a path by piping git's worktree listing into `grep`:

```bash
git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null \
    | grep -Fqx "worktree ${dir_real}"
```

The script runs under `set -o pipefail`. `grep -q` exits as soon as it finds a match and closes the read end of the pipe. If git is still writing (its output exceeds the ~64KB pipe buffer, which happens once you have many worktrees), git receives `SIGPIPE` and exits 141. Under `pipefail` the pipeline's exit status becomes that 141, so the `if !` branch fires and a path that *is* a registered worktree gets rejected.

This stays latent on typical setups where git's output fits in the pipe buffer and git finishes writing before `grep` exits — the SIGPIPE never happens.

## Fix

Capture the listing into a variable first, then match with a herestring. No pipe means no SIGPIPE:

```bash
local worktrees
worktrees=$(git -C "${OPENEMR_ROOT}" worktree list --porcelain 2>/dev/null)
if ! grep -Fqx "worktree ${dir_real}" <<< "${worktrees}"; then
    ...
fi
```

## Test plan

- [x] `shellcheck` clean under the repo's `.shellcheckrc` (`enable=all`)
- [x] `bash -n` passes
- [x] Reproduced the failure on a machine with ~150 worktrees: the old pipe form fails under `pipefail` (pipeline exits 141); the herestring form returns 0
- [x] End-to-end on macOS: `worktree list` shows the entry and `worktree remove` completes cleanly (both previously broken)

## Note

Found while verifying #783 (the macOS realpath fix). That fix let execution finally reach this validation code, surfacing this separate, platform-independent bug. The two are independent; this PR stands alone.