### PR TITLE
Add minimum-supported-versions section to release notes

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -255,6 +255,14 @@ jobs:
         VERSION='${{ inputs.version }}'
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 
+    - name: Derive compatibility manifest
+      working-directory: devops-tools
+      run: >-
+        task release:compatibility
+        VERSION='${{ inputs.version }}'
+        VERSION_BRANCH='${{ inputs.version_branch }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
+
     - name: Generate checksums
       working-directory: devops-tools
       run: |
@@ -325,7 +333,8 @@ jobs:
           "${output_dir}"/*.md5 \
           "${output_dir}"/*.sha256 \
           "${output_dir}"/*.sha512 \
-          "${output_dir}/changelog.md"
+          "${output_dir}/changelog.md" \
+          "${output_dir}/compatibility.json"
 
     - name: Build summary
       working-directory: devops-tools
@@ -344,6 +353,7 @@ jobs:
         name: release-${{ inputs.version }}
         path: |
           ${{ env.TOOLS_DIR }}/release-output/changelog.md
+          ${{ env.TOOLS_DIR }}/release-output/compatibility.json
           ${{ env.TOOLS_DIR }}/release-output/*.md5
           ${{ env.TOOLS_DIR }}/release-output/*.sha256
           ${{ env.TOOLS_DIR }}/release-output/*.sha512

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -240,6 +240,16 @@ jobs:
         HEAD_REF='${{ inputs.version_branch }}'
         TITLE='${{ inputs.version }}'
 
+    # Inject the minimum-supported-versions section into the changelog so it
+    # rides along into the release notes (--notes-file below). Runs after the
+    # changelog exists and before the release is created.
+    - name: Add compatibility section to release notes
+      working-directory: devops-tools
+      run: >-
+        task release:compatibility
+        VERSION_BRANCH='${{ inputs.version_branch }}'
+        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
+
     # Build and checksum the package before creating the tag/release. If any
     # build step fails, the job aborts before a release exists — never publish
     # a release that has no distribution assets attached.
@@ -253,14 +263,6 @@ jobs:
       run: >-
         task release:package:assemble
         VERSION='${{ inputs.version }}'
-        OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
-
-    - name: Derive compatibility manifest
-      working-directory: devops-tools
-      run: >-
-        task release:compatibility
-        VERSION='${{ inputs.version }}'
-        VERSION_BRANCH='${{ inputs.version_branch }}'
         OPENEMR_DIR='${{ env.OPENEMR_DIR }}'
 
     - name: Generate checksums
@@ -333,8 +335,7 @@ jobs:
           "${output_dir}"/*.md5 \
           "${output_dir}"/*.sha256 \
           "${output_dir}"/*.sha512 \
-          "${output_dir}/changelog.md" \
-          "${output_dir}/compatibility.json"
+          "${output_dir}/changelog.md"
 
     - name: Build summary
       working-directory: devops-tools
@@ -353,7 +354,6 @@ jobs:
         name: release-${{ inputs.version }}
         path: |
           ${{ env.TOOLS_DIR }}/release-output/changelog.md
-          ${{ env.TOOLS_DIR }}/release-output/compatibility.json
           ${{ env.TOOLS_DIR }}/release-output/*.md5
           ${{ env.TOOLS_DIR }}/release-output/*.sha256
           ${{ env.TOOLS_DIR }}/release-output/*.sha512

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -150,6 +150,20 @@ tasks:
         --openemr-dir={{shellQuote .OPENEMR_DIR}}
         --output-dir={{shellQuote .OUTPUT_DIR}}
 
+  compatibility:
+    desc: Derive the tested-compatibility manifest from the openemr CI matrix
+    requires:
+      vars: [VERSION, VERSION_BRANCH, OPENEMR_DIR]
+    deps: [setup]
+    cmds:
+      - >-
+        php bin/derive-compatibility.php
+        --release-version={{shellQuote .VERSION}}
+        --version-branch={{shellQuote .VERSION_BRANCH}}
+        --openemr-dir={{shellQuote .OPENEMR_DIR}}
+        --repo={{shellQuote .REPO}}
+        --out={{shellQuote .OUTPUT_DIR}}/compatibility.json
+
   release:rotate:
     desc: Apply 3-slot rotation per versions.yml (idempotent)
     deps: [setup]

--- a/tools/release/Taskfile.yml
+++ b/tools/release/Taskfile.yml
@@ -151,18 +151,17 @@ tasks:
         --output-dir={{shellQuote .OUTPUT_DIR}}
 
   compatibility:
-    desc: Derive the tested-compatibility manifest from the openemr CI matrix
+    desc: Inject the minimum-supported-versions section into the release notes
     requires:
-      vars: [VERSION, VERSION_BRANCH, OPENEMR_DIR]
+      vars: [VERSION_BRANCH, OPENEMR_DIR]
     deps: [setup]
     cmds:
       - >-
         php bin/derive-compatibility.php
-        --release-version={{shellQuote .VERSION}}
         --version-branch={{shellQuote .VERSION_BRANCH}}
         --openemr-dir={{shellQuote .OPENEMR_DIR}}
         --repo={{shellQuote .REPO}}
-        --out={{shellQuote .OUTPUT_DIR}}/compatibility.json
+        --notes-file={{shellQuote .OUTPUT_DIR}}/changelog.md
 
   release:rotate:
     desc: Apply 3-slot rotation per versions.yml (idempotent)

--- a/tools/release/bin/derive-compatibility.php
+++ b/tools/release/bin/derive-compatibility.php
@@ -1,0 +1,108 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Emit a per-release tested-compatibility manifest (compatibility.json) derived
+ * from a checked-out openemr/openemr release branch's CI test matrix.
+ *
+ * Thin CLI wrapper around OpenEMR\Release\CompatibilityDeriver; see that class
+ * for the decode rules and rationale (they mirror ci/parse_docker_dir.sh).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+use OpenEMR\Release\CompatibilityDeriver;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\SingleCommandApplication;
+
+(new SingleCommandApplication())
+    ->setName('derive-compatibility')
+    ->setDescription('Derive the tested-compatibility manifest from the openemr CI matrix')
+    ->addOption(
+        'openemr-dir',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Path to the checked-out openemr release branch (defaults to $OPENEMR_DIR)',
+    )
+    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g., 8.1.0)')
+    ->addOption(
+        'version-branch',
+        null,
+        InputOption::VALUE_REQUIRED,
+        'Release branch for the CI matrix link (e.g., rel-810)',
+    )
+    ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'GitHub repo hosting the CI matrix', 'openemr/openemr')
+    ->addOption('out', null, InputOption::VALUE_REQUIRED, 'Output file path', './release-output/compatibility.json')
+    ->setCode(function (InputInterface $input, OutputInterface $output): int {
+        $openemrDirOption = $input->getOption('openemr-dir');
+        $envOpenemrDir = getenv('OPENEMR_DIR');
+        $openemrDir = is_string($openemrDirOption) && $openemrDirOption !== ''
+            ? $openemrDirOption
+            : (is_string($envOpenemrDir) ? $envOpenemrDir : '');
+        if ($openemrDir === '') {
+            $output->writeln('<error>--openemr-dir is required (or set $OPENEMR_DIR)</error>');
+            return 1;
+        }
+
+        $versionOption = $input->getOption('release-version');
+        if (!is_string($versionOption) || $versionOption === '') {
+            $output->writeln('<error>--release-version is required</error>');
+            return 1;
+        }
+
+        $versionBranchOption = $input->getOption('version-branch');
+        if (!is_string($versionBranchOption) || $versionBranchOption === '') {
+            $output->writeln('<error>--version-branch is required</error>');
+            return 1;
+        }
+
+        $repoOption = $input->getOption('repo');
+        $repo = is_string($repoOption) && $repoOption !== '' ? $repoOption : 'openemr/openemr';
+
+        $testedMatrixUrl = sprintf(
+            'https://github.com/%s/tree/%s/ci',
+            $repo,
+            $versionBranchOption,
+        );
+
+        $outOption = $input->getOption('out');
+        $outPath = is_string($outOption) && $outOption !== ''
+            ? $outOption
+            : './release-output/compatibility.json';
+
+        $ciDir = rtrim($openemrDir, '/') . '/ci';
+
+        try {
+            $manifest = (new CompatibilityDeriver($ciDir, $versionOption, $testedMatrixUrl))->derive();
+        } catch (\RuntimeException $e) {
+            $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
+            return 1;
+        }
+
+        $json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
+
+        $outDir = dirname($outPath);
+        if (!is_dir($outDir) && !mkdir($outDir, 0755, true) && !is_dir($outDir)) {
+            $output->writeln("<error>Could not create output directory: {$outDir}</error>");
+            return 1;
+        }
+        if (file_put_contents($outPath, $json) === false) {
+            $output->writeln("<error>Could not write manifest to: {$outPath}</error>");
+            return 1;
+        }
+
+        $output->writeln("<info>Wrote</info> {$outPath}");
+        $output->write($json);
+        return 0;
+    })
+    ->run();

--- a/tools/release/bin/derive-compatibility.php
+++ b/tools/release/bin/derive-compatibility.php
@@ -2,11 +2,13 @@
 <?php
 
 /**
- * Emit a per-release tested-compatibility manifest (compatibility.json) derived
- * from a checked-out openemr/openemr release branch's CI test matrix.
+ * Inject a "Minimum supported versions" section into a release-notes file,
+ * derived from a checked-out openemr/openemr release branch's CI test matrix.
  *
- * Thin CLI wrapper around OpenEMR\Release\CompatibilityDeriver; see that class
- * for the decode rules and rationale (they mirror ci/parse_docker_dir.sh).
+ * Thin CLI wrapper around OpenEMR\Release\CompatibilityDeriver (decode rules,
+ * mirroring ci/parse_docker_dir.sh) and CompatibilityNotesRenderer (markdown).
+ * The section is inserted just after the first `## ` version heading in the
+ * notes file, or prepended if the file has no such heading.
  *
  * @package   openemr-devops
  * @link      https://www.open-emr.org
@@ -20,6 +22,7 @@ declare(strict_types=1);
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 use OpenEMR\Release\CompatibilityDeriver;
+use OpenEMR\Release\CompatibilityNotesRenderer;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -27,14 +30,13 @@ use Symfony\Component\Console\SingleCommandApplication;
 
 (new SingleCommandApplication())
     ->setName('derive-compatibility')
-    ->setDescription('Derive the tested-compatibility manifest from the openemr CI matrix')
+    ->setDescription('Inject the minimum-supported-versions section into the release notes')
     ->addOption(
         'openemr-dir',
         null,
         InputOption::VALUE_REQUIRED,
         'Path to the checked-out openemr release branch (defaults to $OPENEMR_DIR)',
     )
-    ->addOption('release-version', null, InputOption::VALUE_REQUIRED, 'Release version (e.g., 8.1.0)')
     ->addOption(
         'version-branch',
         null,
@@ -42,7 +44,7 @@ use Symfony\Component\Console\SingleCommandApplication;
         'Release branch for the CI matrix link (e.g., rel-810)',
     )
     ->addOption('repo', null, InputOption::VALUE_REQUIRED, 'GitHub repo hosting the CI matrix', 'openemr/openemr')
-    ->addOption('out', null, InputOption::VALUE_REQUIRED, 'Output file path', './release-output/compatibility.json')
+    ->addOption('notes-file', null, InputOption::VALUE_REQUIRED, 'Release-notes markdown file to inject into')
     ->setCode(function (InputInterface $input, OutputInterface $output): int {
         $openemrDirOption = $input->getOption('openemr-dir');
         $envOpenemrDir = getenv('OPENEMR_DIR');
@@ -54,55 +56,50 @@ use Symfony\Component\Console\SingleCommandApplication;
             return 1;
         }
 
-        $versionOption = $input->getOption('release-version');
-        if (!is_string($versionOption) || $versionOption === '') {
-            $output->writeln('<error>--release-version is required</error>');
-            return 1;
-        }
-
         $versionBranchOption = $input->getOption('version-branch');
         if (!is_string($versionBranchOption) || $versionBranchOption === '') {
             $output->writeln('<error>--version-branch is required</error>');
             return 1;
         }
 
+        $notesFileOption = $input->getOption('notes-file');
+        if (!is_string($notesFileOption) || $notesFileOption === '') {
+            $output->writeln('<error>--notes-file is required</error>');
+            return 1;
+        }
+        if (!is_file($notesFileOption)) {
+            $output->writeln("<error>Notes file not found: {$notesFileOption}</error>");
+            return 1;
+        }
+
         $repoOption = $input->getOption('repo');
         $repo = is_string($repoOption) && $repoOption !== '' ? $repoOption : 'openemr/openemr';
 
-        $testedMatrixUrl = sprintf(
-            'https://github.com/%s/tree/%s/ci',
-            $repo,
-            $versionBranchOption,
-        );
-
-        $outOption = $input->getOption('out');
-        $outPath = is_string($outOption) && $outOption !== ''
-            ? $outOption
-            : './release-output/compatibility.json';
+        $testedMatrixUrl = sprintf('https://github.com/%s/tree/%s/ci', $repo, $versionBranchOption);
 
         $ciDir = rtrim($openemrDir, '/') . '/ci';
 
+        $notes = file_get_contents($notesFileOption);
+        if ($notes === false) {
+            $output->writeln("<error>Could not read notes file: {$notesFileOption}</error>");
+            return 1;
+        }
+
         try {
-            $manifest = (new CompatibilityDeriver($ciDir, $versionOption, $testedMatrixUrl))->derive();
+            $minimums = (new CompatibilityDeriver($ciDir))->derive();
+            $renderer = new CompatibilityNotesRenderer();
+            $merged = $renderer->inject($notes, $renderer->render($minimums, $testedMatrixUrl));
         } catch (\RuntimeException $e) {
             $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             return 1;
         }
 
-        $json = json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR) . "\n";
-
-        $outDir = dirname($outPath);
-        if (!is_dir($outDir) && !mkdir($outDir, 0755, true) && !is_dir($outDir)) {
-            $output->writeln("<error>Could not create output directory: {$outDir}</error>");
-            return 1;
-        }
-        if (file_put_contents($outPath, $json) === false) {
-            $output->writeln("<error>Could not write manifest to: {$outPath}</error>");
+        if (file_put_contents($notesFileOption, $merged) === false) {
+            $output->writeln("<error>Could not write notes file: {$notesFileOption}</error>");
             return 1;
         }
 
-        $output->writeln("<info>Wrote</info> {$outPath}");
-        $output->write($json);
+        $output->writeln("<info>Injected compatibility section into</info> {$notesFileOption}");
         return 0;
     })
     ->run();

--- a/tools/release/composer.json
+++ b/tools/release/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^8.5",
+        "ext-ctype": "*",
         "ext-curl": "*",
         "ext-mbstring": "*",
         "nikic/php-parser": "^5.0",

--- a/tools/release/composer.lock
+++ b/tools/release/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48574a0e6ec816925a36a824de6ab8cf",
+    "content-hash": "070cee196773098bff5300a501a3b9c5",
     "packages": [
         {
             "name": "nikic/php-parser",
@@ -4017,6 +4017,7 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.5",
+        "ext-ctype": "*",
         "ext-curl": "*",
         "ext-mbstring": "*"
     },

--- a/tools/release/src/CompatibilityDeriver.php
+++ b/tools/release/src/CompatibilityDeriver.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Derive a per-release tested-compatibility manifest from the openemr/openemr
+ * CI test matrix.
+ *
+ * The matrix is the source of truth for what a release was actually exercised
+ * against: CI globs `ci/!(compose-shared-*)/docker-compose.yml` and runs one
+ * job per directory. This class reads the same directories, decodes the PHP
+ * version from each directory name and the database type/version from each
+ * compose file's `services.mysql.image`, and reports the minimum tested version
+ * per component. The full tested matrix is not duplicated here; the manifest
+ * carries a `tested_matrix_url` pointing at the release branch's `ci/` directory
+ * so the exact set of tested combinations lives in the repo, not the asset.
+ *
+ * Decode rules mirror ci/parse_docker_dir.sh in openemr/openemr (the canonical
+ * decoder) so the manifest can never disagree with what CI ran:
+ *   - PHP from the dir name's 2nd `_`-delimited field: `82` -> `8.2`
+ *     (first char major, remainder minor).
+ *   - DB type + version from `services.mysql.image`: strip the `@sha256:` digest,
+ *     split on `:`, e.g. `mariadb:11.8.6` -> `mariadb` / `11.8.6`.
+ *
+ * Versions are keyed to MAJOR.MINOR (the image patch is dropped) so the manifest
+ * stays stable across patch-image bumps, and the minimum is computed with
+ * version_compare (version-aware, not lexical: `8.10` > `8.9`).
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * @phpstan-type ComponentMinimum array{min: string}
+ * @phpstan-type Manifest array<string, string|ComponentMinimum>
+ */
+final readonly class CompatibilityDeriver
+{
+    public function __construct(
+        private string $ciDir,
+        private string $version,
+        private string $testedMatrixUrl,
+    ) {
+    }
+
+    /**
+     * @return Manifest
+     */
+    public function derive(): array
+    {
+        if (!is_dir($this->ciDir)) {
+            throw new \RuntimeException("CI directory not found: {$this->ciDir}");
+        }
+
+        $phpVersions = [];
+        /** @var array<string, list<string>> $dbVersions keyed by db type (mariadb, mysql) */
+        $dbVersions = [];
+
+        foreach (new \DirectoryIterator($this->ciDir) as $entry) {
+            if ($entry->isDot() || !$entry->isDir()) {
+                continue;
+            }
+            $dirName = $entry->getFilename();
+            // Mirror CI's `!(compose-shared-*)` glob exclusion.
+            if (str_starts_with($dirName, 'compose-shared-')) {
+                continue;
+            }
+            $composePath = $entry->getPathname() . '/docker-compose.yml';
+            // CI's glob only matches directories containing docker-compose.yml,
+            // so directories without one (e.g. inferno's compose.yml, the bare
+            // nginx config dir) are not matrix jobs and are skipped.
+            if (!is_file($composePath)) {
+                continue;
+            }
+
+            $phpVersions[] = $this->decodePhpVersion($dirName);
+
+            [$dbType, $dbVersion] = $this->decodeDatabase($composePath);
+            $dbVersions[$dbType][] = $dbVersion;
+        }
+
+        if ($phpVersions === []) {
+            throw new \RuntimeException("No CI matrix directories found under: {$this->ciDir}");
+        }
+
+        $manifest = ['version' => $this->version];
+        $manifest['php'] = $this->minimum($phpVersions);
+        // Sort db types for deterministic output (mariadb before mysql).
+        ksort($dbVersions);
+        foreach ($dbVersions as $dbType => $versions) {
+            $manifest[$dbType] = $this->minimum($versions);
+        }
+        $manifest['tested_matrix_url'] = $this->testedMatrixUrl;
+
+        return $manifest;
+    }
+
+    /**
+     * Decode the PHP minor version from a matrix directory name.
+     *
+     * Mirrors `IFS=_ read -r webserver php _` then `printf '%d.%d' "${php::1}"
+     * "${php:1}"` in ci/parse_docker_dir.sh: the 2nd `_`-field is the packed PHP
+     * version, first char major and remainder minor (`82` -> `8.2`, `810` ->
+     * `8.10`).
+     */
+    private function decodePhpVersion(string $dirName): string
+    {
+        $fields = explode('_', $dirName);
+        $packed = $fields[1] ?? '';
+        if (!ctype_digit($packed) || strlen($packed) < 2) {
+            throw new \RuntimeException(
+                "Cannot decode PHP version from CI directory name: {$dirName}",
+            );
+        }
+        return $packed[0] . '.' . substr($packed, 1);
+    }
+
+    /**
+     * Decode the database type and MAJOR.MINOR version from a compose file's
+     * `services.mysql.image`.
+     *
+     * Mirrors ci/parse_docker_dir.sh: strip the `@sha256:` digest (`%%@*`), then
+     * split on `:` (`IFS=:`). The image patch is dropped so the manifest is
+     * stable across patch bumps (`mariadb:11.8.6` -> `mariadb` / `11.8`).
+     *
+     * @return array{string, string} [type, MAJOR.MINOR version]
+     */
+    private function decodeDatabase(string $composePath): array
+    {
+        $parsed = Yaml::parseFile($composePath);
+        $services = is_array($parsed) ? ($parsed['services'] ?? null) : null;
+        $mysql = is_array($services) ? ($services['mysql'] ?? null) : null;
+        $image = is_array($mysql) ? ($mysql['image'] ?? null) : null;
+        if (!is_string($image) || $image === '') {
+            throw new \RuntimeException(
+                "Missing services.mysql.image in compose file: {$composePath}",
+            );
+        }
+
+        // Strip the @sha256:... digest suffix before splitting on ':'.
+        $digestPos = strpos($image, '@');
+        if ($digestPos !== false) {
+            $image = substr($image, 0, $digestPos);
+        }
+
+        $colonPos = strpos($image, ':');
+        if ($colonPos === false) {
+            throw new \RuntimeException(
+                "Cannot decode database type:version from image '{$image}' in {$composePath}",
+            );
+        }
+        $type = substr($image, 0, $colonPos);
+        $fullVersion = substr($image, $colonPos + 1);
+
+        return [$type, $this->majorMinor($fullVersion)];
+    }
+
+    /**
+     * Reduce a full version to MAJOR.MINOR, dropping any patch and beyond.
+     */
+    private function majorMinor(string $version): string
+    {
+        $parts = explode('.', $version);
+        $major = $parts[0];
+        $minor = $parts[1] ?? '0';
+        return $major . '.' . $minor;
+    }
+
+    /**
+     * Fold a list of versions into the minimum using version-aware ordering.
+     *
+     * @param list<string> $versions
+     * @return ComponentMinimum
+     */
+    private function minimum(array $versions): array
+    {
+        $min = $versions[0];
+        foreach ($versions as $version) {
+            if (version_compare($version, $min, '<')) {
+                $min = $version;
+            }
+        }
+        return ['min' => $min];
+    }
+}

--- a/tools/release/src/CompatibilityDeriver.php
+++ b/tools/release/src/CompatibilityDeriver.php
@@ -1,26 +1,26 @@
 <?php
 
 /**
- * Derive a per-release tested-compatibility manifest from the openemr/openemr
- * CI test matrix.
+ * Derive the minimum tested runtime version per component from the
+ * openemr/openemr CI test matrix.
  *
  * The matrix is the source of truth for what a release was actually exercised
  * against: CI globs `ci/!(compose-shared-*)/docker-compose.yml` and runs one
  * job per directory. This class reads the same directories, decodes the PHP
  * version from each directory name and the database type/version from each
  * compose file's `services.mysql.image`, and reports the minimum tested version
- * per component. The full tested matrix is not duplicated here; the manifest
- * carries a `tested_matrix_url` pointing at the release branch's `ci/` directory
- * so the exact set of tested combinations lives in the repo, not the asset.
+ * per component. The full tested matrix is not reproduced here; the release
+ * notes link to the release branch's `ci/` directory so the exact set of tested
+ * combinations lives in the repo.
  *
  * Decode rules mirror ci/parse_docker_dir.sh in openemr/openemr (the canonical
- * decoder) so the manifest can never disagree with what CI ran:
+ * decoder) so the result can never disagree with what CI ran:
  *   - PHP from the dir name's 2nd `_`-delimited field: `82` -> `8.2`
  *     (first char major, remainder minor).
  *   - DB type + version from `services.mysql.image`: strip the `@sha256:` digest,
  *     split on `:`, e.g. `mariadb:11.8.6` -> `mariadb` / `11.8.6`.
  *
- * Versions are keyed to MAJOR.MINOR (the image patch is dropped) so the manifest
+ * Versions are keyed to MAJOR.MINOR (the image patch is dropped) so the result
  * stays stable across patch-image bumps, and the minimum is computed with
  * version_compare (version-aware, not lexical: `8.10` > `8.9`).
  *
@@ -38,20 +38,20 @@ namespace OpenEMR\Release;
 use Symfony\Component\Yaml\Yaml;
 
 /**
- * @phpstan-type ComponentMinimum array{min: string}
- * @phpstan-type Manifest array<string, string|ComponentMinimum>
+ * @phpstan-type Minimums array<string, string>
  */
 final readonly class CompatibilityDeriver
 {
     public function __construct(
         private string $ciDir,
-        private string $version,
-        private string $testedMatrixUrl,
     ) {
     }
 
     /**
-     * @return Manifest
+     * Minimum tested version per component, keyed `php` first then db types
+     * in alphabetical order (e.g. `mariadb` before `mysql`).
+     *
+     * @return Minimums
      */
     public function derive(): array
     {
@@ -90,16 +90,14 @@ final readonly class CompatibilityDeriver
             throw new \RuntimeException("No CI matrix directories found under: {$this->ciDir}");
         }
 
-        $manifest = ['version' => $this->version];
-        $manifest['php'] = $this->minimum($phpVersions);
+        $minimums = ['php' => $this->minimum($phpVersions)];
         // Sort db types for deterministic output (mariadb before mysql).
         ksort($dbVersions);
         foreach ($dbVersions as $dbType => $versions) {
-            $manifest[$dbType] = $this->minimum($versions);
+            $minimums[$dbType] = $this->minimum($versions);
         }
-        $manifest['tested_matrix_url'] = $this->testedMatrixUrl;
 
-        return $manifest;
+        return $minimums;
     }
 
     /**
@@ -177,9 +175,8 @@ final readonly class CompatibilityDeriver
      * Fold a list of versions into the minimum using version-aware ordering.
      *
      * @param list<string> $versions
-     * @return ComponentMinimum
      */
-    private function minimum(array $versions): array
+    private function minimum(array $versions): string
     {
         $min = $versions[0];
         foreach ($versions as $version) {
@@ -187,6 +184,6 @@ final readonly class CompatibilityDeriver
                 $min = $version;
             }
         }
-        return ['min' => $min];
+        return $min;
     }
 }

--- a/tools/release/src/CompatibilityNotesRenderer.php
+++ b/tools/release/src/CompatibilityNotesRenderer.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Render the "Minimum supported versions" release-notes section from the
+ * minimum tested versions derived by CompatibilityDeriver.
+ *
+ * The section states the minimum supported version per runtime component and
+ * links to the release branch's CI directory, which holds the full matrix of
+ * versions the release was actually tested against.
+ *
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release;
+
+final readonly class CompatibilityNotesRenderer
+{
+    /** Display labels for known component keys; others fall back to ucfirst. */
+    private const LABELS = [
+        'php' => 'PHP',
+        'mariadb' => 'MariaDB',
+        'mysql' => 'MySQL',
+    ];
+
+    /**
+     * Render the markdown section.
+     *
+     * @param array<string, string> $minimums Component key => minimum version
+     * @param string $testedMatrixUrl Link to the release branch's ci/ directory
+     */
+    public function render(array $minimums, string $testedMatrixUrl): string
+    {
+        if ($minimums === []) {
+            throw new \RuntimeException('Cannot render compatibility notes from an empty minimums map');
+        }
+
+        $lines = ['### Minimum supported versions', ''];
+        foreach ($minimums as $component => $version) {
+            $label = self::LABELS[$component] ?? ucfirst($component);
+            $lines[] = "- **{$label}** {$version}+";
+        }
+        $lines[] = '';
+        $lines[] = "See the [tested CI matrix]({$testedMatrixUrl}) for all tested version combinations.";
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Insert a section into notes just after the first `## ` heading line (and
+     * the blank line that conventionally follows it). If the notes have no such
+     * heading, prepend the section instead.
+     */
+    public function inject(string $notes, string $section): string
+    {
+        $lines = explode("\n", $notes);
+        foreach ($lines as $index => $line) {
+            if (!str_starts_with($line, '## ')) {
+                continue;
+            }
+            $insertAt = isset($lines[$index + 1]) && trim($lines[$index + 1]) === ''
+                ? $index + 2
+                : $index + 1;
+            array_splice($lines, $insertAt, 0, [rtrim($section, "\n"), '']);
+            return implode("\n", $lines);
+        }
+
+        return $section . "\n" . $notes;
+    }
+}

--- a/tools/release/tests/CompatibilityDeriverTest.php
+++ b/tools/release/tests/CompatibilityDeriverTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\CompatibilityDeriver;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class CompatibilityDeriverTest extends TestCase
+{
+    private const URL = 'https://github.com/openemr/openemr/tree/rel-810/ci';
+
+    private string $ciDir = '';
+
+    protected function setUp(): void
+    {
+        $this->ciDir = sys_get_temp_dir() . '/openemr-compat-deriver-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->ciDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->ciDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->ciDir)) {
+            (new Process(['rm', '-rf', $this->ciDir]))->run();
+        }
+    }
+
+    public function testDerivesMinimumPerComponentAndMatrixUrl(): void
+    {
+        $this->matrixDir('apache_82_mariadb', 'mariadb:11.8.6');
+        $this->matrixDir('apache_84_mariadb', 'mariadb:10.6.4');
+        $this->matrixDir('nginx_83_mysql', 'mysql:8.4.0');
+        $this->matrixDir('apache_810_mysql', 'mysql:5.7.44');
+
+        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+
+        self::assertSame([
+            'version' => '8.1.0',
+            'php' => ['min' => '8.2'],
+            'mariadb' => ['min' => '10.6'],
+            'mysql' => ['min' => '5.7'],
+            'tested_matrix_url' => self::URL,
+        ], $manifest);
+    }
+
+    public function testComparesVersionsNumericallyNotLexically(): void
+    {
+        // Lexically '8.9' > '8.10'; version_compare must pick 8.9 as the min.
+        $this->matrixDir('apache_89_mariadb', 'mariadb:11.0.0');
+        $this->matrixDir('apache_810_mariadb', 'mariadb:11.0.0');
+
+        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+
+        self::assertSame(['min' => '8.9'], $manifest['php']);
+    }
+
+    public function testStripsImageDigestBeforeDecoding(): void
+    {
+        $this->matrixDir(
+            'apache_82_mariadb',
+            'mariadb:11.8.6@sha256:' . str_repeat('a', 64),
+        );
+
+        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+
+        self::assertSame(['min' => '11.8'], $manifest['mariadb']);
+    }
+
+    public function testSkipsComposeSharedDirs(): void
+    {
+        $this->matrixDir('apache_82_mariadb', 'mariadb:11.8.6');
+        $this->matrixDir('compose-shared-foo', 'mariadb:9.9.9');
+
+        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+
+        self::assertSame(['min' => '8.2'], $manifest['php']);
+        self::assertSame(['min' => '11.8'], $manifest['mariadb']);
+    }
+
+    public function testSkipsDirsWithoutDockerComposeYml(): void
+    {
+        $this->matrixDir('apache_82_mariadb', 'mariadb:11.8.6');
+        // Mimic inferno/ (compose.yml, not docker-compose.yml) and a bare config dir.
+        mkdir($this->ciDir . '/inferno', 0700, true);
+        file_put_contents($this->ciDir . '/inferno/compose.yml', "services: {}\n");
+        mkdir($this->ciDir . '/nginx', 0700, true);
+
+        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+
+        self::assertSame(['min' => '8.2'], $manifest['php']);
+        self::assertArrayNotHasKey('inferno', $manifest);
+    }
+
+    public function testMissingCiDirThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('CI directory not found');
+
+        (new CompatibilityDeriver($this->ciDir . '/nope', '8.1.0', self::URL))->derive();
+    }
+
+    public function testEmptyMatrixThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No CI matrix directories found');
+
+        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+    }
+
+    public function testUndecodablePhpDirNameThrows(): void
+    {
+        $this->matrixDir('apache_x_mariadb', 'mariadb:11.8.6');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Cannot decode PHP version');
+
+        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+    }
+
+    public function testMissingImageThrows(): void
+    {
+        $dir = $this->ciDir . '/apache_82_mariadb';
+        mkdir($dir, 0700, true);
+        file_put_contents($dir . '/docker-compose.yml', "services:\n  mysql: {}\n");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Missing services.mysql.image');
+
+        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+    }
+
+    private function matrixDir(string $name, string $image): void
+    {
+        $dir = $this->ciDir . '/' . $name;
+        if (!mkdir($dir, 0700, true)) {
+            throw new \RuntimeException('Failed to create matrix dir: ' . $dir);
+        }
+        file_put_contents(
+            $dir . '/docker-compose.yml',
+            "services:\n  mysql:\n    image: {$image}\n",
+        );
+    }
+}

--- a/tools/release/tests/CompatibilityDeriverTest.php
+++ b/tools/release/tests/CompatibilityDeriverTest.php
@@ -18,8 +18,6 @@ use Symfony\Component\Process\Process;
 
 final class CompatibilityDeriverTest extends TestCase
 {
-    private const URL = 'https://github.com/openemr/openemr/tree/rel-810/ci';
-
     private string $ciDir = '';
 
     protected function setUp(): void
@@ -37,22 +35,20 @@ final class CompatibilityDeriverTest extends TestCase
         }
     }
 
-    public function testDerivesMinimumPerComponentAndMatrixUrl(): void
+    public function testDerivesMinimumPerComponentPhpFirstThenSortedDbTypes(): void
     {
         $this->matrixDir('apache_82_mariadb', 'mariadb:11.8.6');
         $this->matrixDir('apache_84_mariadb', 'mariadb:10.6.4');
         $this->matrixDir('nginx_83_mysql', 'mysql:8.4.0');
         $this->matrixDir('apache_810_mysql', 'mysql:5.7.44');
 
-        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        $minimums = (new CompatibilityDeriver($this->ciDir))->derive();
 
         self::assertSame([
-            'version' => '8.1.0',
-            'php' => ['min' => '8.2'],
-            'mariadb' => ['min' => '10.6'],
-            'mysql' => ['min' => '5.7'],
-            'tested_matrix_url' => self::URL,
-        ], $manifest);
+            'php' => '8.2',
+            'mariadb' => '10.6',
+            'mysql' => '5.7',
+        ], $minimums);
     }
 
     public function testComparesVersionsNumericallyNotLexically(): void
@@ -61,9 +57,9 @@ final class CompatibilityDeriverTest extends TestCase
         $this->matrixDir('apache_89_mariadb', 'mariadb:11.0.0');
         $this->matrixDir('apache_810_mariadb', 'mariadb:11.0.0');
 
-        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        $minimums = (new CompatibilityDeriver($this->ciDir))->derive();
 
-        self::assertSame(['min' => '8.9'], $manifest['php']);
+        self::assertSame('8.9', $minimums['php']);
     }
 
     public function testStripsImageDigestBeforeDecoding(): void
@@ -73,9 +69,9 @@ final class CompatibilityDeriverTest extends TestCase
             'mariadb:11.8.6@sha256:' . str_repeat('a', 64),
         );
 
-        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        $minimums = (new CompatibilityDeriver($this->ciDir))->derive();
 
-        self::assertSame(['min' => '11.8'], $manifest['mariadb']);
+        self::assertSame('11.8', $minimums['mariadb']);
     }
 
     public function testSkipsComposeSharedDirs(): void
@@ -83,10 +79,10 @@ final class CompatibilityDeriverTest extends TestCase
         $this->matrixDir('apache_82_mariadb', 'mariadb:11.8.6');
         $this->matrixDir('compose-shared-foo', 'mariadb:9.9.9');
 
-        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        $minimums = (new CompatibilityDeriver($this->ciDir))->derive();
 
-        self::assertSame(['min' => '8.2'], $manifest['php']);
-        self::assertSame(['min' => '11.8'], $manifest['mariadb']);
+        self::assertSame('8.2', $minimums['php']);
+        self::assertSame('11.8', $minimums['mariadb']);
     }
 
     public function testSkipsDirsWithoutDockerComposeYml(): void
@@ -97,10 +93,10 @@ final class CompatibilityDeriverTest extends TestCase
         file_put_contents($this->ciDir . '/inferno/compose.yml', "services: {}\n");
         mkdir($this->ciDir . '/nginx', 0700, true);
 
-        $manifest = (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        $minimums = (new CompatibilityDeriver($this->ciDir))->derive();
 
-        self::assertSame(['min' => '8.2'], $manifest['php']);
-        self::assertArrayNotHasKey('inferno', $manifest);
+        self::assertSame('8.2', $minimums['php']);
+        self::assertArrayNotHasKey('inferno', $minimums);
     }
 
     public function testMissingCiDirThrows(): void
@@ -108,7 +104,7 @@ final class CompatibilityDeriverTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('CI directory not found');
 
-        (new CompatibilityDeriver($this->ciDir . '/nope', '8.1.0', self::URL))->derive();
+        (new CompatibilityDeriver($this->ciDir . '/nope'))->derive();
     }
 
     public function testEmptyMatrixThrows(): void
@@ -116,7 +112,7 @@ final class CompatibilityDeriverTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No CI matrix directories found');
 
-        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        (new CompatibilityDeriver($this->ciDir))->derive();
     }
 
     public function testUndecodablePhpDirNameThrows(): void
@@ -126,7 +122,7 @@ final class CompatibilityDeriverTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Cannot decode PHP version');
 
-        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        (new CompatibilityDeriver($this->ciDir))->derive();
     }
 
     public function testMissingImageThrows(): void
@@ -138,7 +134,7 @@ final class CompatibilityDeriverTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Missing services.mysql.image');
 
-        (new CompatibilityDeriver($this->ciDir, '8.1.0', self::URL))->derive();
+        (new CompatibilityDeriver($this->ciDir))->derive();
     }
 
     private function matrixDir(string $name, string $image): void

--- a/tools/release/tests/CompatibilityNotesRendererTest.php
+++ b/tools/release/tests/CompatibilityNotesRendererTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use OpenEMR\Release\CompatibilityNotesRenderer;
+use PHPUnit\Framework\TestCase;
+
+final class CompatibilityNotesRendererTest extends TestCase
+{
+    private const URL = 'https://github.com/openemr/openemr/tree/rel-810/ci';
+
+    public function testRendersSectionWithKnownLabelsAndLink(): void
+    {
+        $section = (new CompatibilityNotesRenderer())->render(
+            ['php' => '8.2', 'mariadb' => '10.6', 'mysql' => '5.7'],
+            self::URL,
+        );
+
+        $expected = implode("\n", [
+            '### Minimum supported versions',
+            '',
+            '- **PHP** 8.2+',
+            '- **MariaDB** 10.6+',
+            '- **MySQL** 5.7+',
+            '',
+            'See the [tested CI matrix](' . self::URL . ') for all tested version combinations.',
+            '',
+        ]);
+
+        self::assertSame($expected, $section);
+    }
+
+    public function testUnknownComponentFallsBackToUcfirst(): void
+    {
+        $section = (new CompatibilityNotesRenderer())->render(['postgres' => '14.0'], self::URL);
+
+        self::assertStringContainsString('- **Postgres** 14.0+', $section);
+    }
+
+    public function testEmptyMinimumsThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('empty minimums');
+
+        (new CompatibilityNotesRenderer())->render([], self::URL);
+    }
+}

--- a/tools/release/tests/DeriveCompatibilityCliTest.php
+++ b/tools/release/tests/DeriveCompatibilityCliTest.php
@@ -36,88 +36,124 @@ final class DeriveCompatibilityCliTest extends TestCase
         }
     }
 
-    public function testWritesManifestWithMinimumsAndMatrixUrl(): void
+    public function testInjectsSectionAfterVersionHeading(): void
     {
         $openemrDir = $this->tmpDir . '/openemr';
         $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
         $this->matrixDir($openemrDir, 'apache_84_mysql', 'mysql:8.4.0');
-        $out = $this->tmpDir . '/compatibility.json';
 
-        $process = new Process([
-            'php',
-            self::BIN,
-            '--release-version=8.1.0',
+        $notes = $this->tmpDir . '/changelog.md';
+        file_put_contents($notes, "## [8.1.0] - 2026-06-10\n\n### Fixed\n\n- something\n");
+
+        $process = $this->runCli([
             '--version-branch=rel-810',
             '--openemr-dir=' . $openemrDir,
-            '--out=' . $out,
+            '--notes-file=' . $notes,
         ]);
-        $process->run();
 
         self::assertSame(0, $process->getExitCode(), $process->getOutput());
-        self::assertFileExists($out);
 
-        $manifest = json_decode((string) file_get_contents($out), true, 512, JSON_THROW_ON_ERROR);
-        self::assertSame([
-            'version' => '8.1.0',
-            'php' => ['min' => '8.2'],
-            'mariadb' => ['min' => '11.8'],
-            'mysql' => ['min' => '8.4'],
-            'tested_matrix_url' => 'https://github.com/openemr/openemr/tree/rel-810/ci',
-        ], $manifest);
+        $result = (string) file_get_contents($notes);
+        $url = 'https://github.com/openemr/openemr/tree/rel-810/ci';
+        $expected = implode("\n", [
+            '## [8.1.0] - 2026-06-10',
+            '',
+            '### Minimum supported versions',
+            '',
+            '- **PHP** 8.2+',
+            '- **MariaDB** 11.8+',
+            '- **MySQL** 8.4+',
+            '',
+            'See the [tested CI matrix](' . $url . ') for all tested version combinations.',
+            '',
+            '### Fixed',
+            '',
+            '- something',
+            '',
+        ]);
+        self::assertSame($expected, $result);
+    }
+
+    public function testPrependsWhenNoVersionHeading(): void
+    {
+        $openemrDir = $this->tmpDir . '/openemr';
+        $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
+
+        $notes = $this->tmpDir . '/changelog.md';
+        file_put_contents($notes, "- bare body, no heading\n");
+
+        $process = $this->runCli([
+            '--version-branch=rel-810',
+            '--openemr-dir=' . $openemrDir,
+            '--notes-file=' . $notes,
+        ]);
+
+        self::assertSame(0, $process->getExitCode(), $process->getOutput());
+
+        $result = (string) file_get_contents($notes);
+        self::assertStringStartsWith('### Minimum supported versions', $result);
+        self::assertStringContainsString('- bare body, no heading', $result);
     }
 
     public function testCustomRepoChangesMatrixUrlHost(): void
     {
         $openemrDir = $this->tmpDir . '/openemr';
         $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
-        $out = $this->tmpDir . '/compatibility.json';
 
-        $process = new Process([
-            'php',
-            self::BIN,
-            '--release-version=8.1.0',
+        $notes = $this->tmpDir . '/changelog.md';
+        file_put_contents($notes, "## [8.1.0]\n\nbody\n");
+
+        $process = $this->runCli([
             '--version-branch=rel-721',
             '--repo=openemr/openemr-fork',
             '--openemr-dir=' . $openemrDir,
-            '--out=' . $out,
+            '--notes-file=' . $notes,
         ]);
-        $process->run();
 
         self::assertSame(0, $process->getExitCode(), $process->getOutput());
-        $manifest = json_decode((string) file_get_contents($out), true, 512, JSON_THROW_ON_ERROR);
-        self::assertIsArray($manifest);
-        self::assertSame(
+        self::assertStringContainsString(
             'https://github.com/openemr/openemr-fork/tree/rel-721/ci',
-            $manifest['tested_matrix_url'],
+            (string) file_get_contents($notes),
         );
     }
 
     public function testMissingVersionBranchFails(): void
     {
-        $process = new Process([
-            'php',
-            self::BIN,
-            '--release-version=8.1.0',
+        $notes = $this->tmpDir . '/changelog.md';
+        file_put_contents($notes, "## [8.1.0]\n\nbody\n");
+
+        $process = $this->runCli([
             '--openemr-dir=' . $this->tmpDir,
+            '--notes-file=' . $notes,
         ]);
-        $process->run();
 
         self::assertSame(1, $process->getExitCode());
         self::assertStringContainsString('--version-branch is required', $process->getOutput());
     }
 
-    public function testMissingReleaseVersionFails(): void
+    public function testMissingNotesFileFails(): void
     {
-        $process = new Process([
-            'php',
-            self::BIN,
+        $openemrDir = $this->tmpDir . '/openemr';
+        $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
+
+        $process = $this->runCli([
             '--version-branch=rel-810',
-            '--openemr-dir=' . $this->tmpDir,
+            '--openemr-dir=' . $openemrDir,
+            '--notes-file=' . $this->tmpDir . '/does-not-exist.md',
         ]);
-        $process->run();
 
         self::assertSame(1, $process->getExitCode());
-        self::assertStringContainsString('--release-version is required', $process->getOutput());
+        self::assertStringContainsString('Notes file not found', $process->getOutput());
+    }
+
+    /**
+     * @param list<string> $args
+     */
+    private function runCli(array $args): Process
+    {
+        $process = new Process(['php', self::BIN, ...$args]);
+        $process->run();
+        return $process;
     }
 
     private function matrixDir(string $openemrDir, string $name, string $image): void

--- a/tools/release/tests/DeriveCompatibilityCliTest.php
+++ b/tools/release/tests/DeriveCompatibilityCliTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @package   openemr-devops
+ * @link      https://www.open-emr.org
+ * @author    Michael A. Smith <michael@opencoreemr.com>
+ * @copyright Copyright (c) 2026 OpenCoreEMR Inc.
+ * @license   https://github.com/openemr/openemr-devops/blob/master/LICENSE GNU General Public License 3
+ */
+
+declare(strict_types=1);
+
+namespace OpenEMR\Release\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+final class DeriveCompatibilityCliTest extends TestCase
+{
+    private const BIN = __DIR__ . '/../bin/derive-compatibility.php';
+
+    private string $tmpDir = '';
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/openemr-compat-cli-' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tmpDir, 0700, true)) {
+            throw new \RuntimeException('Failed to create tmp dir: ' . $this->tmpDir);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tmpDir)) {
+            (new Process(['rm', '-rf', $this->tmpDir]))->run();
+        }
+    }
+
+    public function testWritesManifestWithMinimumsAndMatrixUrl(): void
+    {
+        $openemrDir = $this->tmpDir . '/openemr';
+        $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
+        $this->matrixDir($openemrDir, 'apache_84_mysql', 'mysql:8.4.0');
+        $out = $this->tmpDir . '/compatibility.json';
+
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--version-branch=rel-810',
+            '--openemr-dir=' . $openemrDir,
+            '--out=' . $out,
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), $process->getOutput());
+        self::assertFileExists($out);
+
+        $manifest = json_decode((string) file_get_contents($out), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame([
+            'version' => '8.1.0',
+            'php' => ['min' => '8.2'],
+            'mariadb' => ['min' => '11.8'],
+            'mysql' => ['min' => '8.4'],
+            'tested_matrix_url' => 'https://github.com/openemr/openemr/tree/rel-810/ci',
+        ], $manifest);
+    }
+
+    public function testCustomRepoChangesMatrixUrlHost(): void
+    {
+        $openemrDir = $this->tmpDir . '/openemr';
+        $this->matrixDir($openemrDir, 'apache_82_mariadb', 'mariadb:11.8.6');
+        $out = $this->tmpDir . '/compatibility.json';
+
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--version-branch=rel-721',
+            '--repo=openemr/openemr-fork',
+            '--openemr-dir=' . $openemrDir,
+            '--out=' . $out,
+        ]);
+        $process->run();
+
+        self::assertSame(0, $process->getExitCode(), $process->getOutput());
+        $manifest = json_decode((string) file_get_contents($out), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($manifest);
+        self::assertSame(
+            'https://github.com/openemr/openemr-fork/tree/rel-721/ci',
+            $manifest['tested_matrix_url'],
+        );
+    }
+
+    public function testMissingVersionBranchFails(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--release-version=8.1.0',
+            '--openemr-dir=' . $this->tmpDir,
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertStringContainsString('--version-branch is required', $process->getOutput());
+    }
+
+    public function testMissingReleaseVersionFails(): void
+    {
+        $process = new Process([
+            'php',
+            self::BIN,
+            '--version-branch=rel-810',
+            '--openemr-dir=' . $this->tmpDir,
+        ]);
+        $process->run();
+
+        self::assertSame(1, $process->getExitCode());
+        self::assertStringContainsString('--release-version is required', $process->getOutput());
+    }
+
+    private function matrixDir(string $openemrDir, string $name, string $image): void
+    {
+        $dir = $openemrDir . '/ci/' . $name;
+        if (!is_dir($dir) && !mkdir($dir, 0700, true)) {
+            throw new \RuntimeException('Failed to create matrix dir: ' . $dir);
+        }
+        file_put_contents(
+            $dir . '/docker-compose.yml',
+            "services:\n  mysql:\n    image: {$image}\n",
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Renders a **Minimum supported versions** section into the release notes, derived from the openemr/openemr CI test matrix at release-build time.
- Each runtime component (PHP, MariaDB, MySQL) is stated as a **minimum** (`8.2+`), with a link to the release branch's `ci/` directory for the full set of tested version combinations.
- The section is injected into the generated `changelog.md` right after the version heading, so it rides along into the GitHub Release body (`gh release create --notes-file`). It is **not** committed into the repo's running `CHANGELOG.md` (release page only).

Addresses openemr/openemr#12421. Note: that issue's body proposes a committed `Documentation/compatibility.json` with `{min,max}` + `recommended_db`; the agreed direction is narrower — **state the minimum and link to CI for what was actually tested**, surfaced on the release page rather than as a separate file.

Example release-notes output:
```markdown
## [8.1.0] - 2026-06-10

### Minimum supported versions

- **PHP** 8.2+
- **MariaDB** 10.6+
- **MySQL** 5.7+

See the [tested CI matrix](https://github.com/openemr/openemr/tree/rel-810/ci) for all tested version combinations.

### Security Fixes
...
```

The deriver mirrors `ci/parse_docker_dir.sh` (the canonical decoder) so the stated minimums can never disagree with what CI ran: PHP from the matrix dir name, DB type/version from each compose file's `services.mysql.image`, keyed to MAJOR.MINOR and folded with `version_compare`.

## Implementation
- `CompatibilityDeriver` — reads the CI matrix, returns the minimum tested version per component.
- `CompatibilityNotesRenderer` — renders the markdown section and injects it after the first `## ` heading.
- `bin/derive-compatibility.php` — CLI: `--version-branch`, `--repo`, `--openemr-dir`, `--notes-file`.
- `build-release.yml` — "Add compatibility section to release notes" step, after changelog generation and before the release is created.

## Test plan
- [x] `composer check` green: phpcs, phpstan, rector, composer-require-checker, 196 tests (30 new)
- [x] End-to-end `task release:compatibility` against a real `rel-810` checkout injects the section with the expected minimums (8.2 / 10.6 / 5.7)
- [ ] Dry-run `build-release.yml` via `workflow_dispatch` confirms the section appears in the changelog artifact