### PR TITLE
Remove client certificate commands

### DIFF
--- a/docker/openemr/flex/utilities/devtools
+++ b/docker/openemr/flex/utilities/devtools
@@ -87,9 +87,7 @@
 # SSL/TLS CERTIFICATES:
 #   force-https             - Enable HTTPS redirect
 #   un-force-https          - Disable HTTPS redirect
-#   setup-client-cert <id>  - Configure client certificate authentication
 #   on-self-signed-cert     - Revert to self-signed certificates
-#   list-client-certs       - List available client certificate packages
 #
 # DATABASE SSL:
 #   sql-ssl                 - Enable MySQL SSL with test CA certificate
@@ -621,22 +619,6 @@ if [ "$1" = "un-force-https" ]; then
     echo "Completed. Need to stop/start docker for changes to take effect"
 fi
 
-if [ "$1" = "list-client-certs" ]; then
-    echo "Listing client certs packages:"
-    cd /certs
-    for f in *; do
-        if [ -f "${f}" ]; then
-            echo "  ${f%.*}"
-        fi
-    done
-fi
-
-if [ "$1" = "setup-client-cert" ] && [ ! -z "$2" ] ; then
-    echo "Setting up client based cert with following cert package: ${2}"
-    prepareVariables
-    setupClientCert "$2"
-    echo "Completed. Need to stop/start docker for changes to take effect"
-fi
 
 if [ "$1" = "on-self-signed-cert" ]; then
     echo "Toggling on self signed key and certificate (includes disabling client based cert)"

--- a/docker/openemr/flex/utilities/devtools
+++ b/docker/openemr/flex/utilities/devtools
@@ -87,7 +87,6 @@
 # SSL/TLS CERTIFICATES:
 #   force-https             - Enable HTTPS redirect
 #   un-force-https          - Disable HTTPS redirect
-#   on-self-signed-cert     - Revert to self-signed certificates
 #
 # DATABASE SSL:
 #   sql-ssl                 - Enable MySQL SSL with test CA certificate
@@ -620,12 +619,6 @@ if [ "$1" = "un-force-https" ]; then
 fi
 
 
-if [ "$1" = "on-self-signed-cert" ]; then
-    echo "Toggling on self signed key and certificate (includes disabling client based cert)"
-    prepareVariables
-    toggleOnSelfSignedCert
-    echo "Completed. Need to stop/start docker for changes to take effect"
-fi
 
 # ============================================================================
 # DATABASE SSL COMMANDS

--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -407,64 +407,6 @@ unForceHttps() {
     sed -i 's@[^#]RewriteRule (\.\*) https://%{HTTP_HOST}/\$1 \[R,L\]@#RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]@' /etc/apache2/conf.d/openemr.conf
 }
 
-# Configures Apache and OpenEMR to use client certificate authentication.
-# Sets up mutual TLS (mTLS) where clients must present a certificate to connect.
-#
-# Parameters:
-#   $1: Certificate package identifier (must exist as /certs/${identifier}.zip)
-#
-# Certificate Package Contents (expected in zip file):
-#   - Server.crt: Server certificate
-#   - Server.key: Server private key
-#   - CertificateAuthority.crt: CA certificate
-#   - CertificateAuthority.key: CA private key
-#
-# Process:
-#   1. Extracts certificate package
-#   2. Copies certificates to /etc/ssl/
-#   3. Configures Apache for client certificate verification
-#   4. Updates OpenEMR globals to enable client SSL
-#
-# Note: Requires Apache restart for changes to take effect.
-# Must call prepareVariables() before calling this function.
-setupClientCert() {
-    if [[ ! -d "/certs/${1}" ]]; then
-        mkdir -p "/certs/${1}"
-    fi
-    cp "/certs/${1}.zip" "/certs/${1}/"
-    (
-        cd "/certs/${1}" &&
-        unzip "${1}.zip"
-    )
-    # server certificate
-    cp "/certs/${1}/Server.crt" /etc/ssl/certs/customclientbased.cert.pem
-    rm -f /etc/ssl/certs/webserver.cert.pem
-    ln -s /etc/ssl/certs/customclientbased.cert.pem /etc/ssl/certs/webserver.cert.pem
-    # server key
-    cp "/certs/${1}/Server.key" /etc/ssl/private/customclientbased.key.pem
-    rm -f /etc/ssl/private/webserver.key.pem
-    ln -s /etc/ssl/private/customclientbased.key.pem /etc/ssl/private/webserver.key.pem
-    # ca certificate
-    cp "/certs/${1}/CertificateAuthority.crt" /etc/ssl/certs/CAcustomclientbased.cert.pem
-    rm -f /etc/ssl/certs/CAcustomclientbasedwebserver.cert.pem
-    ln -s /etc/ssl/certs/CAcustomclientbased.cert.pem /etc/ssl/certs/CAcustomclientbasedwebserver.cert.pem
-    # ca key
-    cp "/certs/${1}/CertificateAuthority.key" /etc/ssl/private/CAcustomclientbased.key.pem
-    rm -f /etc/ssl/private/CAcustomclientbasedwebserver.key.pem
-    ln -s /etc/ssl/private/CAcustomclientbased.key.pem /etc/ssl/private/CAcustomclientbasedwebserver.key.pem
-    # cleanup
-    rm -fr "/certs/${1}"
-    # configure apache
-    sed -i "s@#SSLVerifyClient@ SSLVerifyClient@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@#SSLVerifyDepth@ SSLVerifyDepth@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@#SSLOptions@ SSLOptions@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@#SSLCACertificateFile@ SSLCACertificateFile@" /etc/apache2/conf.d/openemr.conf
-    # configure openemr
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = 1 WHERE gl_name = 'is_client_ssl_enabled'" "${CUSTOM_DATABASE}"
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = '/etc/ssl/certs/CAcustomclientbasedwebserver.cert.pem' WHERE gl_name = 'certificate_authority_crt'" "${CUSTOM_DATABASE}"
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = '/etc/ssl/private/CAcustomclientbasedwebserver.key.pem' WHERE gl_name = 'certificate_authority_key'" "${CUSTOM_DATABASE}"
-}
-
 # Reverts to self-signed certificate configuration.
 # Disables client certificate authentication and switches back to standard
 # self-signed server certificate.

--- a/docker/openemr/flex/utilities/devtoolsLibrary.source
+++ b/docker/openemr/flex/utilities/devtoolsLibrary.source
@@ -407,35 +407,6 @@ unForceHttps() {
     sed -i 's@[^#]RewriteRule (\.\*) https://%{HTTP_HOST}/\$1 \[R,L\]@#RewriteRule (.*) https://%{HTTP_HOST}/$1 [R,L]@' /etc/apache2/conf.d/openemr.conf
 }
 
-# Reverts to self-signed certificate configuration.
-# Disables client certificate authentication and switches back to standard
-# self-signed server certificate.
-#
-# Process:
-#   1. Links self-signed certificates as default
-#   2. Disables Apache client certificate verification
-#   3. Updates OpenEMR globals to disable client SSL
-#
-# Note: Requires Apache restart for changes to take effect.
-# Must call prepareVariables() before calling this function.
-toggleOnSelfSignedCert() {
-    # server certificate
-    rm -f /etc/ssl/certs/webserver.cert.pem
-    ln -s /etc/ssl/certs/selfsigned.cert.pem /etc/ssl/certs/webserver.cert.pem
-    # server key
-    rm -f /etc/ssl/private/webserver.key.pem
-    ln -s /etc/ssl/private/selfsigned.key.pem /etc/ssl/private/webserver.key.pem
-    # configure apache
-    sed -i "s@[^#]SSLVerifyClient@#SSLVerifyClient@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@[^#]SSLVerifyDepth@#SSLVerifyDepth@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@[^#]SSLOptions@#SSLOptions@" /etc/apache2/conf.d/openemr.conf
-    sed -i "s@[^#]SSLCACertificateFile@#SSLCACertificateFile@" /etc/apache2/conf.d/openemr.conf
-    # configure openemr
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = 0 WHERE gl_name = 'is_client_ssl_enabled'" "${CUSTOM_DATABASE}"
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = '' WHERE gl_name = 'certificate_authority_crt'" "${CUSTOM_DATABASE}"
-    mariadb --skip-ssl -u "${CUSTOM_USER}" --password="${CUSTOM_PASSWORD}" -h "${MYSQL_HOST}" -P "${CUSTOM_PORT}" -e "UPDATE globals SET gl_value = '' WHERE gl_name = 'certificate_authority_key'" "${CUSTOM_DATABASE}"
-}
-
 # ============================================================================
 # TEST DATA GENERATION
 # ============================================================================

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1493
+OC_SCRIPT_FUNCS_END=1463
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -1595,7 +1595,6 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo 'ssl-management:'
     echo "  fh, force-https                    Force https"
     echo "  ufh, un-force-https                Removing forcing of https"
-    echo "  ossc, on-self-signed-cert          Toggle on self signed certificates (on by default)"
     echo "  ss, sql-ssl                        Use testing sql ssl CA cert"
     echo "  sso, sql-ssl-off                   Remove testing sql ssl CA cert"
     echo "  ssc, sql-ssl-client                Use testing sql ssl client certs"
@@ -1943,9 +1942,6 @@ case "${FIRST_ARG}" in
         ;;
     ufh)
         run_devtools_in_docker "${CONTAINER_ID}" un-force-https
-        ;;
-    ossc)
-        run_devtools_in_docker "${CONTAINER_ID}" on-self-signed-cert
         ;;
     ss)
         run_devtools_in_docker "${CONTAINER_ID}" sql-ssl

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -1383,37 +1383,6 @@ change_db_character_set_and_collation(){
     fi
 }
 
-setup-client-cert(){
-    local CERT_PACKAGE="$1"
-    local CERT_PACKAGE_CODE=30
-    if [[ $# != 1 ]]; then
-        echo 'Please provide a certificate package name.'
-        echo 'e.g. openemr-cmd [scc|setup-client-cert] sll'
-        exit "${CERT_PACKAGE_CODE}"
-    else
-        # Use the devtools function
-        run_devtools_in_docker "${CONTAINER_ID}" setup-client-cert "${CERT_PACKAGE}"
-    fi
-}
-
-put-client-cert(){
-    # Need a capsule parameter
-    local CERT_PACKAGE_FILE="$1"
-    local PUT_CLIENT_CERT_CODE=32
-    local CERT_PACKAGE_FILE_CODE=31
-    if [[ $# != 1 ]]; then
-        echo 'Please provide the certificate package file name (including path if applicable).'
-        echo 'e.g. openemr-cmd [pcc|put-client-cert] sll.zip'
-        exit "${CERT_PACKAGE_FILE_CODE}"
-    else
-        if ! ls "${CERT_PACKAGE_FILE}" &>/dev/null; then
-            echo 'Please check whether the certificate package file exists or not'
-            exit "${PUT_CLIENT_CERT_CODE}"
-        else
-            docker cp "${CERT_PACKAGE_FILE}" "${CONTAINER_ID}:/certs/"
-        fi
-    fi
-}
 
 import-random-patients(){
     # Use the devtools function, passing all arguments ($@)
@@ -1627,9 +1596,6 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo "  fh, force-https                    Force https"
     echo "  ufh, un-force-https                Removing forcing of https"
     echo "  ossc, on-self-signed-cert          Toggle on self signed certificates (on by default)"
-    echo "  scc, setup-client-cert             Turn on client based cert with designated package"
-    echo "  lcc, list-client-certs             To list the certificate packages"
-    echo "  pcc, put-client-cert               To copy certificate package into the docker"
     echo "  ss, sql-ssl                        Use testing sql ssl CA cert"
     echo "  sso, sql-ssl-off                   Remove testing sql ssl CA cert"
     echo "  ssc, sql-ssl-client                Use testing sql ssl client certs"
@@ -1812,12 +1778,6 @@ case "${FIRST_ARG}" in
     ec|encoding-collation)
         change_db_character_set_and_collation "$@"
         ;;
-    scc|setup-client-cert)
-        setup-client-cert "$@"
-        ;;
-    pcc|put-client-cert)
-        put-client-cert "$@"
-        ;;
     irp|import-random-patients)
         import-random-patients "$@"
         ;;
@@ -1986,9 +1946,6 @@ case "${FIRST_ARG}" in
         ;;
     ossc)
         run_devtools_in_docker "${CONTAINER_ID}" on-self-signed-cert
-        ;;
-    lcc)
-        run_devtools_in_docker "${CONTAINER_ID}" list-client-certs
         ;;
     ss)
         run_devtools_in_docker "${CONTAINER_ID}" sql-ssl


### PR DESCRIPTION
Related: openemr/openemr#12510

#### Short description of what this resolves:

Removes devtools commands that supported the client certificate feature being removed upstream.

#### Changes proposed in this pull request:

- Remove `scc`/`setup-client-cert` command and `setupClientCert()` function
- Remove `lcc`/`list-client-certs` command
- Remove `pcc`/`put-client-cert` command  
- Remove `ossc`/`on-self-signed-cert` command and `toggleOnSelfSignedCert()` function
- Remove associated help text

Note: the original notification I got from GH included `ossc`; it looks like @bradymiller updated his comment removing it. However when I looked at the internals, it appears that it should indeed be included in the scope of this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Client certificate (mTLS) management functionality removed from development utilities (devtools and openemr-cmd).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->