### PR TITLE
feat(openemr-cmd): add --base for worktree add, default to canonical openemr/openemr master

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1463
+OC_SCRIPT_FUNCS_END=1536
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -62,7 +62,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1536
+OC_SCRIPT_FUNCS_END=1563
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/worktree_add_base.bats
+++ b/tests/bats/openemr-cmd/worktree_add_base.bats
@@ -1,0 +1,174 @@
+# BATS: --base flag of `openemr-cmd worktree add` and the underlying
+# wt_resolve_base helper.
+#
+# Contract under test:
+#   --base <url>[#<ref>]    -> fetch from URL, base on FETCH_HEAD
+#   --base <git commit-ish> -> pure git rev-parse resolution, no fetch
+#   no --base               -> fetch canonical openemr/openemr master
+#                              (NOT routed through wt_resolve_base; covered
+#                              via the integration-error tests only)
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_ROOT=$(oc_mktempdir)
+
+    # Real local git repo with one commit on master, an extra branch, and
+    # a tag. Used both as OPENEMR_ROOT (target of rev-parse) and as a
+    # file:// fetch source for URL-form tests.
+    oc_init_repo "${TMP_ROOT}"
+    git -C "${TMP_ROOT}" branch rel-test
+    # tag.gpgsign / tag.forceSignAnnotated in a user's global config would
+    # otherwise force annotated+signed tags and prompt for a message.
+    git -C "${TMP_ROOT}" -c tag.gpgsign=false -c tag.forceSignAnnotated=false tag v-test
+
+    export TMP_ROOT
+}
+
+teardown() {
+    [[ -n "${TMP_ROOT:-}" ]] && rm -rf "${TMP_ROOT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    # Some tests don't set STUB_DIR, so the [[ -n ]] above can be the
+    # teardown's last command and return 1. Force success.
+    return 0
+}
+
+# Run a wt_resolve_base call in a subshell with the script's function defs
+# sourced. Stderr is folded into stdout so assertions on hint messages work.
+run_resolve() {
+    local arg="$1"
+    run env \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WT_CANONICAL_URL="https://github.com/openemr/openemr.git" \
+        bash -c "
+            set -uo pipefail
+            eval \"\$(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')\"
+            wt_resolve_base '${arg}' 2>&1
+        "
+}
+
+# --- URL form ---------------------------------------------------------------
+
+@test "wt_resolve_base: file:// URL with #ref fetches and echoes FETCH_HEAD" {
+    run_resolve "file://${TMP_ROOT}#master"
+    assert_success
+    # FETCH_HEAD appears on the last line; the wt_info chatter is above it.
+    [[ "${lines[-1]}" = "FETCH_HEAD" ]]
+}
+
+@test "wt_resolve_base: file:// URL without #ref defaults to master" {
+    run_resolve "file://${TMP_ROOT}"
+    assert_success
+    [[ "${lines[-1]}" = "FETCH_HEAD" ]]
+}
+
+@test "wt_resolve_base: URL fetch failure returns non-zero with 'fetch failed' hint" {
+    run_resolve "file:///nonexistent/repo/that/does/not/exist.git#master"
+    assert_failure
+    assert_output --partial "fetch failed"
+}
+
+@test "wt_resolve_base: git@ form is dispatched as URL (not as a local ref)" {
+    # We can't actually auth in the test env, so we expect the fetch step
+    # to fail. The point is to confirm git@... gets to the fetch branch
+    # rather than falling through to rev-parse with the 'is not a URL' hint.
+    run_resolve "git@github.com:fake-org-bats/fake-repo-bats.git#master"
+    assert_failure
+    refute_output --partial "is not a URL"
+}
+
+@test "wt_resolve_base: https:// form is dispatched as URL" {
+    # Same shape as the git@ test — fetch will fail in the test env (the
+    # repo doesn't exist), but we just need to confirm the dispatch.
+    run_resolve "https://github.com/fake-org-bats/fake-repo-bats.git#master"
+    assert_failure
+    refute_output --partial "is not a URL"
+}
+
+# --- git-native form --------------------------------------------------------
+
+@test "wt_resolve_base: local branch name resolves to itself (echoed for git worktree add to use)" {
+    run_resolve "master"
+    assert_success
+    assert_output "master"
+}
+
+@test "wt_resolve_base: non-master local branch resolves" {
+    run_resolve "rel-test"
+    assert_success
+    assert_output "rel-test"
+}
+
+@test "wt_resolve_base: tag resolves" {
+    run_resolve "v-test"
+    assert_success
+    assert_output "v-test"
+}
+
+@test "wt_resolve_base: HEAD resolves (explicit opt-in to primary HEAD)" {
+    run_resolve "HEAD"
+    assert_success
+    assert_output "HEAD"
+}
+
+@test "wt_resolve_base: full SHA resolves" {
+    local sha
+    sha=$(git -C "${TMP_ROOT}" rev-parse HEAD)
+    run_resolve "${sha}"
+    assert_success
+    assert_output "${sha}"
+}
+
+@test "wt_resolve_base: nonexistent ref fails with helpful canonical-URL hint" {
+    run_resolve "nonexistent-branch-xyz"
+    assert_failure
+    assert_output --partial "is not a URL and does not resolve as a local git ref"
+    assert_output --partial "github.com/openemr/openemr.git#nonexistent-branch-xyz"
+}
+
+# --- cmd_worktree_add integration ------------------------------------------
+# These call the full script as a subprocess to exercise arg parsing and
+# the wt_die paths. We don't try to drive a successful worktree creation
+# end-to-end (that needs real docker compose dirs, port allocation, etc.);
+# the error paths are what guard the user-facing contract.
+
+@test "cmd_worktree_add: --base without -b errors and points at -b requirement" {
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "${SCRIPT}" worktree add somebranch --base master
+    assert_failure
+    assert_output --partial "--base only applies with -b"
+}
+
+@test "cmd_worktree_add: --base unknown ref dies with the canonical-URL hint" {
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    # Bypass the wt_compose_subdir existence check by creating the dir.
+    mkdir -p "${TMP_ROOT}/docker/development-easy"
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "${SCRIPT}" worktree add feat -b --base nonexistent-xyz
+    assert_failure
+    assert_output --partial "is not a URL and does not resolve as a local git ref"
+    assert_output --partial "github.com/openemr/openemr.git#nonexistent-xyz"
+    assert_output --partial "Failed to resolve --base 'nonexistent-xyz'"
+}
+
+@test "cmd_worktree_add: --base with no value errors clearly" {
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "${SCRIPT}" worktree add feat -b --base
+    assert_failure
+    assert_output --partial "--base requires a value"
+}

--- a/tests/bats/openemr-cmd/worktree_add_base.bats
+++ b/tests/bats/openemr-cmd/worktree_add_base.bats
@@ -57,13 +57,19 @@ run_resolve() {
     run_resolve "file://${TMP_ROOT}#master"
     assert_success
     # FETCH_HEAD appears on the last line; the wt_info chatter is above it.
-    [[ "${lines[-1]}" = "FETCH_HEAD" ]]
+    # A SHA appears on its own line; wt_info chatter is above it. Use
+    # assert_line (per-line match) so the anchors work, and a regex so
+    # we don't have to plumb the expected SHA in. Bash 3.2 compatible.
+    assert_line --regexp '^[0-9a-f]{40}$'
 }
 
 @test "wt_resolve_base: file:// URL without #ref defaults to master" {
     run_resolve "file://${TMP_ROOT}"
     assert_success
-    [[ "${lines[-1]}" = "FETCH_HEAD" ]]
+    # A SHA appears on its own line; wt_info chatter is above it. Use
+    # assert_line (per-line match) so the anchors work, and a regex so
+    # we don't have to plumb the expected SHA in. Bash 3.2 compatible.
+    assert_line --regexp '^[0-9a-f]{40}$'
 }
 
 @test "wt_resolve_base: URL fetch failure returns non-zero with 'fetch failed' hint" {
@@ -171,4 +177,28 @@ run_resolve() {
         "${SCRIPT}" worktree add feat -b --base
     assert_failure
     assert_output --partial "--base requires a value"
+}
+
+# --- help-block drift guard --------------------------------------------------
+# openemr-cmd has TWO worktree-add usage blocks:
+#   1. top-level `openemr-cmd -h` (in the main usage block)
+#   2. `openemr-cmd worktree` no-subcommand fallback (in cmd_worktree())
+# Both must surface --base so users running either get current info.
+
+@test "help drift: top-level -h surfaces --base on the worktree add line" {
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    run env PATH="${STUB_DIR}:$PATH" "${SCRIPT}" -h
+    # USAGE_EXIT_CODE=13; openemr-cmd -h exits non-zero by design.
+    assert_output --partial "[--base <ref>]"
+}
+
+@test "help drift: 'worktree' (no subcommand) fallback surfaces --base" {
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="$(dirname "${TMP_ROOT}")" \
+        "${SCRIPT}" worktree
+    assert_failure
+    assert_output --partial "[--base <ref>]"
 }

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -69,7 +69,7 @@ wt_require_cmd() {
 #
 # Two forms:
 #   URL (https://, git@, ssh://, git://, file://) optionally with "#<ref>"
-#       -> fetch <url> <ref> (default ref: master); echo FETCH_HEAD
+#       -> fetch <url> <ref> (default ref: master); echo a stable SHA
 #       This is the form intended for AI assistants and any caller that
 #       wants a freshly-fetched, fully-reproducible base independent of
 #       local repo state. The primary's HEAD is never read.
@@ -82,6 +82,31 @@ wt_require_cmd() {
 #
 # The default behavior (no --base supplied) is NOT routed through this
 # helper; the caller fetches canonical openemr/openemr master directly.
+#
+# Concurrency: the URL form fetches into a per-invocation temp ref
+# (refs/wt-base-tmp/<pid>-<rand>) and immediately resolves to an immutable
+# SHA. This avoids the FETCH_HEAD race where a second concurrent fetch in
+# the same primary repo would overwrite FETCH_HEAD before the caller's
+# `git worktree add` consumed it. wt_fetch_to_sha encapsulates the pattern.
+wt_fetch_to_sha() {
+    local url="$1" ref="$2"
+    local tmpref="refs/wt-base-tmp/$$-${RANDOM}-${RANDOM}"
+    if ! git -C "${OPENEMR_ROOT}" fetch --quiet "${url}" "${ref}:${tmpref}" >&2; then
+        wt_info "fetch failed; check the URL and ref" >&2
+        return 1
+    fi
+    local sha
+    sha=$(git -C "${OPENEMR_ROOT}" rev-parse --verify --quiet "${tmpref}")
+    local rc=$?
+    # Best-effort cleanup; refs/wt-base-tmp/* are harmless if orphaned.
+    git -C "${OPENEMR_ROOT}" update-ref -d "${tmpref}" 2>/dev/null || true
+    if [[ ${rc} -ne 0 ]]; then
+        wt_info "fetched ${ref} but could not resolve to a SHA" >&2
+        return 1
+    fi
+    echo "${sha}"
+}
+
 wt_resolve_base() {
     local arg="$1"
     local url ref
@@ -95,12 +120,8 @@ wt_resolve_base() {
             ref="master"
         fi
         wt_info "Fetching ${ref} from ${url}" >&2
-        if ! git -C "${OPENEMR_ROOT}" fetch --quiet "${url}" "${ref}" >&2; then
-            wt_info "fetch failed; check the URL and ref" >&2
-            return 1
-        fi
-        echo "FETCH_HEAD"
-        return 0
+        wt_fetch_to_sha "${url}" "${ref}"
+        return $?
     fi
 
     if ! git -C "${OPENEMR_ROOT}" rev-parse --verify --quiet "${arg}^{commit}" >/dev/null; then
@@ -578,12 +599,14 @@ cmd_worktree_add() {
             # Default: fetch canonical openemr/openemr master fresh. Primary
             # HEAD is never read, so concurrent worktree creation by multiple
             # agents is safe regardless of which branch is checked out in the
-            # primary repo.
+            # primary repo. Fetched via wt_fetch_to_sha so the resolved base
+            # is a stable SHA, not the shared mutable FETCH_HEAD ref.
             wt_info "Fetching master from openemr/openemr (canonical)"
-            git -C "${OPENEMR_ROOT}" fetch --quiet "${WT_CANONICAL_URL}" master \
+            # shellcheck disable=SC2310  # function uses explicit return, not set -e
+            resolved_base=$(wt_fetch_to_sha "${WT_CANONICAL_URL}" master) \
                 || wt_die "Failed to fetch master from ${WT_CANONICAL_URL}"
-            resolved_base="FETCH_HEAD"
         else
+            # shellcheck disable=SC2310  # function uses explicit return, not set -e
             resolved_base=$(wt_resolve_base "${base}") \
                 || wt_die "Failed to resolve --base '${base}' (see hints above)"
         fi
@@ -1048,8 +1071,12 @@ cmd_worktree() {
         *)
             echo "Usage: openemr-cmd worktree <add|remove|up|down|start|stop|exec|list|regen|set-env|prune> [options]"
             echo ""
-            echo "  add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]"
-            echo "                            Create worktree (-b creates new branch, default env: easy)"
+            echo "  add <branch> [-b] [--base <ref>] [--env easy|easy-light|easy-redis] [--start]"
+            echo "                            Create worktree (default env: easy)"
+            echo "                            -b           : create new branch; default base is canonical openemr/openemr master (fetched fresh)"
+            echo "                            --base <ref> : (with -b) base on a specific ref. Two forms:"
+            echo "                                             <url>[#<ref>]  -> fetch from URL (e.g. https://github.com/openemr/openemr.git#rel-810)"
+            echo "                                             <commit-ish>   -> standard git resolution (local branch, origin/master, tag, SHA, HEAD, ...)"
             echo "  remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)"
             echo "  up <branch>               Start Docker stack for worktree"
             echo "  down <branch> [--keep-volumes]  Stop Docker stack for worktree (volumes deleted by default)"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -63,26 +63,30 @@ wt_require_cmd() {
     done
 }
 
-# Resolve a worktree-add --base argument to a local commit-ish suitable for
-# `git worktree add -b ... <commit-ish>`. Echoes the resolved ref to stdout;
-# all human-readable progress goes to stderr. Performs the network fetch as a
-# side effect — the primary repo's HEAD is never read or modified, so this is
-# safe to call concurrently from multiple agents.
+# Resolve a worktree-add --base argument to a commit-ish that
+# `git worktree add -b ... <commit-ish>` can use. Echoes the resolved ref to
+# stdout; human-readable progress and errors go to stderr.
 #
-# Dispatch (in order):
-#   URL (https://, git@, ssh://, git://), optionally with "#<ref>"
-#       -> fetch <url> <ref>          ; echo FETCH_HEAD
-#   SHA already present in local object db (7-40 hex chars)
-#       -> no fetch                   ; echo <sha>
-#   <remote>/<ref> where <remote> is a configured local remote
-#       -> fetch <remote> <ref>       ; echo <remote>/<ref>
-#   bare ref name (master, rel-810, v8_0_0_3, refs/tags/v8.1.1, ...)
-#       -> fetch <canonical> <ref>    ; echo FETCH_HEAD
+# Two forms:
+#   URL (https://, git@, ssh://, git://, file://) optionally with "#<ref>"
+#       -> fetch <url> <ref> (default ref: master); echo FETCH_HEAD
+#       This is the form intended for AI assistants and any caller that
+#       wants a freshly-fetched, fully-reproducible base independent of
+#       local repo state. The primary's HEAD is never read.
+#   anything else
+#       -> pure git <commit-ish> semantics. Hand the arg to git as-is so
+#          it resolves via the standard rev-parse rules: local branch
+#          name, remote-tracking ref (origin/master), tag, SHA, HEAD,
+#          @{u}, etc. No fetch happens — freshness is the caller's
+#          responsibility (a normal `git fetch <remote>` ahead of time).
+#
+# The default behavior (no --base supplied) is NOT routed through this
+# helper; the caller fetches canonical openemr/openemr master directly.
 wt_resolve_base() {
     local arg="$1"
-    local url ref prefix rest
+    local url ref
 
-    if [[ "${arg}" =~ ^(https?://|git@|ssh://|git://) ]]; then
+    if [[ "${arg}" =~ ^(https?://|git@|ssh://|git://|file://) ]]; then
         if [[ "${arg}" == *"#"* ]]; then
             url="${arg%%#*}"
             ref="${arg#*#}"
@@ -91,33 +95,21 @@ wt_resolve_base() {
             ref="master"
         fi
         wt_info "Fetching ${ref} from ${url}" >&2
-        git -C "${OPENEMR_ROOT}" fetch --quiet "${url}" "${ref}" >&2 || return 1
+        if ! git -C "${OPENEMR_ROOT}" fetch --quiet "${url}" "${ref}" >&2; then
+            wt_info "fetch failed; check the URL and ref" >&2
+            return 1
+        fi
         echo "FETCH_HEAD"
         return 0
     fi
 
-    if [[ "${arg}" =~ ^[0-9a-fA-F]{7,40}$ ]] \
-        && git -C "${OPENEMR_ROOT}" rev-parse --verify --quiet "${arg}^{commit}" >/dev/null
-    then
-        echo "${arg}"
-        return 0
+    if ! git -C "${OPENEMR_ROOT}" rev-parse --verify --quiet "${arg}^{commit}" >/dev/null; then
+        wt_info "'${arg}' is not a URL and does not resolve as a local git ref" >&2
+        wt_info "to fetch '${arg}' from canonical openemr/openemr, use:" >&2
+        wt_info "  --base ${WT_CANONICAL_URL}#${arg}" >&2
+        return 1
     fi
-
-    if [[ "${arg}" == */* ]]; then
-        prefix="${arg%%/*}"
-        rest="${arg#*/}"
-        if git -C "${OPENEMR_ROOT}" config --get "remote.${prefix}.url" >/dev/null 2>&1; then
-            wt_info "Fetching ${rest} from remote '${prefix}'" >&2
-            git -C "${OPENEMR_ROOT}" fetch --quiet "${prefix}" "${rest}" >&2 || return 1
-            echo "${prefix}/${rest}"
-            return 0
-        fi
-        # Else fall through and treat as bare ref against canonical.
-    fi
-
-    wt_info "Fetching ${arg} from openemr/openemr (canonical)" >&2
-    git -C "${OPENEMR_ROOT}" fetch --quiet "${WT_CANONICAL_URL}" "${arg}" >&2 || return 1
-    echo "FETCH_HEAD"
+    echo "${arg}"
     return 0
 }
 
@@ -582,10 +574,22 @@ cmd_worktree_add() {
     wt_info "Creating git worktree for '${branch}' at ${dir}"
     if ${new_branch}; then
         local resolved_base
-        resolved_base=$(wt_resolve_base "${base:-master}") || wt_die "Failed to resolve base ref '${base:-master}'"
-        # --no-track keeps the new feature branch from inheriting the base's
-        # remote-tracking config; matches the previous "branch off HEAD with
-        # no tracking" behavior of `git worktree add -b <branch> <dir>`.
+        if [[ -z "${base}" ]]; then
+            # Default: fetch canonical openemr/openemr master fresh. Primary
+            # HEAD is never read, so concurrent worktree creation by multiple
+            # agents is safe regardless of which branch is checked out in the
+            # primary repo.
+            wt_info "Fetching master from openemr/openemr (canonical)"
+            git -C "${OPENEMR_ROOT}" fetch --quiet "${WT_CANONICAL_URL}" master \
+                || wt_die "Failed to fetch master from ${WT_CANONICAL_URL}"
+            resolved_base="FETCH_HEAD"
+        else
+            resolved_base=$(wt_resolve_base "${base}") \
+                || wt_die "Failed to resolve --base '${base}' (see hints above)"
+        fi
+        # --no-track keeps the new feature branch from inheriting the base
+        # ref's remote-tracking config; matches the previous "branch off HEAD
+        # with no tracking" behavior of `git worktree add -b <branch> <dir>`.
         git -C "${OPENEMR_ROOT}" worktree add --no-track -b "${branch}" "${dir}" "${resolved_base}"
     else
         git -C "${OPENEMR_ROOT}" worktree add "${dir}" "${branch}"
@@ -1577,9 +1581,10 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo 'worktree-management:'
     echo "  worktree add <branch> [-b] [--base <ref>] [--env easy|easy-light|easy-redis] [--start]"
     echo "                                     Create worktree (default env: easy)"
-    echo "                                     -b           : create new branch; defaults to canonical openemr/openemr master (fetched from GitHub)"
-    echo "                                     --base <ref> : (with -b) base the new branch on a different ref:"
-    echo "                                                    bare name (rel-810, v8_0_0_3), <remote>/<ref>, <url>[#<ref>], or local SHA"
+    echo "                                     -b           : create new branch; default base is canonical openemr/openemr master (fetched fresh)"
+    echo "                                     --base <ref> : (with -b) base on a specific ref. Two forms:"
+    echo "                                                      <url>[#<ref>]  -> fetch from URL (e.g. https://github.com/openemr/openemr.git#rel-810)"
+    echo "                                                      <commit-ish>   -> standard git resolution (local branch, origin/master, tag, SHA, HEAD, ...)"
     echo "  worktree remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)"
     echo "  worktree up <branch>               Start Docker stack for a worktree"
     echo "  worktree down <branch> [--keep-volumes]  Stop Docker stack (volumes deleted by default)"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.41"
+VERSION="1.0.42"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -49,6 +49,11 @@ WT_STATE_FILE="${OPENEMR_ROOT}/.worktrees.json"
 VALID_ENVS=("easy" "easy-light" "easy-redis")
 DEFAULT_ENV="easy"
 
+# Canonical openemr/openemr source-of-truth URL used as the default base when
+# creating new branches via `worktree add -b`. Public read over HTTPS so no
+# auth and no named remote required. Override with WT_CANONICAL_URL.
+WT_CANONICAL_URL="${WT_CANONICAL_URL:-https://github.com/openemr/openemr.git}"
+
 wt_die()  { echo "error: $*" >&2; exit 1; }
 wt_info() { echo "  --> $*"; }
 
@@ -56,6 +61,64 @@ wt_require_cmd() {
     for cmd in "$@"; do
         if ! command -v "${cmd}" &>/dev/null; then wt_die "'${cmd}' is required but not found"; fi
     done
+}
+
+# Resolve a worktree-add --base argument to a local commit-ish suitable for
+# `git worktree add -b ... <commit-ish>`. Echoes the resolved ref to stdout;
+# all human-readable progress goes to stderr. Performs the network fetch as a
+# side effect — the primary repo's HEAD is never read or modified, so this is
+# safe to call concurrently from multiple agents.
+#
+# Dispatch (in order):
+#   URL (https://, git@, ssh://, git://), optionally with "#<ref>"
+#       -> fetch <url> <ref>          ; echo FETCH_HEAD
+#   SHA already present in local object db (7-40 hex chars)
+#       -> no fetch                   ; echo <sha>
+#   <remote>/<ref> where <remote> is a configured local remote
+#       -> fetch <remote> <ref>       ; echo <remote>/<ref>
+#   bare ref name (master, rel-810, v8_0_0_3, refs/tags/v8.1.1, ...)
+#       -> fetch <canonical> <ref>    ; echo FETCH_HEAD
+wt_resolve_base() {
+    local arg="$1"
+    local url ref prefix rest
+
+    if [[ "${arg}" =~ ^(https?://|git@|ssh://|git://) ]]; then
+        if [[ "${arg}" == *"#"* ]]; then
+            url="${arg%%#*}"
+            ref="${arg#*#}"
+        else
+            url="${arg}"
+            ref="master"
+        fi
+        wt_info "Fetching ${ref} from ${url}" >&2
+        git -C "${OPENEMR_ROOT}" fetch --quiet "${url}" "${ref}" >&2 || return 1
+        echo "FETCH_HEAD"
+        return 0
+    fi
+
+    if [[ "${arg}" =~ ^[0-9a-fA-F]{7,40}$ ]] \
+        && git -C "${OPENEMR_ROOT}" rev-parse --verify --quiet "${arg}^{commit}" >/dev/null
+    then
+        echo "${arg}"
+        return 0
+    fi
+
+    if [[ "${arg}" == */* ]]; then
+        prefix="${arg%%/*}"
+        rest="${arg#*/}"
+        if git -C "${OPENEMR_ROOT}" config --get "remote.${prefix}.url" >/dev/null 2>&1; then
+            wt_info "Fetching ${rest} from remote '${prefix}'" >&2
+            git -C "${OPENEMR_ROOT}" fetch --quiet "${prefix}" "${rest}" >&2 || return 1
+            echo "${prefix}/${rest}"
+            return 0
+        fi
+        # Else fall through and treat as bare ref against canonical.
+    fi
+
+    wt_info "Fetching ${arg} from openemr/openemr (canonical)" >&2
+    git -C "${OPENEMR_ROOT}" fetch --quiet "${WT_CANONICAL_URL}" "${arg}" >&2 || return 1
+    echo "FETCH_HEAD"
+    return 0
 }
 
 # realpath flag support differs by platform: GNU coreutils has -e/-m; the
@@ -481,18 +544,20 @@ wt_compose_cmd() {
 
 # shellcheck disable=SC2004
 cmd_worktree_add() {
-    local branch="" env="${DEFAULT_ENV}" start=false new_branch=false
+    local branch="" env="${DEFAULT_ENV}" start=false new_branch=false base=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
             --env)           if [[ -z "${2:-}" ]]; then wt_die "--env requires a value"; fi; env=$2; shift 2 ;;
+            --base)          if [[ -z "${2:-}" ]]; then wt_die "--base requires a value"; fi; base=$2; shift 2 ;;
             --start)         start=true; shift ;;
             -b|--new-branch) new_branch=true; shift ;;
             -*)              wt_die "Unknown option: $1" ;;
             *)               if [[ -z "${branch}" ]]; then branch=$1; else wt_die "Unexpected argument: $1"; fi; shift ;;
         esac
     done
-    if [[ -z "${branch}" ]]; then wt_die "Usage: openemr-cmd worktree add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]"; fi
+    if [[ -z "${branch}" ]]; then wt_die "Usage: openemr-cmd worktree add <branch> [-b] [--base <ref>] [--env easy|easy-light|easy-redis] [--start]"; fi
+    if [[ -n "${base}" && ! "${new_branch}" == true ]]; then wt_die "--base only applies with -b (it picks the base for a new branch)"; fi
 
     wt_require_cmd git docker jq realpath
     wt_validate_env "${env}"
@@ -516,7 +581,12 @@ cmd_worktree_add() {
 
     wt_info "Creating git worktree for '${branch}' at ${dir}"
     if ${new_branch}; then
-        git -C "${OPENEMR_ROOT}" worktree add -b "${branch}" "${dir}"
+        local resolved_base
+        resolved_base=$(wt_resolve_base "${base:-master}") || wt_die "Failed to resolve base ref '${base:-master}'"
+        # --no-track keeps the new feature branch from inheriting the base's
+        # remote-tracking config; matches the previous "branch off HEAD with
+        # no tracking" behavior of `git worktree add -b <branch> <dir>`.
+        git -C "${OPENEMR_ROOT}" worktree add --no-track -b "${branch}" "${dir}" "${resolved_base}"
     else
         git -C "${OPENEMR_ROOT}" worktree add "${dir}" "${branch}"
     fi
@@ -1505,8 +1575,11 @@ if [[ $# -eq 0 || "${FIRST_ARG}" = '--help' || "${FIRST_ARG}" = '-h' ]]; then
     echo "  -d                                 Specify the docker id or name to execute commands"
     echo 'Commands:'
     echo 'worktree-management:'
-    echo "  worktree add <branch> [-b] [--env easy|easy-light|easy-redis] [--start]"
-    echo "                                     Create worktree (-b creates new branch, default env: easy)"
+    echo "  worktree add <branch> [-b] [--base <ref>] [--env easy|easy-light|easy-redis] [--start]"
+    echo "                                     Create worktree (default env: easy)"
+    echo "                                     -b           : create new branch; defaults to canonical openemr/openemr master (fetched from GitHub)"
+    echo "                                     --base <ref> : (with -b) base the new branch on a different ref:"
+    echo "                                                    bare name (rel-810, v8_0_0_3), <remote>/<ref>, <url>[#<ref>], or local SHA"
     echo "  worktree remove <branch> [--keep-volumes] Remove worktree (volumes deleted by default)"
     echo "  worktree up <branch>               Start Docker stack for a worktree"
     echo "  worktree down <branch> [--keep-volumes]  Stop Docker stack (volumes deleted by default)"

--- a/utilities/openemr-cmd/openemr-cmd-h
+++ b/utilities/openemr-cmd/openemr-cmd-h
@@ -38,7 +38,7 @@ fi
 # Use ${FIRST_ARG}
 case "${FIRST_ARG}" in
     worktree)
-        filter_help_output worktree-management 16
+        filter_help_output worktree-management 17
         ;;
     docker)
         filter_help_output docker-management 10

--- a/utilities/openemr-cmd/openemr-cmd-h
+++ b/utilities/openemr-cmd/openemr-cmd-h
@@ -38,7 +38,7 @@ fi
 # Use ${FIRST_ARG}
 case "${FIRST_ARG}" in
     worktree)
-        filter_help_output worktree-management 13
+        filter_help_output worktree-management 16
         ;;
     docker)
         filter_help_output docker-management 10


### PR DESCRIPTION
Resolves #814.

## Summary

Before this change, `openemr-cmd worktree add <branch> -b` based the new branch on the primary repo's HEAD. That made primary HEAD an implicit coordination surface across concurrent agents and silently stale when the primary hadn't been freshly fetched.

This PR replaces that with an explicit, freshly-fetched canonical default and a `--base <ref>` flag with **two-form semantics**:

- **`--base <url>[#<ref>]`** — fetch from URL. For AI assistants and anyone who wants a fully-reproducible, network-fetched base independent of local state. Default ref is `master`. `file://` is accepted (which is how the bats tests work without network).
- **`--base <commit-ish>`** — pure git `rev-parse` semantics. Handles local branches, remote-tracking refs (`origin/master`), tags, SHAs, `HEAD`, `@{u}`, anything git understands. No fetch — freshness is the caller's responsibility (just like `git checkout -b ... <start-point>`).

Default behavior (no `--base`) still fetches canonical `openemr/openemr` master directly, so the ergonomic "just give me a worktree" path is unchanged. Primary HEAD is never read on the default path.

## Why two forms

[Discussion in the issue thread](https://github.com/openemr/openemr-devops/issues/814) converged on two distinct usage profiles:

| Profile | What they pass | What they get |
|---|---|---|
| Low-scale human dev | `--base <bare-ref>` | Pure git semantics — local branch / tag / SHA. Fast, no network. |
| High-scale AI agent | `--base https://github.com/openemr/openemr.git#<ref>` | Explicit canonical fetch every time. Network, reproducible across agents/machines, zero coupling to local state. |

This is cleaner than the earlier "fetch on bare names" sketch (which forced a `local:` escape hatch for local refs) and aligns `--base` with how git's native `<commit-ish>` works.

## Behavior matrix

| Invocation | What happens |
|---|---|
| `... -b` | Fetch `master` from canonical `https://github.com/openemr/openemr.git`; base on resolved SHA |
| `... -b --base https://github.com/openemr/openemr.git#rel-810` | Fetch `rel-810` from that URL; base on resolved SHA |
| `... -b --base file:///path/to/local-fork#branch` | Fetch from `file://` URL; base on resolved SHA |
| `... -b --base master` | Local `master`, no fetch |
| `... -b --base origin/master` | Local remote-tracking ref `origin/master`, no fetch |
| `... -b --base v8_0_0_3` | Local tag, no fetch |
| `... -b --base HEAD` | Whatever primary `HEAD` is (explicit opt-in) |
| `... -b --base <sha>` | That SHA, no fetch |
| `... -b --base nonexistent-xyz` | Fail with hint: re-run as `--base https://github.com/openemr/openemr.git#nonexistent-xyz` to fetch it |
| `... --base master` (no `-b`) | Fail: `--base only applies with -b` |

`--no-track` is passed to `git worktree add` so the new branch doesn't inherit the base ref's remote-tracking config — matches the previous no-tracking behavior.

`WT_CANONICAL_URL` env var overrides the canonical URL for forks/mirrors.

## Concurrency safety

Fetches go through `wt_fetch_to_sha`, which writes into a per-invocation temp ref (`refs/wt-base-tmp/<pid>-<rand>-<rand>`) and immediately resolves to an immutable SHA before any `git worktree add` consumes it. This avoids the `FETCH_HEAD` race that would otherwise let two concurrent agents overwrite each other's fetch result. Temp refs are cleaned up best-effort; orphans under `refs/wt-base-tmp/*` are harmless.

## Files

- `utilities/openemr-cmd/openemr-cmd` — `wt_resolve_base()` + `wt_fetch_to_sha()` helpers, `--base` parsing, `WT_CANONICAL_URL` constant, version → `1.0.42`, updated inline help on both worktree help blocks (top-level `-h` + `cmd_worktree()` no-subcommand fallback)
- `utilities/openemr-cmd/openemr-cmd-h` — `-A` line count bump for new help block
- `tests/bats/openemr-cmd/worktree_add_base.bats` — 16 bats cases covering both `--base` forms, all error paths, and a drift guard that asserts both help blocks surface `[--base <ref>]`
- `tests/bats/openemr-cmd/helpers.bash` — `OC_SCRIPT_FUNCS_END` bumped for the new helpers

## Paired follow-up — landed

openemr/openemr#12613 — paired doc update to `openemr/CONTRIBUTING.md` and `openemr/CLAUDE.md` explaining the new `-b` default and `--base` flag, so contributors and AI agents reading those docs don't assume the old HEAD-based behavior.

## Test plan

- [x] `bats tests/bats/openemr-cmd/` — 60 passing (16 new, 44 existing, 0 failures)
- [x] CI: BATS (ubuntu-22.04 + macos-14), ShellCheck — all green
- [x] On a real install: `openemr-cmd worktree add new-feature -b` creates a worktree based on freshly-fetched canonical master
- [x] `--base https://github.com/openemr/openemr.git#rel-810` bases on canonical rel-810
- [x] `--base master` bases on local master (no network)
- [x] `--base upstream/master` bases on local remote-tracking ref
- [x] `--base nonexistent-xyz` errors with the canonical-URL hint
- [x] `--base master` without `-b` errors clearly
- [x] Primary repo's HEAD is unchanged before/after in all cases above
- [x] `openemr-cmd -h` shows the new options (openemr-cmd-h unchanged structurally; just bumped -A line count)
- [x] `openemr-cmd worktree` (no subcommand) fallback also shows the new options
- [x] Two concurrent `openemr-cmd worktree add ... -b` calls each get their own base SHA (no FETCH_HEAD race) — verified with parallel `--base <url>#rel-810` + `--base <url>#rel-800`, each landed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)