### PR TITLE
docs(readme): drop docker-pipeline references after migration to openemr core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,11 @@
 [![ShellCheck](https://github.com/openemr/openemr-devops/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/shellcheck.yml)
-[![Dockerfile Linting](https://github.com/openemr/openemr-devops/actions/workflows/hadolint.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/hadolint.yml)
 [![Docker Compose Linting](https://github.com/openemr/openemr-devops/actions/workflows/dclint.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/dclint.yml)
-[![BATS Tests](https://github.com/openemr/openemr-devops/actions/workflows/test-bats.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/test-bats.yml)
-[![Container Functionality](https://github.com/openemr/openemr-devops/actions/workflows/test-container-functionality.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/test-container-functionality.yml)
-[![Production Docker Test](https://github.com/openemr/openemr-devops/actions/workflows/test-production.yml/badge.svg)](https://github.com/openemr/openemr-devops/actions/workflows/test-production.yml)
 
 # openemr-devops
 
 OpenEMR administration and deployment tooling
 
 ## Resource Index
-
-### Components and Infrastructure
-
-* [Official OpenEMR Docker](docker/openemr): Source repository for the [Docker](https://hub.docker.com/r/openemr/openemr/) library
-  * **Production Docker Testing**: Automated workflow verifies production OpenEMR Docker images (versioned releases like 7.0.4) can build correctly and function with database connections. Tests include unit, fixtures, services, validators, and controllers suites.
-  * **Flex Docker Testing**: Automated workflow tests development-oriented "flex" Docker images designed for development where OpenEMR code is mounted separately rather than embedded in the image.
 
 ### Deployment Options
 


### PR DESCRIPTION
## Summary

Phase 5 of the docker migration (#803, merged 2026-06-20) deleted the workflows + directory that backed four README badges and the "Components and Infrastructure" subsection. This PR removes those dead references rather than redirecting to openemr/openemr.

## What's deleted

**Badges** pointing at deleted workflows:
- ❌ Dockerfile Linting → `hadolint.yml` (deleted in #803)
- ❌ BATS Tests → `test-bats.yml` (deleted in #803)
- ❌ Container Functionality → `test-container-functionality.yml` (deleted in #803)
- ❌ Production Docker Test → `test-production.yml` (deleted in #803)

**Subsection** referencing the deleted docker pipeline:
- ❌ `### Components and Infrastructure` — `[Official OpenEMR Docker](docker/openemr)` was a 404 (`docker/openemr/` deleted in #803), and the Production/Flex Docker Testing sub-bullets describe the workflows above.

## What stays

- ✅ ShellCheck badge — `shellcheck.yml` is still alive
- ✅ Docker Compose Linting badge — `dclint.yml` is still alive (lints kubernetes/, packages/, etc. compose files that stay in this repo)
- ✅ Deployment Options (Ubuntu installer, Kubernetes, Raspberry Pi)
- ✅ AWS Installations
- ✅ Management Utilities (openemr-cmd, env-installer, monitor, portainer, env-migrator — all still in `utilities/`)
- ✅ Contact Us

Per the migration plan in #790, this repo is now scoped to deployment + utilities + kubernetes + AWS packaging. Docker-image production lives in openemr/openemr alongside the source it ships.

## Companion PR

A companion PR on openemr/openemr will land at the same time, covering:
- `CONTRIBUTING.md` mention of devops (strips "Docker," from the devops-role description)
- `DOCKER_README.md` (adds a "where the pipeline lives" pointer)
- `docker/README.md` (expanded from one-line stub into a real directory guide)
- New `docs/docker-migration-from-devops.md` (the migration's living planning doc, relocated to its long-term home — content was previously maintained as the body of openemr-devops#790)
- Sweep of other docs for stale openemr-devops/docker/* references

## Test plan

- [ ] CI green
- [ ] Visual review: badges still render (only the 2 alive ones), no broken links remaining