### PR TITLE
test(openemr-cmd): lifecycle commands, symlink guards, summary URLs

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -55,7 +55,14 @@ oc_make_docker_stub_dir() {
 # 'docker compose' (plugin probe) call must succeed so
 # check_docker_compose_install picks the plugin path; everything else
 # also returns 0. The shim does NOT shell out anywhere.
+#
+# 'docker compose ... ps ...' invocations echo the DOCKER_PS_OUTPUT
+# env var (default: empty) so tests can simulate "stack is up" / "stack
+# is down" without standing up real containers.
 echo "\$@" >> "${log}"
+case " \$* " in
+    *' ps '*) [ -n "\${DOCKER_PS_OUTPUT-}" ] && echo "\${DOCKER_PS_OUTPUT}" ;;
+esac
 if [ "\${1-}" = "compose" ]; then
     exit 0
 fi

--- a/tests/bats/openemr-cmd/worktree_add_integration.bats
+++ b/tests/bats/openemr-cmd/worktree_add_integration.bats
@@ -203,3 +203,47 @@ run_add() {
     # State key is the branch as-passed, NOT the slug.
     [[ "$(jq -r '."feature/foo-bar".dir' "${TMP_ROOT}/.worktrees.json")" = "${wt_dir}" ]]
 }
+
+# --- post-add summary URL rendering -----------------------------------------
+# The script prints HTTP/HTTPS/phpMyAdmin/Mailpit/CouchDB/Redis/MySQL URLs
+# with port = base + offset. Easy to regress (someone bumps a base port and
+# forgets the corresponding echo line); these guard the printed math.
+
+@test "summary lines: easy env at offset 1 prints OpenEMR/phpMyAdmin/Mailpit/CouchDB/MySQL" {
+    run_add summary-easy -b
+    assert_success
+    assert_output --partial "OpenEMR   : https://localhost:9301"
+    assert_output --partial "phpMyAdmin: http://localhost:8311"
+    assert_output --partial "Mailpit   : http://localhost:8026"
+    assert_output --partial "CouchDB   : http://localhost:5985"
+    assert_output --partial "MySQL     : localhost:8321"
+    refute_output --partial "Redis"
+}
+
+@test "summary lines: easy-light at offset 1 omits Mailpit/CouchDB/Redis" {
+    run_add summary-light -b --env easy-light
+    assert_success
+    assert_output --partial "OpenEMR   : https://localhost:9301"
+    assert_output --partial "MySQL     : localhost:8321"
+    refute_output --partial "Mailpit"
+    refute_output --partial "CouchDB"
+    refute_output --partial "Redis"
+}
+
+@test "summary lines: easy-redis at offset 1 includes Redis URL" {
+    run_add summary-redis -b --env easy-redis
+    assert_success
+    assert_output --partial "Redis     : localhost:6380"
+    assert_output --partial "Mailpit   : http://localhost:8026"
+}
+
+# --- --env validation at the cmd level --------------------------------------
+# wt_validate_env alone is covered in helpers_pure.bats; this asserts that
+# `worktree add --env bogus` actually surfaces that validation up through
+# cmd_worktree_add (the dispatcher path that real users invoke).
+
+@test "add --env <bogus>: cmd_worktree_add surfaces wt_validate_env error" {
+    run_add some-branch -b --env totally-not-a-real-env
+    assert_failure
+    assert_output --partial "Invalid env 'totally-not-a-real-env'"
+}

--- a/tests/bats/openemr-cmd/worktree_lifecycle.bats
+++ b/tests/bats/openemr-cmd/worktree_lifecycle.bats
@@ -1,0 +1,182 @@
+# BATS: cmd_worktree_{up,down,start,stop,regen,set-env} compose invocations.
+#
+# Where worktree_add_integration.bats covers the `add` create flow, this
+# file exercises the lifecycle commands that act on an already-added
+# worktree. The recording docker stub captures every `docker compose ...`
+# invocation to ${STUB_DIR}/docker.log; each test asserts the lifecycle
+# command went out with the right project name, env-file, override-file,
+# and trailing action (up -d / down --volumes / start / stop / ...).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    export TMP_PARENT TMP_ROOT STUB_DIR
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Run any openemr-cmd invocation under the hermetic fixture.
+run_oc() {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        DOCKER_PS_OUTPUT="${DOCKER_PS_OUTPUT-}" \
+        "${SCRIPT}" "$@"
+}
+
+# Add a worktree as preconditions for lifecycle tests, then truncate the
+# docker.log so the test sees only the lifecycle command's invocations.
+setup_worktree() {
+    run_oc worktree add "$@"
+    assert_success
+    : > "${STUB_DIR}/docker.log"
+}
+
+# Convenience: extract the compose invocation line (excludes the bare
+# `compose` plugin-probe call).
+compose_call_line() {
+    grep -F -e "compose " "${STUB_DIR}/docker.log" | grep -F -e "-p openemr-" | head -1
+}
+
+# --- up ---------------------------------------------------------------------
+
+@test "up <branch>: runs 'compose ... -p openemr-<slug> ... up -d'" {
+    setup_worktree feature-a -b
+    run_oc worktree up feature-a
+    assert_success
+    local line
+    line=$(compose_call_line)
+    [[ "${line}" == *"compose"*" --env-file "*"/openemr-wt-feature-a/docker/development-easy/.env"* ]]
+    [[ "${line}" == *"-p openemr-feature-a"* ]]
+    [[ "${line}" == *"-f "*"/docker-compose.yml"*"-f "*"/docker-compose.override.yml"* ]]
+    [[ "${line}" == *"up -d" ]]
+}
+
+# --- down (volumes by default; --keep-volumes preserves) --------------------
+
+@test "down <branch> (default): runs 'compose ... down --volumes'" {
+    setup_worktree feature-b -b
+    run_oc worktree down feature-b
+    assert_success
+    local line
+    line=$(compose_call_line)
+    [[ "${line}" == *"-p openemr-feature-b"* ]]
+    [[ "${line}" == *"down --volumes" ]]
+}
+
+@test "down <branch> --keep-volumes: runs 'compose ... down' WITHOUT --volumes" {
+    setup_worktree feature-c -b
+    run_oc worktree down feature-c --keep-volumes
+    assert_success
+    local line
+    line=$(compose_call_line)
+    [[ "${line}" == *"-p openemr-feature-c"* ]]
+    [[ "${line}" == *"down" ]]
+    [[ "${line}" != *"--volumes"* ]] || fail "--keep-volumes should suppress --volumes; saw: ${line}"
+}
+
+# --- start / stop -----------------------------------------------------------
+
+@test "start <branch>: runs 'compose ... start' (no -d, no --volumes)" {
+    setup_worktree feature-d -b
+    run_oc worktree start feature-d
+    assert_success
+    local line
+    line=$(compose_call_line)
+    [[ "${line}" == *"-p openemr-feature-d"* ]]
+    [[ "${line}" == *" start" ]] || fail "expected trailing 'start'; saw: ${line}"
+    [[ "${line}" != *"up -d"* ]] || fail "start should not invoke 'up -d'"
+}
+
+@test "stop <branch>: runs 'compose ... stop'" {
+    setup_worktree feature-e -b
+    run_oc worktree stop feature-e
+    assert_success
+    local line
+    line=$(compose_call_line)
+    [[ "${line}" == *"-p openemr-feature-e"* ]]
+    [[ "${line}" == *" stop" ]]
+    [[ "${line}" != *"down"* ]] || fail "stop should not invoke 'down'"
+}
+
+# --- regen (no docker call, just rewrites compose files) --------------------
+
+@test "regen <branch>: rewrites .env + override; does NOT call docker compose" {
+    setup_worktree feature-f -b
+    local envf="${TMP_PARENT}/openemr-wt-feature-f/docker/development-easy/.env"
+    local ovf="${TMP_PARENT}/openemr-wt-feature-f/docker/development-easy/docker-compose.override.yml"
+
+    # Tamper with both files so we can prove they were rewritten.
+    echo "# tampered" > "${envf}"
+    echo "# tampered" > "${ovf}"
+
+    run_oc worktree regen feature-f
+    assert_success
+    grep -qE "^WT_NAME=feature-f$" "${envf}"
+    grep -q "name: openemr-feature-f_db" "${ovf}"
+
+    # No `compose` invocation should appear in the log for regen (only the
+    # plugin-probe `compose` line, which has no further args).
+    ! grep -F -e "compose " "${STUB_DIR}/docker.log" | grep -F -e "-p openemr-" \
+        || fail "regen should not call 'docker compose -p ...'"
+}
+
+# --- set-env ----------------------------------------------------------------
+
+@test "set-env: refuses with explicit error when the stack is still up" {
+    setup_worktree feature-g -b
+    # Simulate `compose ps -aq` returning a non-empty container list.
+    DOCKER_PS_OUTPUT="dummycontainerid" run_oc worktree set-env feature-g easy-redis
+    assert_failure
+    assert_output --partial "Stack must be down before switching env"
+    # State entry's env did NOT change.
+    [[ "$(jq -r '."feature-g".env' "${TMP_ROOT}/.worktrees.json")" = "easy" ]]
+}
+
+@test "set-env: when stack is down, rewrites state + .env + override for the new env" {
+    setup_worktree feature-h -b
+    # DOCKER_PS_OUTPUT empty (default) -> stack appears down -> proceed.
+    run_oc worktree set-env feature-h easy-redis
+    assert_success
+
+    # State entry's env field updated.
+    [[ "$(jq -r '."feature-h".env' "${TMP_ROOT}/.worktrees.json")" = "easy-redis" ]]
+
+    # New env's .env + override files exist with redis bits.
+    local new_envf="${TMP_PARENT}/openemr-wt-feature-h/docker/development-easy-redis/.env"
+    local new_ovf="${TMP_PARENT}/openemr-wt-feature-h/docker/development-easy-redis/docker-compose.override.yml"
+    [[ -f "${new_envf}" ]]
+    grep -qE "^WT_REDIS_PORT=" "${new_envf}"
+    grep -q "container_name: openemr-feature-h-redis-master" "${new_ovf}"
+}
+
+@test "set-env: no-op when the target env equals the current env" {
+    setup_worktree feature-i -b
+    run_oc worktree set-env feature-i easy
+    assert_success
+    assert_output --partial "already on env 'easy'"
+}
+
+@test "set-env: refuses an invalid env name with the validate-env message" {
+    setup_worktree feature-j -b
+    run_oc worktree set-env feature-j bogus-env-name
+    assert_failure
+    assert_output --partial "Invalid env 'bogus-env-name'"
+    # State unchanged.
+    [[ "$(jq -r '."feature-j".env' "${TMP_ROOT}/.worktrees.json")" = "easy" ]]
+}

--- a/tests/bats/openemr-cmd/worktree_symlink_guards.bats
+++ b/tests/bats/openemr-cmd/worktree_symlink_guards.bats
@@ -1,0 +1,117 @@
+# BATS: cmd_worktree_add symlink-attack guards.
+#
+# openemr-cmd refuses to add a worktree (or carries an additional refusal
+# inside wt_write_override) when the base commit being checked out contains
+# symlinks that could escape the worktree root — docker/, docker/<env>/,
+# docker/library/. These guards exist because a malicious branch could
+# commit one of those as a symlink to a host path, and once docker compose
+# resolves the override file's bind-mount sources via that symlink the
+# container would mount arbitrary host content.
+#
+# Each test below commits the malicious shape onto the fixture repo's
+# master commit, then verifies that:
+#   - the add invocation fails with an explicit "Refusing" message,
+#   - the cleanup behavior matches the script's contract (early-stage
+#     guards in cmd_worktree_add force-remove the partial worktree;
+#     guards inside wt_write_override leave the worktree on disk for
+#     manual inspection).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    # Symlinks should be committed and recreated on checkout (the default
+    # on Unix, but pin it so the test is robust to inherited config).
+    git -C "${TMP_ROOT}" config core.symlinks true
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    export TMP_PARENT TMP_ROOT STUB_DIR
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+run_oc() {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" "$@"
+}
+
+# Commit a malicious shape onto a side branch (not master): <target_path>
+# (relative to TMP_ROOT) becomes a symlink to <symlink_dest> on <side_branch>.
+# Primary's master is left untouched so the pre-checkout existence checks in
+# cmd_worktree_add (which look at OPENEMR_ROOT/<compose_subdir>) still pass.
+# Tests then base off <side_branch> so the new worktree's checkout contains
+# the symlink, which is what triggers the in-checkout symlink guards.
+commit_path_as_symlink_on_branch() {
+    local side_branch=$1 target=$2 dest=$3
+    git -C "${TMP_ROOT}" checkout --quiet -b "${side_branch}"
+    git -C "${TMP_ROOT}" rm -rf "${target}" > /dev/null
+    ln -s "${dest}" "${TMP_ROOT}/${target}"
+    git -C "${TMP_ROOT}" add "${target}"
+    git -C "${TMP_ROOT}" commit --quiet -m "fixture (${side_branch}): ${target} -> ${dest} symlink"
+    git -C "${TMP_ROOT}" checkout --quiet master
+}
+
+# --- early-stage guards in cmd_worktree_add (force-remove on detection) ----
+
+@test "add: refuses + force-removes the worktree when docker/ is a symlink in the checkout" {
+    commit_path_as_symlink_on_branch evil-docker-src docker /tmp/elsewhere-docker
+    run_oc worktree add evil-docker -b --base evil-docker-src
+    assert_failure
+    assert_output --partial "Refusing"
+    assert_output --partial "docker"
+    assert_output --partial "is a symlink in the checked-out branch"
+    [[ ! -d "${TMP_PARENT}/openemr-wt-evil-docker" ]] \
+        || fail "early-stage guard should have force-removed the worktree dir"
+    ! jq -e '."evil-docker"' "${TMP_ROOT}/.worktrees.json" >/dev/null 2>&1 \
+        || fail "state entry should not have been written"
+}
+
+@test "add: refuses + force-removes when docker/development-easy/ is a symlink in the checkout" {
+    commit_path_as_symlink_on_branch evil-easy-src docker/development-easy /tmp/elsewhere-easy
+    run_oc worktree add evil-easy -b --base evil-easy-src
+    assert_failure
+    assert_output --partial "Refusing"
+    assert_output --partial "docker/development-easy"
+    assert_output --partial "is a symlink in the checked-out branch"
+    [[ ! -d "${TMP_PARENT}/openemr-wt-evil-easy" ]] \
+        || fail "early-stage guard should have force-removed the worktree dir"
+    ! jq -e '."evil-easy"' "${TMP_ROOT}/.worktrees.json" >/dev/null 2>&1 \
+        || fail "state entry should not have been written"
+}
+
+# --- defense-in-depth guard inside wt_write_override ------------------------
+
+@test "add: refuses (no auto-cleanup) when docker/library/ is a symlink in the checkout" {
+    # Replace docker/library (a real dir in the fixture) with a symlink on
+    # a side branch. wt_write_override's check fires AFTER mkdir + the
+    # early-stage guards, so per the script's contract the partial worktree
+    # is left in place for the user to inspect / remove manually.
+    commit_path_as_symlink_on_branch evil-lib-src docker/library /tmp/elsewhere-lib
+    run_oc worktree add evil-lib -b --base evil-lib-src
+    assert_failure
+    assert_output --partial "Refusing"
+    assert_output --partial "docker/library"
+    assert_output --partial "is a symlink"
+    # State entry NOT written (wt_state_set comes after wt_write_override).
+    ! jq -e '."evil-lib"' "${TMP_ROOT}/.worktrees.json" >/dev/null 2>&1 \
+        || fail "state entry should not exist (wt_state_set runs after wt_write_override)"
+    # Worktree dir is intentionally LEFT on disk — wt_write_override has
+    # no force-remove. This asserts on that contract so a future refactor
+    # that adds cleanup here would update this test deliberately.
+    [[ -d "${TMP_PARENT}/openemr-wt-evil-lib" ]] \
+        || fail "wt_write_override symlink guard should NOT auto-remove the worktree dir"
+}


### PR DESCRIPTION
Three additional slices of low-cost bats coverage on top of #816 so the zero-real-docker test surface tracks more of the script's behavior. Same hermetic pattern as `worktree_add_integration.bats`: tmp git repo, recording docker stub, `file://` canonical URL.

## What's covered

### Slice A — lifecycle commands (`worktree_lifecycle.bats`, 10 tests)

Asserts every `cmd_worktree_{up,down,start,stop,regen,set-env}` invocation goes out as the right `docker compose ... -p openemr-<slug> ...` call.

| Command | Asserts |
|---|---|
| `up` | `up -d` against the worktree's override file |
| `down` (default) | `down --volumes` |
| `down --keep-volumes` | `down` *without* `--volumes` |
| `start` / `stop` | lighter pause/resume (no `-d`, no `--volumes`) |
| `regen` | rewrites `.env` + override; does NOT call docker compose |
| `set-env` (stack up) | refuses with "Stack must be down" (simulated via `DOCKER_PS_OUTPUT`) |
| `set-env` (stack down) | rewrites state + env + override for the new env |
| `set-env` (same env) | no-op with "already on env" message |
| `set-env` (bogus env) | refuses with `wt_validate_env` error |

### Slice B — symlink-attack guards (`worktree_symlink_guards.bats`, 3 tests)

Verifies `cmd_worktree_add` refuses to proceed (with the right cleanup behavior) when the base commit being checked out contains symlinks that could escape the worktree root. Tests commit the malicious shape onto a side branch (leaving master clean so the pre-checkout dir-exists check passes) and base off that branch:

| Shape | Asserts |
|---|---|
| `docker/` is a symlink in checkout | early-stage guard fires; partial worktree dir force-removed |
| `docker/development-<env>/` is a symlink | same shape |
| `docker/library/` is a symlink | `wt_write_override` guard fires; per contract the partial worktree is LEFT on disk for manual inspection |

### Slice C — additions to `worktree_add_integration.bats` (4 tests)

- Summary URLs render correctly per env (`easy` / `easy-light` / `easy-redis`) — catches regressions if a base port is bumped without updating the corresponding `echo` line.
- `--env <bogus>` at the `cmd_worktree_add` level surfaces `wt_validate_env`'s error (helpers_pure.bats already covers `wt_validate_env` in isolation).

## Helper additions

- `oc_make_docker_stub_dir` — the recording stub now echoes `${DOCKER_PS_OUTPUT}` on `... ps ...` invocations (default: empty), so tests can simulate "stack is up" without standing up real containers. Backward-compatible — tests that don't set `DOCKER_PS_OUTPUT` see empty output, same as before.

## Local results

- `bats tests/bats/openemr-cmd/` — **88 ok, 0 failures** (17 new, 71 existing). Up from the 71/0 baseline after #816.
- ShellCheck — clean

## What's left for future PRs

- Tier 2 (real-docker e2e in a separate CI workflow) — when warranted
- `cmd_worktree_exec` container-resolution test (needs a smarter docker stub for `docker ps --filter label=...`)
- Primary `.git` is a symlink — hard to set up in isolation; defense-in-depth check
- Path-traversal guard via `realpath` — only triggers when symlinks earlier in the chain already exist, which the symlink guards above catch first

## Test plan

- [x] `bats tests/bats/openemr-cmd/` passes locally (88 ok, 0 failures)
- [x] ShellCheck clean
- [ ] CI: BATS (ubuntu-22.04 + macos-14), ShellCheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)