### PR TITLE
test(openemr-cmd): integration coverage for cmd_worktree_add side effects (Tier 1)

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -33,20 +33,30 @@ oc_mktempdir() {
 
 # Build a PATH-stubs directory containing a 'docker' shim that responds to
 # 'docker compose' (no args, plugin probe) with exit 0 and ignores everything
-# else with empty output and exit 0. The shim does NOT shell out anywhere.
+# else with empty output and exit 0. The shim records every invocation to
+# ${stub_dir}/docker.log (one line per call, space-joined args) so tests can
+# assert on the exact compose invocations the script made.
 #
 # Usage:
 #   stub_dir=$(oc_make_docker_stub_dir)
-#   PATH="${stub_dir}:$PATH" run "$SCRIPT" worktree list
+#   PATH="${stub_dir}:$PATH" run "$SCRIPT" worktree up <branch>
+#   grep -- '-p openemr-<slug>' "${stub_dir}/docker.log"
 oc_make_docker_stub_dir() {
-    local d
+    local d log
     d=$(oc_mktempdir)
-    cat > "${d}/docker" <<'STUB'
+    log="${d}/docker.log"
+    : > "${log}"
+    # Heredoc unquoted to interpolate ${log} (the absolute log path);
+    # $@/$1/etc. are escaped so they stay literal in the stub script.
+    cat > "${d}/docker" <<STUB
 #!/bin/sh
 # Predictable stub of 'docker' used by openemr-cmd BATS tests.
-# 'docker compose' (plugin probe) must succeed so check_docker_compose_install
-# picks the plugin path; everything else returns empty/0.
-if [ "${1-}" = "compose" ]; then
+# Records each invocation to ${log} for caller-side assertions. The
+# 'docker compose' (plugin probe) call must succeed so
+# check_docker_compose_install picks the plugin path; everything else
+# also returns 0. The shim does NOT shell out anywhere.
+echo "\$@" >> "${log}"
+if [ "\${1-}" = "compose" ]; then
     exit 0
 fi
 exit 0
@@ -94,6 +104,32 @@ oc_init_repo() {
     : > "${dir}/.placeholder"
     git -C "${dir}" add .placeholder
     git -C "${dir}" commit --quiet -m "init" >/dev/null
+}
+
+# Initialize $1 as a real git repo AND commit the docker/ layout that
+# cmd_worktree_add expects to find on the base ref it checks out: each env's
+# docker/development-<env>/ subdir (with a placeholder docker-compose.yml so
+# the path can be passed to docker via -f) plus docker/library/ (resolved by
+# wt_write_override for bind-mounts). After this, the repo's master tip is a
+# commit that any subsequent `git worktree add ... master` (or canonical fetch
+# via file://${repo}) will check out and have everything cmd_worktree_add
+# needs to write its override + .env files without tripping the no-symlink /
+# no-traversal guards.
+#
+# Usage:
+#   oc_init_repo_with_fixtures "${TMP_ROOT}"
+oc_init_repo_with_fixtures() {
+    local dir=$1
+    oc_init_repo "${dir}"
+    mkdir -p "${dir}/docker/library"
+    : > "${dir}/docker/library/.placeholder"
+    local env
+    for env in easy easy-light easy-redis; do
+        mkdir -p "${dir}/docker/development-${env}"
+        echo "# bats fixture compose for ${env}" > "${dir}/docker/development-${env}/docker-compose.yml"
+    done
+    git -C "${dir}" add docker
+    git -C "${dir}" commit --quiet -m "fixture: docker dirs for openemr-cmd worktree add"
 }
 
 # Register a new git worktree on a new branch under <wt-parent>/<dirname>.

--- a/tests/bats/openemr-cmd/worktree_add_integration.bats
+++ b/tests/bats/openemr-cmd/worktree_add_integration.bats
@@ -1,0 +1,205 @@
+# BATS: cmd_worktree_add end-to-end side effects.
+#
+# Where worktree_add_base.bats covers --base argument parsing + resolution,
+# this file exercises the full create flow and verifies every artifact
+# cmd_worktree_add is supposed to produce:
+#   - registered git worktree directory under WORKTREE_PARENT
+#   - new branch (or checked-out existing branch) pointing at the right SHA
+#   - .worktrees.json state entry with offset/dir/env
+#   - per-env compose .env file with the right WT_* port variables
+#   - docker-compose.override.yml with branch-scoped volume names
+#   - port-offset uniqueness across consecutive adds
+#   - --start triggers a `docker compose ... up -d` against the right project
+#
+# All side effects land inside a hermetic TMP_PARENT (no network, no real
+# docker). Canonical fetch is redirected to a file:// URL pointing at the
+# same tmp repo via WT_CANONICAL_URL so the default `-b` path stays inside
+# the test fixture.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    export TMP_PARENT TMP_ROOT STUB_DIR
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Run the script's `worktree add` against the hermetic fixture.
+run_add() {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# --- core happy path --------------------------------------------------------
+
+@test "add -b (default canonical fetch via file:// URL) creates dir, branch, state, .env, override" {
+    run_add feature-x -b
+    assert_success
+
+    local wt_dir="${TMP_PARENT}/openemr-wt-feature-x"
+    [[ -d "${wt_dir}" ]] || fail "worktree dir missing: ${wt_dir}"
+
+    # Branch tip matches what canonical (= TMP_ROOT itself) had at master.
+    local got expected
+    got=$(git -C "${TMP_ROOT}" rev-parse feature-x)
+    expected=$(git -C "${TMP_ROOT}" rev-parse master)
+    [[ "${got}" = "${expected}" ]] || fail "branch ${got} != expected ${expected}"
+
+    # State entry present with offset 1, env easy, correct dir.
+    [[ -f "${TMP_ROOT}/.worktrees.json" ]]
+    local entry
+    entry=$(jq -c '."feature-x"' "${TMP_ROOT}/.worktrees.json")
+    [[ "${entry}" != "null" ]] || fail "no state entry for feature-x"
+    [[ "$(jq -r '."feature-x".offset' "${TMP_ROOT}/.worktrees.json")" = "1" ]]
+    [[ "$(jq -r '."feature-x".env'    "${TMP_ROOT}/.worktrees.json")" = "easy" ]]
+    [[ "$(jq -r '."feature-x".dir'    "${TMP_ROOT}/.worktrees.json")" = "${wt_dir}" ]]
+
+    # .env file has the right WT_* variables.
+    local envf="${wt_dir}/docker/development-easy/.env"
+    [[ -f "${envf}" ]] || fail "compose .env missing: ${envf}"
+    grep -qE "^WT_NAME=feature-x$"  "${envf}"
+    grep -qE "^WT_ENV=easy$"        "${envf}"
+    grep -qE "^WT_OFFSET=1$"        "${envf}"
+    grep -qE "^WT_HTTP_PORT=8301$"  "${envf}"
+    grep -qE "^WT_HTTPS_PORT=9301$" "${envf}"
+    grep -qE "^WT_MYSQL_PORT=8321$" "${envf}"
+
+    # Override file present and uses branch-scoped volume names.
+    local ovf="${wt_dir}/docker/development-easy/docker-compose.override.yml"
+    [[ -f "${ovf}" ]] || fail "override missing: ${ovf}"
+    grep -q "name: openemr-feature-x_db"     "${ovf}"
+    grep -q "name: openemr-feature-x_assets" "${ovf}"
+}
+
+@test "add -b --base <local-ref> uses the local ref's SHA without a fetch" {
+    # Capture canonical's notion of master so we can later show we did NOT
+    # fall back to it (we want LOCAL master, which happens to be the same
+    # commit here — but the assertion is structurally about the --base path).
+    run_add feature-y -b --base master
+    assert_success
+    local got expected
+    got=$(git -C "${TMP_ROOT}" rev-parse feature-y)
+    expected=$(git -C "${TMP_ROOT}" rev-parse master)
+    [[ "${got}" = "${expected}" ]]
+}
+
+@test "add -b --env easy-redis routes to the easy-redis compose subdir + adds WT_REDIS_PORT" {
+    run_add feature-r -b --env easy-redis
+    assert_success
+    local wt_dir="${TMP_PARENT}/openemr-wt-feature-r"
+    [[ -f "${wt_dir}/docker/development-easy-redis/.env" ]]
+    grep -qE "^WT_REDIS_PORT=6380$" "${wt_dir}/docker/development-easy-redis/.env"
+    # Easy-redis-only redis container_name override block is emitted.
+    grep -q "container_name: openemr-feature-r-redis-master" \
+        "${wt_dir}/docker/development-easy-redis/docker-compose.override.yml"
+}
+
+@test "add -b --env easy-light skips selenium/couchdb/mailpit/redis ports" {
+    run_add feature-l -b --env easy-light
+    assert_success
+    local envf="${TMP_PARENT}/openemr-wt-feature-l/docker/development-easy-light/.env"
+    grep -qE "^WT_NAME=feature-l$"  "${envf}"
+    ! grep -q "^WT_SELENIUM_PORT="  "${envf}"
+    ! grep -q "^WT_COUCHDB_PORT="   "${envf}"
+    ! grep -q "^WT_MAILPIT_UI_PORT=" "${envf}"
+    ! grep -q "^WT_REDIS_PORT="     "${envf}"
+}
+
+# --- port-offset uniqueness -------------------------------------------------
+
+@test "three consecutive adds allocate distinct offsets 1, 2, 3" {
+    run_add a1 -b ; assert_success
+    run_add a2 -b ; assert_success
+    run_add a3 -b ; assert_success
+    [[ "$(jq -r '.a1.offset' "${TMP_ROOT}/.worktrees.json")" = "1" ]]
+    [[ "$(jq -r '.a2.offset' "${TMP_ROOT}/.worktrees.json")" = "2" ]]
+    [[ "$(jq -r '.a3.offset' "${TMP_ROOT}/.worktrees.json")" = "3" ]]
+}
+
+@test "removing a worktree frees its offset for the next add" {
+    skip "wt_state_remove is not exposed via a non-interactive worktree-remove path; covered indirectly by prune.bats"
+}
+
+# --- existing branch (no -b) ------------------------------------------------
+
+@test "add <existing-branch> (no -b) checks out the existing branch into a new worktree" {
+    # Make an existing branch on the primary, then ask worktree-add to check
+    # it out into a new dir.
+    git -C "${TMP_ROOT}" branch existing-feat master
+    run_add existing-feat
+    assert_success
+    local wt_dir="${TMP_PARENT}/openemr-wt-existing-feat"
+    [[ -d "${wt_dir}" ]]
+    # State entry written with offset 1.
+    [[ "$(jq -r '."existing-feat".offset' "${TMP_ROOT}/.worktrees.json")" = "1" ]]
+    # Checkout is on existing-feat, not master.
+    local wt_head_branch
+    wt_head_branch=$(git -C "${wt_dir}" symbolic-ref --short HEAD)
+    [[ "${wt_head_branch}" = "existing-feat" ]]
+}
+
+# --- duplicate branch -------------------------------------------------------
+
+@test "second add of an already-registered branch fails with an explicit message" {
+    run_add dup-branch -b ; assert_success
+    run_add dup-branch -b
+    assert_failure
+    assert_output --partial "Worktree for 'dup-branch' already exists"
+}
+
+# --- --start triggers compose up against the right project ------------------
+
+@test "add -b --start runs 'docker compose ... -p openemr-<slug> ... up -d'" {
+    run_add start-me -b --start
+    assert_success
+    # The stub records every docker invocation to docker.log; assert the
+    # compose-up invocation went out with the branch-scoped project name and
+    # the worktree's override file.
+    local log="${STUB_DIR}/docker.log"
+    [[ -f "${log}" ]]
+    # `-e` so the `-p` in the pattern isn't parsed as a grep flag.
+    grep -F -e "-p openemr-start-me" "${log}" | grep -F -e "up -d" \
+        || { echo "--- docker.log contents ---"; cat "${log}"; fail "expected compose-up invocation not found"; }
+}
+
+# --- primary HEAD invariant -------------------------------------------------
+
+@test "primary repo's HEAD is unchanged after a successful add" {
+    local head_before head_after
+    head_before=$(git -C "${TMP_ROOT}" rev-parse HEAD)
+    run_add invariant-x -b
+    assert_success
+    head_after=$(git -C "${TMP_ROOT}" rev-parse HEAD)
+    [[ "${head_before}" = "${head_after}" ]] || \
+        fail "HEAD moved: ${head_before} -> ${head_after}"
+}
+
+# --- branch-slugging ROUNDTRIP ----------------------------------------------
+
+@test "branch with slashes slugifies into dir + override volume names consistently" {
+    run_add feature/foo-bar -b
+    assert_success
+    local wt_dir="${TMP_PARENT}/openemr-wt-feature-foo-bar"
+    [[ -d "${wt_dir}" ]]
+    grep -q "name: openemr-feature-foo-bar_db" \
+        "${wt_dir}/docker/development-easy/docker-compose.override.yml"
+    # State key is the branch as-passed, NOT the slug.
+    [[ "$(jq -r '."feature/foo-bar".dir' "${TMP_ROOT}/.worktrees.json")" = "${wt_dir}" ]]
+}


### PR DESCRIPTION
First slice of the regression-coverage roadmap discussed under #814 / #815 (the "Tier 1" tier: extend bats with deeper docker/git stubs to verify cmd_worktree_add's full create flow without touching real containers).

## Summary

Existing tests for `openemr-cmd worktree` cover pure helpers, state file hygiene, list/prune/remove edge cases, and `--base` argument parsing + ref resolution. They did not cover the **side-effect surface of a successful `cmd_worktree_add`** — the place where most real-world regressions would land. This PR adds 11 integration tests asserting:

- Registered git worktree directory under `WORKTREE_PARENT`
- New branch (or checked-out existing branch) pointing at the correct SHA
- `.worktrees.json` state entry with the right `offset` / `dir` / `env`
- Per-env compose `.env` file containing the right `WT_*` port variables
- `docker-compose.override.yml` with branch-scoped volume names
- Port-offset uniqueness across consecutive `add`s
- `--start` invokes `docker compose ... -p openemr-<slug> ... up -d`
- Primary repo's `HEAD` is untouched after a successful add
- Branch-name slugification roundtrips through dir name + override volume names

Per-env routing is also exercised: `--env easy-redis` lands in `docker/development-easy-redis/` with `WT_REDIS_PORT` + branch-scoped redis `container_name` overrides; `--env easy-light` skips selenium/couchdb/mailpit/redis port variables.

## Hermetic — no network, no real docker

Canonical fetch is redirected to a `file://` URL pointing at the test's tmp git repo via `WT_CANONICAL_URL`, so the default `-b` path stays inside the fixture. Docker is stubbed via `oc_make_docker_stub_dir` which now also records every invocation to `${stub_dir}/docker.log` so the `--start` test can assert on the exact compose invocation the script made.

## Helper additions

- **`oc_make_docker_stub_dir`** — same backward-compatible behavior (`docker compose` probe returns 0) but now logs every invocation to `${stub_dir}/docker.log`. Tests that don't read the log are unaffected.
- **`oc_init_repo_with_fixtures`** — builds on `oc_init_repo`; commits `docker/development-{easy,easy-light,easy-redis}/docker-compose.yml` + `docker/library/` so any subsequent `git worktree add ... master` checkout has the layout `cmd_worktree_add` needs.

## Local results

- `bats tests/bats/openemr-cmd/` — **71 ok, 0 failures** (11 new, 60 existing)
- ShellCheck — clean

## Files

- `tests/bats/openemr-cmd/helpers.bash` — two helper additions described above
- `tests/bats/openemr-cmd/worktree_add_integration.bats` — 11 new tests

## Roadmap context

This is **Tier 1**. Future slices when needed:

- Tier 2 — separate CI workflow that runs `worktree add --start` against a real openemr image, verifies the stack actually comes up, runs a trivial command via `worktree exec`, tears down. Slow (~3-5 min per scenario), catches things stubs can't. Run on push to master only.
- Tier 3 — golden-file tests for `.env` / `docker-compose.override.yml` / `.worktrees.json` shape. Cheap, useful if those artifact shapes become stability commitments for other tooling.

## Test plan

- [x] `bats tests/bats/openemr-cmd/` passes locally (71 ok, 0 failures)
- [x] ShellCheck clean
- [ ] CI: BATS (ubuntu-22.04 + macos-14), ShellCheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suite for the `worktree add` command, validating git worktree creation, branch checkout behavior, configuration updates, environment file generation, docker compose overrides, port offset uniqueness, and duplicate branch prevention scenarios
  * Enhanced test helper infrastructure to log docker invocations for precise assertion of command usage patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->