### PR TITLE
ci(docker): disable scheduled docker builds (phase 3 of #790 migration)

### DIFF
--- a/.github/workflows/build-322.yml
+++ b/.github/workflows/build-322.yml
@@ -14,9 +14,13 @@ name: Flex 3.22 Dockers Build
 #
 
 on:
+  # Schedule disabled as part of the docker-image migration to
+  # openemr/openemr core. The flex-3.22 nightly tags are now published
+  # by openemr/openemr's docker-build-322.yml (06:00 UTC). This file
+  # stays here with workflow_dispatch as a manual escape hatch only,
+  # slated for deletion in phase 5 of the migration. See
+  # openemr-devops#790 for the migration tracking issue.
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-323.yml
+++ b/.github/workflows/build-323.yml
@@ -16,9 +16,14 @@ name: Flex 3.23 Dockers Build
 # (ENSURE TO MAKE THIS (is_default_flex) FALSE WHEN A NEW ALPINE VERSION TAKES OVER AS THE DEFAULT!)
 
 on:
+  # Schedule disabled as part of the docker-image migration to
+  # openemr/openemr core. The flex-3.23 nightly tags (including the
+  # bare `flex` default) are now published by openemr/openemr's
+  # docker-build-323.yml (06:00 UTC). This file stays here with
+  # workflow_dispatch as a manual escape hatch only, slated for
+  # deletion in phase 5 of the migration. See openemr-devops#790
+  # for the migration tracking issue.
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-704.yml
+++ b/.github/workflows/build-704.yml
@@ -1,9 +1,15 @@
 name: Production 7.0.4 Docker Build
 
 on:
+  # Schedule disabled as part of the docker-image migration to
+  # openemr/openemr core. The 7.0.4 production tag (plus 7.0.4.0 and
+  # the date-suffixed variant) is now published by openemr/openemr's
+  # docker-release-orchestrator.yml fanning out to the rel-704 row in
+  # .github/release-targets.yml (06:00 UTC). This file stays here
+  # with workflow_dispatch as a manual escape hatch only, slated for
+  # deletion in phase 5 of the migration. See openemr-devops#790
+  # for the migration tracking issue.
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-704.yml
+++ b/.github/workflows/build-704.yml
@@ -39,9 +39,3 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           no-cache: true
-
-      - name: Push Docker Hub readme
-        uses: ./.github/actions/push-dockerhub-readme
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-edge.yml
+++ b/.github/workflows/build-edge.yml
@@ -13,9 +13,13 @@ name: Flex Edge Dockers Nightly Build
 # The is_default_flex environment variable is used to determine if this is the default flex image.
 #  (This is NOT the default flex image, so is_default_flex is false)
 on:
+  # Schedule disabled as part of the docker-image migration to
+  # openemr/openemr core. The flex-edge nightly tags are now published
+  # by openemr/openemr's docker-build-edge.yml (06:00 UTC). This file
+  # stays here with workflow_dispatch as a manual escape hatch only,
+  # slated for deletion in phase 5 of the migration. See
+  # openemr-devops#790 for the migration tracking issue.
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:

--- a/.github/workflows/build-openemr.yml
+++ b/.github/workflows/build-openemr.yml
@@ -145,9 +145,3 @@ jobs:
             tags+=(-t "openemr/openemr:${DIR}")
           fi
           docker buildx imagetools create "${tags[@]}" "${digests[@]}"
-
-      - name: Push Docker Hub readme
-        uses: ./.github/actions/push-dockerhub-readme
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-openemr.yml
+++ b/.github/workflows/build-openemr.yml
@@ -7,9 +7,16 @@ name: OpenEMR Docker Build (current/next/dev)
 # so this file holds no version strings and never needs rewriting.
 
 on:
+  # Schedule disabled as part of the docker-image migration to
+  # openemr/openemr core. The current/next/dev rotating slot tags
+  # (each currently resolving to 8.0.0/8.1.0/8.1.1 respectively, plus
+  # the version-numbered and date-suffixed variants) are now published
+  # by openemr/openemr's docker-release-orchestrator.yml fanning out to
+  # the rel-800, rel-810, and master rows of .github/release-targets.yml
+  # (06:00 UTC). This file stays here with workflow_dispatch as a
+  # manual escape hatch only, slated for deletion in phase 5 of the
+  # migration. See openemr-devops#790 for the migration tracking issue.
   workflow_dispatch:
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
 
 jobs:
   build:


### PR DESCRIPTION
Phase 3 of the docker-image migration tracked in #790.

The five scheduled docker build workflows in this repo overlap with tags now published by openemr/openemr's `docker-release-orchestrator.yml` fanning out at 06:00 UTC. Devops's 02:00 UTC builds re-push the same tags four hours earlier each night, which both wastes builder time and creates a race-then-overwrite cycle on Docker Hub.

This PR removes the `schedule:` block from each affected workflow, leaving `workflow_dispatch:` as a manual escape hatch so the workflows can still be triggered if the openemr/openemr side needs a debugging fallback during the cutover window. Each file gets a comment header documenting which openemr-core workflow took over its tag set, and pointing at #790 for the full migration context.

## Tag overlap (currently double-published, after this PR single-published from openemr/openemr core)

| File | Tags it publishes | Replaced by |
|---|---|---|
| `build-322.yml` | `flex-3.22-php-{8.2,8.3,8.4}`, `flex-3.22` | core `docker-build-322.yml` |
| `build-323.yml` | `flex-3.23-php-{8.3,8.4,8.5}`, `flex-3.23`, `flex` | core `docker-build-323.yml` |
| `build-edge.yml` | `flex-edge-php-{8.3,8.4,8.5}`, `flex-edge` | core `docker-build-edge.yml` |
| `build-704.yml` | `7.0.4`, `7.0.4.0`, `7.0.4-<date>` | core orchestrator → rel-704 row |
| `build-openemr.yml` | `current`/`next`/`dev` + `8.0.0`/`8.1.0`/`8.1.1` + date-suffixed variants | core orchestrator → rel-800 / rel-810 / master rows |

Phase 5 of the migration (later) deletes these five files entirely. This interim step neutralizes them first so any cutover problem-solving happens against a single publisher rather than two competing schedules. Reversible in one revert if the migration hits a snag.

## Docker Hub readme push step also removed

A second commit on this branch removes the `Push Docker Hub readme` step from `build-openemr.yml` and `build-704.yml`. Those two workflows used to call the `push-dockerhub-readme` composite action after a successful image build to update Docker Hub's repo description for `openemr/openemr`.

The schedule removal above already shuts down the nightly path through this step. But both workflows retain `workflow_dispatch:` as a manual escape hatch for ad-hoc image republishing, and without this second change a manual dispatch would still push the devops-rendered readme. Once openemr/openemr#12482's phase 4 work lands and openemr core takes over readme publishing, a manual devops dispatch would silently overwrite core's freshly-published readme with the old devops content.

The `push-dockerhub-readme` composite action itself stays under `.github/actions/` for now — still useful for ad-hoc testing of the devops PHP/Twig renderer — and gets cleaned up in phase 5 along with the rest of the inert docker pipeline.

## Out of scope (deliberately untouched)

The release-mechanism workflows stay in this repo and continue working — they're release packaging, not docker production:

- `build-release.yml` + `build-release-on-tag.yml` (release tarballs + GitHub Release)
- `release-rotation.yml` (3-slot rotation PR)
- `release-announcements.yml` (per-channel announcement drafts)
- `build-patch.yml` (manual patch release)
- `ship-release.yml` (3-PR release orchestration)

A separate post-phase-5 release-mechanism migration project picks those up; see the "Beyond the migration" section of [the planning doc](https://github.com/openemr/openemr-devops/issues/790).

## Pre-merge checklist

- [ ] Confirm openemr/openemr master's `docker-release-orchestrator.yml` is producing fresh Docker Hub pushes for the overlapping tags (verify via `openemr/openemr` page on Docker Hub).
- [ ] Confirm openemr/openemr#12482 has merged so master's release-targets.yml is live.
- [ ] Confirm openemr/openemr#12495, #12496, #12497 have merged so rel-810/800/704 docker pipelines exist on the core side.
- [ ] Byte-identical drift canary green on openemr/openemr master.

## Rollback

`git revert` this PR restores the `schedule:` blocks. Devops's 02:00 UTC builds resume; brief tag-republish race during the next ~24h until further action. Single-step recovery.

Refs: #790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Disabled scheduled (cron) Docker image build automation across multiple workflows, switching them to manual-only execution.
  * Documented that nightly/current/next/dev tag publishing is handled by an external orchestration workflow.
  * Removed steps related to publishing an updated “Docker Hub readme” artifact from these workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
