### PR TITLE
ci(openemr-cmd): add macOS leg to BATS matrix; fix bash 3.2 compat

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd.yml
+++ b/.github/workflows/test-bats-openemr-cmd.yml
@@ -16,8 +16,12 @@ on:
 
 jobs:
   bats-openemr-cmd:
-    name: BATS openemr-cmd
-    runs-on: ubuntu-22.04
+    name: BATS openemr-cmd (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Install Bats

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1467
+OC_SCRIPT_FUNCS_END=1468
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others
@@ -75,8 +75,10 @@ OC_SCRIPT_FUNCS_END=1467
 oc_source_funcs() {
     local script
     script=$(oc_script_path) || return 1
-    # shellcheck disable=SC1090,SC2312
-    source <(head -n "${OC_SCRIPT_FUNCS_END}" "${script}")
+    # eval, not 'source <(...)': process substitution is broken under macOS
+    # system bash 3.2, where <() fails to define the sourced functions.
+    # shellcheck disable=SC2312
+    eval "$(head -n "${OC_SCRIPT_FUNCS_END}" "${script}")"
 }
 
 # Initialize $1 as a real git repo with one commit, so commands like

--- a/tests/bats/openemr-cmd/helpers_pure.bats
+++ b/tests/bats/openemr-cmd/helpers_pure.bats
@@ -28,8 +28,9 @@ oc_run_in_funcs() {
     local tmp_root=$4
     run env OPENEMR_ROOT="${tmp_root}" bash -c "
         set -euo pipefail
-        # shellcheck disable=SC1090
-        source <(head -n ${funcs_end} '${script_path}')
+        # eval, not 'source <(...)': process substitution is broken under
+        # macOS system bash 3.2, where <() fails to define the functions.
+        eval \"\$(head -n ${funcs_end} '${script_path}')\"
         ${snippet}
     "
 }

--- a/tests/bats/openemr-cmd/state.bats
+++ b/tests/bats/openemr-cmd/state.bats
@@ -28,8 +28,9 @@ oc_run_state() {
         WT_STATE_FILE="${TMP_STATE}" \
         bash -c "
             set -euo pipefail
-            # shellcheck disable=SC1090
-            source <(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')
+            # eval, not 'source <(...)': process substitution is broken under
+            # macOS system bash 3.2, where <() fails to define the functions.
+            eval \"\$(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')\"
             # Re-export WT_STATE_FILE after sourcing: the script's top-level
             # WT_STATE_FILE=... line overrides our env var when sourced.
             WT_STATE_FILE='${TMP_STATE}'

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -1458,7 +1458,8 @@ docker-pull-image(){
     while IFS= read -r SERVICE; do
         [[ -z "${SERVICE}" ]] && continue
         read -r -e -p "Do you wish to pull ${SERVICE} ? [Y/n] " RESP </dev/tty
-        if [[ -z "${RESP}" || "${RESP,,}" = y ]]; then
+        # [Yy] glob keeps this bash 3.2 (system macOS bash) compatible; ${var,,} is bash 4+.
+        if [[ -z "${RESP}" || "${RESP}" = [Yy] ]]; then
             run_docker_compose -f "${COMPOSE_FILE}" pull "${SERVICE}"
         else
             echo "Skipping ${SERVICE}"


### PR DESCRIPTION
## Summary

`openemr-cmd` is a host CLI developers run on their Macs, but its BATS workflow only ran on `ubuntu-22.04`. So macOS-portability bugs reached users with zero CI coverage — most recently the BSD `realpath` failure fixed manually in #783. This adds a `macos-14` leg to the BATS matrix, where the script runs under macOS system **bash 3.2**, the sharpest portability risk.

Adding that leg immediately surfaced two real bash 3.2 incompatibilities, both fixed here:

- **`openemr-cmd`** used `${RESP,,}` (bash 4+ case-modification), which throws `bad substitution` under bash 3.2. Replaced with a `[Yy]` glob match in `[[ ]]`, preserving the `[Y/n]` default-yes semantics. (Verified identical behavior on bash 3.2 and 5.)
- **Test harness** sourced the script via process substitution (`source <(head -n …)`), which silently defines no functions under macOS bash 3.2. Switched the three sites (`helpers.bash`, `helpers_pure.bats`, `state.bats`) to `eval "$(head -n …)"`.

The repo is public, so GitHub-hosted macOS minutes are free. The macOS leg is **advisory** for now (`fail-fast: false`, not branch-protection-required) and can be promoted to required later.

## Test plan

- [x] Full openemr-cmd BATS suite passes **39/39 under system bash 3.2** (macOS-runner equivalent)
- [x] Full suite passes **39/39 under bash 5** (Linux-runner equivalent)
- [x] `${RESP,,}` → `[Yy]` glob verified semantically identical across both shells (empty→pull, y/Y→pull, else→skip)
- [x] Workflow YAML validates; `helpers.bash` and `openemr-cmd` shellcheck-clean
- [ ] CI: confirm both `ubuntu-22.04` and `macos-14` legs go green