### PR TITLE
test(openemr-cmd): broaden worktree bats coverage; small fixes uncovered along the way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .vscode
 .idea
 /.task/
+
+# bats helper libraries — fetched at test time (CI workflow clones them
+# fresh; locally they are cloned into tests/bats/test_helper/ on demand)
+/tests/bats/test_helper/

--- a/tests/bats/openemr-cmd/branch_name_edges.bats
+++ b/tests/bats/openemr-cmd/branch_name_edges.bats
@@ -1,0 +1,131 @@
+# BATS: branch-name edge cases for `worktree add`.
+#
+# wt_slug strips everything outside [a-zA-Z0-9_-] and lowercases, so
+# distinct branch names can collide on the same slug (e.g. "foo/bar"
+# and "foo-bar" both → "foo-bar"). The Docker project name uses the
+# slug, so a collision means two stacks competing for the same project
+# name → port conflicts and clobbered state.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# --- slug collisions --------------------------------------------------------
+
+@test "branch-name: 'foo/bar' and 'foo-bar' slugify to the same value (worktree dir collision)" {
+    run oc_run_add foo/bar -b --env easy
+    assert_success
+    run oc_run_add foo-bar -b --env easy
+    # Second add must fail — same on-disk dir, same docker project name.
+    # git worktree add will surface either "already exists" or "already used".
+    assert_failure
+    if ! ( echo "${output}" | grep -Eq "already (exists|used by worktree|checked out)" ); then
+        echo "${output}"
+        fail "expected git's already-exists/used error on slug collision"
+    fi
+    # Only the first slug-owner is in state.
+    [[ "$(jq -r 'has("foo/bar")' "${STATE_FILE}")" = "true" ]] || fail "first entry missing"
+    [[ "$(jq -r 'has("foo-bar")' "${STATE_FILE}")" = "false" ]] || fail "second entry was written despite collision"
+}
+
+# --- empty slug -------------------------------------------------------------
+
+@test "branch-name: name that slugifies to empty (e.g. '!!!') is refused with a clear error" {
+    # wt_slug strips all non-[a-zA-Z0-9_-] chars and lowercases. "!!!" → "".
+    # An empty slug would produce a worktree dir of "openemr-wt-" (trailing
+    # dash) and a docker project of "openemr-" — both ambiguous. The script
+    # refuses early with a clear message.
+    run oc_run_add '!!!' -b --env easy
+    assert_failure
+    assert_output --partial "contains no slug-safe characters"
+    # No half-built state.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("!!!")' "${STATE_FILE}")" = "false" ]] || fail "empty-slug branch was written to state"
+    fi
+    # No half-built worktree dir.
+    [[ ! -e "${TMP_PARENT}/openemr-wt-" ]] || fail "empty-slug dir was created"
+}
+
+# --- branch name with leading dash (must not be parsed as a flag) ----------
+
+@test "branch-name: leading-dash branch name is treated as a branch, not a flag" {
+    # Our CLI parser sees '-foo' as an unknown option. Real defensive call
+    # would use '--' to terminate options, but the script doesn't support
+    # '--'; pin the current refusal so a parser regression doesn't silently
+    # add a flag named '-foo'.
+    run oc_run_add -foo-leading -b --env easy
+    assert_failure
+    assert_output --partial "Unknown option"
+}
+
+# --- branch name that is also a git reserved/special token -----------------
+
+@test "branch-name: 'HEAD' is rejected by git (cannot create as a branch)" {
+    run oc_run_add HEAD -b --env easy
+    assert_failure
+    # git refuses with one of several messages depending on version.
+    # We just assert we didn't silently write a HEAD entry.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("HEAD")' "${STATE_FILE}")" = "false" ]] \
+            || fail "HEAD was written to state despite git rejecting it"
+    fi
+}
+
+# --- very long branch name --------------------------------------------------
+
+@test "branch-name: very long branch (200 chars) produces a long-but-valid slug and entry" {
+    # Linux/macOS dir name limits are 255 bytes — 200 char branch → 200 char
+    # slug → openemr-wt-<200-char-slug> = 211 chars → under limit.
+    local longbranch
+    longbranch=$(printf 'b%.0s' {1..200})  # 200 'b's
+    run oc_run_add "${longbranch}" -b --env easy
+    assert_success
+    [[ "$(jq -r --arg b "${longbranch}" 'has($b)' "${STATE_FILE}")" = "true" ]] \
+        || fail "long-branch entry missing"
+    [[ -d "${TMP_PARENT}/openemr-wt-${longbranch}" ]] || fail "long-branch worktree dir missing"
+}
+
+# --- unicode chars stripped from slug --------------------------------------
+
+@test "branch-name: unicode chars are stripped from slug (predictable docker project name)" {
+    # 'feature-Ä' → branch stays 'feature-Ä' in git, slug becomes 'feature-'.
+    # Add should succeed (git accepts unicode branches) and the on-disk
+    # dir reflects the stripped slug.
+    run oc_run_add 'feature-Ä' -b --env easy
+    assert_success
+    [[ "$(jq -r '."feature-Ä"' "${STATE_FILE}")" != "null" ]] \
+        || fail "unicode branch entry missing"
+    # Dir uses the stripped slug.
+    [[ -d "${TMP_PARENT}/openemr-wt-feature-" ]] || {
+        ls "${TMP_PARENT}/"
+        fail "expected slug 'feature-' on disk"
+    }
+}

--- a/tests/bats/openemr-cmd/docker_failure_propagation.bats
+++ b/tests/bats/openemr-cmd/docker_failure_propagation.bats
@@ -1,0 +1,124 @@
+# BATS: docker compose failures propagate (no silent swallowing).
+#
+# The script runs under `set -euo pipefail`. docker compose invocations
+# in cmd_worktree_up/down/remove are wrapped with 2>/dev/null in some
+# spots but NEVER `|| true`, so a non-zero exit must abort the
+# operation. These tests pin that contract: if docker fails, the user
+# sees the failure (non-zero exit code) and state is not silently
+# advanced past the failure point.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+# Variant docker stub: respond to the 'compose' plugin probe with success
+# (so check_docker_compose_install picks the plugin path) but fail every
+# subsequent 'compose ...' subcommand with exit 7.
+oc_make_docker_failing_stub_dir() {
+    local d log
+    d=$(oc_mktempdir)
+    log="${d}/docker.log"
+    : > "${log}"
+    cat > "${d}/docker" <<STUB
+#!/bin/sh
+echo "\$@" >> "${log}"
+# Plugin probe: 'docker compose' (no further args) must succeed so
+# check_docker_compose_install detects the plugin path.
+if [ "\$#" = "1" ] && [ "\$1" = "compose" ]; then
+    exit 0
+fi
+# Any subsequent compose subcommand (up/down/ps/etc.) fails with code 7.
+case " \$* " in
+    *' compose '*) exit 7 ;;
+esac
+# Non-compose invocations succeed (no current ones, but be defensive).
+exit 0
+STUB
+    chmod +x "${d}/docker"
+    echo "${d}"
+}
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_OK_DIR=$(oc_make_docker_stub_dir)
+    STUB_FAIL_DIR=$(oc_make_docker_failing_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_OK_DIR STUB_FAIL_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_OK_DIR:-}" ]] && rm -rf "${STUB_OK_DIR}"
+    [[ -n "${STUB_FAIL_DIR:-}" ]] && rm -rf "${STUB_FAIL_DIR}"
+    return 0
+}
+
+# Add a worktree (with the OK stub) so the FAIL-stub tests have a target.
+fixture_add() {
+    local branch=$1 env=${2:-easy}
+    env \
+        PATH="${STUB_OK_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add "${branch}" -b --env "${env}" >/dev/null 2>&1
+}
+
+# --- worktree up: docker compose up fails -----------------------------------
+
+@test "docker failure: 'worktree up' surfaces non-zero exit when docker compose up fails" {
+    fixture_add up-fail-branch
+    run env \
+        PATH="${STUB_FAIL_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree up up-fail-branch
+    assert_failure
+    # State entry still present — `up` does not mutate state.
+    [[ "$(jq -r 'has("up-fail-branch")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry disappeared on failed up"
+}
+
+# --- worktree down: docker compose down fails -------------------------------
+
+@test "docker failure: 'worktree down' surfaces non-zero exit when docker compose down fails" {
+    fixture_add down-fail-branch
+    run env \
+        PATH="${STUB_FAIL_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree down down-fail-branch
+    assert_failure
+    [[ "$(jq -r 'has("down-fail-branch")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry disappeared on failed down"
+}
+
+# --- worktree remove: docker compose down fails -----------------------------
+# 'remove' wraps compose down with 2>/dev/null. set -e still propagates the
+# exit code. State entry must remain intact so the user can retry once they
+# resolve the docker issue.
+
+@test "docker failure: 'worktree remove' aborts on compose down failure; state + dir preserved for retry" {
+    fixture_add rm-fail-branch
+    local wt_dir="${TMP_PARENT}/openemr-wt-rm-fail-branch"
+    [[ -d "${wt_dir}" ]] || fail "fixture worktree dir not created"
+    run bash -c "printf 'y\n' | env \
+        PATH='${STUB_FAIL_DIR}:${PATH}' \
+        OPENEMR_ROOT='${TMP_ROOT}' \
+        WORKTREE_PARENT='${TMP_PARENT}' \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        '${SCRIPT}' worktree remove rm-fail-branch --keep-volumes"
+    assert_failure
+    # State entry preserved.
+    [[ "$(jq -r 'has("rm-fail-branch")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry was removed despite docker failure"
+    # Worktree dir preserved.
+    [[ -d "${wt_dir}" ]] || fail "worktree dir was removed despite docker failure"
+    # Lockfile cleaned up by the EXIT trap.
+    [[ ! -e "${STATE_FILE}.lock" ]] || fail "lockfile lingering after failed remove"
+}

--- a/tests/bats/openemr-cmd/exec_and_existing_edges.bats
+++ b/tests/bats/openemr-cmd/exec_and_existing_edges.bats
@@ -1,0 +1,105 @@
+# BATS: existing-state edges + `worktree exec` argument-shape tests.
+#
+# Covered:
+#   - re-add of an existing branch refuses (no double-write)
+#   - exec with no args / missing cmd surfaces usage
+#   - exec for an unknown branch surfaces "No worktree found"
+#   - exec when the container isn't running surfaces a clear hint
+#   - down/stop for an unknown branch surface "No worktree found"
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" "$@"
+}
+
+# --- existing state edges ---------------------------------------------------
+
+@test "existing state: re-add of an already-tracked branch refuses with clear error" {
+    oc_run worktree add dup-branch -b --env easy >/dev/null
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run worktree add dup-branch -b --env easy
+    assert_failure
+    assert_output --partial "already exists"
+    # State unchanged — no clobber of the original entry.
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "state file mutated by failed re-add"
+}
+
+@test "existing state: 'down' for unknown branch fails with state lookup error" {
+    # No state file at all yet → "No worktrees found".
+    run oc_run worktree down ghost-branch
+    assert_failure
+    assert_output --partial "No worktrees found"
+}
+
+@test "existing state: 'stop' for unknown branch (state file exists but entry missing) fails cleanly" {
+    # Seed an empty-but-valid state file.
+    echo '{}' > "${STATE_FILE}"
+    run oc_run worktree stop ghost-branch
+    assert_failure
+    # wt_compose_cmd's wt_state_get returns "" → wt_die "No worktree found for branch 'ghost-branch'"
+    assert_output --partial "No worktree found for branch 'ghost-branch'"
+}
+
+# --- exec argument-shape edges ---------------------------------------------
+
+@test "exec: no args at all surfaces usage" {
+    echo '{}' > "${STATE_FILE}"
+    run oc_run worktree exec
+    assert_failure
+    assert_output --partial "Usage:"
+    assert_output --partial "worktree exec"
+}
+
+@test "exec: branch supplied but no command surfaces usage" {
+    echo '{}' > "${STATE_FILE}"
+    run oc_run worktree exec some-branch
+    assert_failure
+    assert_output --partial "Usage:"
+    assert_output --partial "worktree exec"
+}
+
+@test "exec: unknown branch surfaces 'No worktree found'" {
+    echo '{}' > "${STATE_FILE}"
+    run oc_run worktree exec ghost-branch some-subcommand
+    assert_failure
+    assert_output --partial "No worktree found for branch 'ghost-branch'"
+}
+
+@test "exec: branch exists but no container running surfaces clear hint" {
+    # Add a worktree so the branch is in state, then exec when container
+    # discovery returns nothing (DOCKER_PS_OUTPUT default = empty).
+    oc_run worktree add no-container -b --env easy >/dev/null
+    run oc_run worktree exec no-container some-subcommand
+    assert_failure
+    assert_output --partial "OpenEMR container is not running for worktree 'no-container'"
+    # Hint mentions 'worktree up' as the next step.
+    assert_output --partial "worktree up no-container"
+}

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -79,7 +79,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1712
+OC_SCRIPT_FUNCS_END=1715
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -79,7 +79,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1687
+OC_SCRIPT_FUNCS_END=1712
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/lower_value_edges.bats
+++ b/tests/bats/openemr-cmd/lower_value_edges.bats
@@ -1,0 +1,125 @@
+# BATS: lower-value edges — offset gap-filling, set-env no-op + invalid env,
+# and WT_STATE_LOCK_TIMEOUT_S=0 fail-fast.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" "$@"
+}
+
+# --- offset gap-filling -----------------------------------------------------
+
+@test "offset: wt_next_offset fills the lowest gap (state has 1,3 → next add gets 2)" {
+    # Seed the state with offsets 1 and 3, leaving 2 as the gap.
+    cat > "${STATE_FILE}" <<JSON
+{
+  "alpha": {"offset": 1, "dir": "${TMP_PARENT}/openemr-wt-alpha", "env": "easy"},
+  "gamma": {"offset": 3, "dir": "${TMP_PARENT}/openemr-wt-gamma", "env": "easy"}
+}
+JSON
+    # Pre-create the registered worktrees so wt_validate_dir would pass if
+    # something walked them (add doesn't validate existing entries; this is
+    # just defensive setup).
+    git -C "${TMP_ROOT}" worktree add --quiet -b alpha "${TMP_PARENT}/openemr-wt-alpha" >/dev/null
+    git -C "${TMP_ROOT}" worktree add --quiet -b gamma "${TMP_PARENT}/openemr-wt-gamma" >/dev/null
+
+    oc_run worktree add beta -b --env easy >/dev/null
+    local beta_offset
+    beta_offset=$(jq -r '.beta.offset' "${STATE_FILE}")
+    [[ "${beta_offset}" = "2" ]] || fail "expected next offset 2 (filling the gap), got '${beta_offset}'"
+}
+
+@test "offset: wt_next_offset returns 1 on an empty state" {
+    echo '{}' > "${STATE_FILE}"
+    oc_run worktree add solo -b --env easy >/dev/null
+    [[ "$(jq -r '.solo.offset' "${STATE_FILE}")" = "1" ]] || fail "expected first offset 1"
+}
+
+@test "offset: wt_next_offset returns N+1 when no gap (state has 1,2,3)" {
+    cat > "${STATE_FILE}" <<JSON
+{
+  "a": {"offset": 1, "dir": "${TMP_PARENT}/openemr-wt-a", "env": "easy"},
+  "b": {"offset": 2, "dir": "${TMP_PARENT}/openemr-wt-b", "env": "easy"},
+  "c": {"offset": 3, "dir": "${TMP_PARENT}/openemr-wt-c", "env": "easy"}
+}
+JSON
+    git -C "${TMP_ROOT}" worktree add --quiet -b a "${TMP_PARENT}/openemr-wt-a" >/dev/null
+    git -C "${TMP_ROOT}" worktree add --quiet -b b "${TMP_PARENT}/openemr-wt-b" >/dev/null
+    git -C "${TMP_ROOT}" worktree add --quiet -b c "${TMP_PARENT}/openemr-wt-c" >/dev/null
+
+    oc_run worktree add d -b --env easy >/dev/null
+    [[ "$(jq -r '.d.offset' "${STATE_FILE}")" = "4" ]] || fail "expected offset 4"
+}
+
+# --- set-env no-op / invalid env -------------------------------------------
+
+@test "set-env: target env is the same as current env → no-op with informational message" {
+    oc_run worktree add already-easy -b --env easy >/dev/null
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run worktree set-env already-easy easy
+    assert_success
+    assert_output --partial "already on env 'easy'"
+    # State unchanged.
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "state mutated by no-op set-env"
+}
+
+@test "set-env: invalid env name surfaces wt_validate_env error" {
+    oc_run worktree add valid-branch -b --env easy >/dev/null
+    run oc_run worktree set-env valid-branch nonsense-env
+    assert_failure
+    assert_output --partial "Invalid env"
+    # State still says 'easy'.
+    [[ "$(jq -r '."valid-branch".env' "${STATE_FILE}")" = "easy" ]] \
+        || fail "state env field mutated despite invalid input"
+}
+
+# --- WT_STATE_LOCK_TIMEOUT_S=0 fail-fast -----------------------------------
+
+@test "lock-timeout=0: a held lock causes immediate fail (no spin)" {
+    # Hold the lock externally; ask for timeout=0 so the script must
+    # fail-fast on the very first attempt.
+    local lockfile="${STATE_FILE}.lock"
+    echo 99999 > "${lockfile}"
+    # Use `time` to bound the call — should return in well under a second.
+    local start_s end_s elapsed
+    start_s=$(date +%s)
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=0 \
+        "${SCRIPT}" worktree prune
+    end_s=$(date +%s)
+    elapsed=$((end_s - start_s))
+    assert_failure
+    assert_output --partial "Timed out waiting for state lock"
+    (( elapsed <= 2 )) || fail "expected fail-fast under 2s, took ${elapsed}s"
+    rm -f "${lockfile}"
+}

--- a/tests/bats/openemr-cmd/prune.bats
+++ b/tests/bats/openemr-cmd/prune.bats
@@ -181,3 +181,59 @@ JSON
     assert_success
     assert_output "true"
 }
+
+# --- state-lock integration -------------------------------------------------
+# prune mutates state and must hold the state lock for the iterate+remove
+# critical section so a concurrent `add` between our state read and our
+# wt_state_remove can't have its in-flight entry pruned away as "stale"
+# (its dir might not yet exist on disk, failing wt_validate_dir_safe).
+# --dry-run is read-only and stays unlocked.
+
+@test "prune acquires the state lock (blocked while held externally; times out)" {
+    # Hold the lock externally by writing the lockfile manually.
+    local lockfile="${STATE_FILE}.lock"
+    echo 99999 > "${lockfile}"
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/stale": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist", "env": "easy"}
+}
+JSON
+    # Short timeout so the test is fast; assert the timeout error.
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        "$SCRIPT" worktree prune
+    assert_failure
+    assert_output --partial "Timed out waiting for state lock"
+    # State unchanged — prune never got past the acquire.
+    run jq -r 'has("feature/stale")' "${STATE_FILE}"
+    assert_output "true"
+    rm -f "${lockfile}"
+}
+
+@test "prune --dry-run does NOT acquire the lock (runs even when lock is held)" {
+    # Read-only path; expected to bypass lock entirely.
+    local lockfile="${STATE_FILE}.lock"
+    echo 99999 > "${lockfile}"
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/stale": {"offset": 1, "dir": "${TMP_WT_PARENT}/does-not-exist", "env": "easy"}
+}
+JSON
+    # Should complete WITHOUT timing out (very short timeout to prove it).
+    run env \
+        PATH="${STUB_DIR}:$PATH" \
+        OPENEMR_ROOT="${TMP_OPENEMR_ROOT}" \
+        WORKTREE_PARENT="${TMP_WT_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        "$SCRIPT" worktree prune --dry-run
+    assert_success
+    assert_output --partial "Would prune stale entry:"
+    refute_output --partial "Timed out"
+    # State unchanged (dry-run).
+    run jq -r 'has("feature/stale")' "${STATE_FILE}"
+    assert_output "true"
+    rm -f "${lockfile}"
+}

--- a/tests/bats/openemr-cmd/prune.bats
+++ b/tests/bats/openemr-cmd/prune.bats
@@ -237,3 +237,15 @@ JSON
     assert_output "true"
     rm -f "${lockfile}"
 }
+
+@test "prune releases the lock on the empty-state fast path (no leaked lockfile)" {
+    # Empty state hits the '(no stale entries)' early return inside the
+    # locked section. The lock MUST be released before that return so a
+    # subsequent state op doesn't see a leaked lockfile (the trap-on-exit
+    # is a safety net, not the primary release).
+    echo '{}' > "${STATE_FILE}"
+    oc_run_prune
+    assert_success
+    assert_output --partial "(no stale entries)"
+    [[ ! -e "${STATE_FILE}.lock" ]] || fail "prune leaked the state lockfile on the empty-state path"
+}

--- a/tests/bats/openemr-cmd/state_corruption.bats
+++ b/tests/bats/openemr-cmd/state_corruption.bats
@@ -105,6 +105,7 @@ oc_run_with_state() {
     local before
     before=$(cat "${STATE_FILE}")
     run oc_run_with_state worktree list
+    assert_failure
     [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "list rewrote corrupted state"
 }
 

--- a/tests/bats/openemr-cmd/state_corruption.bats
+++ b/tests/bats/openemr-cmd/state_corruption.bats
@@ -1,0 +1,133 @@
+# BATS: behavior under corrupted .worktrees.json.
+#
+# We don't try to "recover" from a corrupted state file (jq can't parse
+# it; there's no safe recovery without losing data). The invariant we
+# pin here: when state is corrupted, the failing op MUST NOT overwrite
+# it with an empty/blank file. The user's broken state must remain on
+# disk so they can inspect/restore it.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run_with_state() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" "$@"
+}
+
+# --- empty state file -------------------------------------------------------
+
+@test "state corruption: empty .worktrees.json — add transparently repairs (zero-byte = nothing to preserve)" {
+    # A zero-byte state file has no data to lose, so the script is free to
+    # treat it like a missing file. jq's null input + assignment produces a
+    # well-formed object on first write. This pins that behavior.
+    : > "${STATE_FILE}"
+    run oc_run_with_state worktree add foo -b --env easy
+    assert_success
+    # File is now valid JSON containing our entry.
+    jq empty "${STATE_FILE}" || fail "state file is not valid JSON after add"
+    [[ "$(jq -r 'has("foo")' "${STATE_FILE}")" = "true" ]] || fail "added entry missing"
+}
+
+@test "state corruption: empty .worktrees.json — list transparently repairs and shows no entries" {
+    # wt_init_state treats empty as uninitialized and writes '{}'. list then
+    # walks an empty object and reports no worktrees, exiting cleanly.
+    : > "${STATE_FILE}"
+    run oc_run_with_state worktree list
+    assert_success
+    jq empty "${STATE_FILE}" || fail "list left state file unparseable"
+    [[ "$(jq -r 'length' "${STATE_FILE}")" = "0" ]] || fail "list invented entries"
+}
+
+# --- garbage non-JSON content ----------------------------------------------
+
+@test "state corruption: non-JSON content — add fails, original content preserved" {
+    printf 'not json at all\n' > "${STATE_FILE}"
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run_with_state worktree add foo -b --env easy
+    assert_failure
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "state file mutated by failing op"
+}
+
+@test "state corruption: non-JSON content — remove fails, original content preserved" {
+    printf 'totally bogus\n' > "${STATE_FILE}"
+    local before
+    before=$(cat "${STATE_FILE}")
+    # Feed 'y' in case the prompt is reached (it shouldn't be).
+    run bash -c "printf 'y\n' | env \
+        PATH='${STUB_DIR}:${PATH}' \
+        OPENEMR_ROOT='${TMP_ROOT}' \
+        WORKTREE_PARENT='${TMP_PARENT}' \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        '${SCRIPT}' worktree remove foo --keep-volumes"
+    assert_failure
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "state file mutated by failing remove"
+}
+
+# --- truncated JSON ---------------------------------------------------------
+
+@test "state corruption: truncated JSON — prune fails cleanly, file preserved" {
+    # Mid-write torn JSON (the leading brace and one half-written entry).
+    printf '{"feat":{"off' > "${STATE_FILE}"
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run_with_state worktree prune
+    assert_failure
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "prune rewrote corrupted state"
+}
+
+@test "state corruption: truncated JSON — list fails cleanly, file preserved" {
+    printf '{"feat":{"off' > "${STATE_FILE}"
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run_with_state worktree list
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "list rewrote corrupted state"
+}
+
+# --- wrong shape (top-level array) ------------------------------------------
+
+@test "state corruption: top-level array instead of object — add fails, file preserved" {
+    # Valid JSON, but the script's state model expects an object keyed by branch.
+    echo '["not", "an", "object"]' > "${STATE_FILE}"
+    local before
+    before=$(cat "${STATE_FILE}")
+    run oc_run_with_state worktree add foo -b --env easy
+    assert_failure
+    [[ "$(cat "${STATE_FILE}")" = "${before}" ]] || fail "state file mutated by failing add"
+}
+
+# --- recovery via manual cleanup --------------------------------------------
+
+@test "state corruption: after manual rm of corrupted file, add succeeds with fresh state" {
+    printf 'busted\n' > "${STATE_FILE}"
+    # Documented recovery: remove the corrupted state file.
+    rm -f "${STATE_FILE}"
+    run oc_run_with_state worktree add recovered -b --env easy
+    assert_success
+    [[ "$(jq -r 'has("recovered")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry missing after manual-recovery + add"
+}

--- a/tests/bats/openemr-cmd/state_lock_crash_recovery.bats
+++ b/tests/bats/openemr-cmd/state_lock_crash_recovery.bats
@@ -1,0 +1,168 @@
+# BATS: behavior under crash scenarios for openemr-cmd worktree.
+#
+# Two crash classes are exercised:
+#
+#   (1) Lockfile leak via SIGKILL: an external holder is SIGKILL'd while
+#       holding .worktrees.json.lock. EXIT traps don't fire on SIGKILL, so
+#       the lockfile lingers. The next acquirer must time out cleanly
+#       with the manual-cleanup hint (no auto-steal, per state_lock.bats).
+#
+#   (2) Orphaned git worktree (no state entry): simulate the narrow
+#       window where `git worktree add` registered a worktree on disk
+#       but the process died before wt_state_set wrote the entry. A
+#       subsequent `worktree add <same-branch>` should surface git's
+#       "already checked out" error — not silently overwrite or wedge.
+#       `worktree prune` does NOT clean this up (it only walks state
+#       entries); manual `git worktree remove` is the recovery path.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    LOCK_FILE="${STATE_FILE}.lock"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE LOCK_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+@test "SIGKILL'd holder leaves the lockfile; the next acquirer times out with manual-cleanup hint" {
+    # Start a background bash that acquires the lock, then sleeps. SIGKILL
+    # it. The EXIT trap won't fire, so the lockfile will linger with the
+    # holder PID still inside.
+    local holder_log="${TMP_PARENT}/holder.log"
+    OPENEMR_ROOT="${TMP_ROOT}" \
+    WT_STATE_FILE="${STATE_FILE}" \
+    bash -c "
+        set -uo pipefail
+        eval \"\$(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')\"
+        WT_STATE_FILE='${STATE_FILE}'
+        WT_STATE_LOCK_FILE='${LOCK_FILE}'
+        wt_acquire_state_lock
+        echo holder-acquired
+        sleep 30
+    " > "${holder_log}" 2>&1 &
+    local holder_pid=$!
+    # Wait for the holder to have actually acquired the lock.
+    local i=0
+    while (( i < 100 )); do
+        [[ -f "${LOCK_FILE}" ]] && grep -q holder-acquired "${holder_log}" 2>/dev/null && break
+        sleep 0.05
+        i=$((i + 1))
+    done
+    [[ -f "${LOCK_FILE}" ]] || fail "holder did not create lockfile in time"
+
+    # Kill -9 the holder. EXIT trap does NOT fire. Lockfile should linger.
+    kill -KILL "${holder_pid}" 2>/dev/null || true
+    wait "${holder_pid}" 2>/dev/null || true
+    [[ -f "${LOCK_FILE}" ]] || fail "lockfile was unexpectedly cleaned after SIGKILL"
+
+    # Now try to acquire the lock with a short timeout. Must fail with the
+    # manual-cleanup hint.
+    run env \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WT_STATE_FILE="${STATE_FILE}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        bash -c "
+            set -uo pipefail
+            eval \"\$(head -n ${OC_SCRIPT_FUNCS_END} '${SCRIPT}')\"
+            WT_STATE_FILE='${STATE_FILE}'
+            WT_STATE_LOCK_FILE='${LOCK_FILE}'
+            wt_acquire_state_lock 2>&1
+        "
+    assert_failure
+    assert_output --partial "Timed out waiting for state lock"
+    assert_output --partial "remove the lock file manually"
+    # Lockfile still present (we never stole it).
+    [[ -f "${LOCK_FILE}" ]] || fail "lockfile was removed despite no-steal contract"
+}
+
+@test "after manual cleanup of an orphaned lockfile, the next operation succeeds" {
+    # The documented recovery for a SIGKILL'd holder. Write a fake
+    # lockfile, then `rm -f` it, then perform a real state op. Tests
+    # that the recovery instructions actually work end-to-end.
+    echo 99999 > "${LOCK_FILE}"
+    rm -f "${LOCK_FILE}"
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=10 \
+        "${SCRIPT}" worktree add recovered-branch -b --env easy
+    assert_success
+    assert_output --partial "Worktree 'recovered-branch' ready"
+    [[ "$(jq -r 'has("recovered-branch")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry not written after recovery"
+    [[ ! -e "${LOCK_FILE}" ]] || fail "lockfile still present after successful op"
+}
+
+@test "orphaned git worktree (no state entry) leads to git already-checked-out error on second add" {
+    # Simulate the narrow crash window: process registered a git worktree
+    # via `git worktree add ... -b orphaned-branch <dir>` but died before
+    # wt_state_set wrote the entry.
+    local orphan_dir="${TMP_PARENT}/openemr-wt-orphaned-branch"
+    git -C "${TMP_ROOT}" worktree add --quiet --no-track -b orphaned-branch "${orphan_dir}" master >/dev/null
+
+    # State has no entry for this branch.
+    [[ ! -f "${STATE_FILE}" ]] || [[ "$(jq -r 'has("orphaned-branch")' "${STATE_FILE}")" = "false" ]] \
+        || fail "fixture state should NOT contain orphaned-branch"
+
+    # Now invoke worktree add for the same branch. Should fail with git's
+    # message — NOT silently succeed.
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=10 \
+        "${SCRIPT}" worktree add orphaned-branch -b --env easy
+    assert_failure
+    # `git worktree add` will refuse because the branch already exists.
+    # Tolerate either git's "already exists" or its "already checked out" phrasing.
+    if ! ( echo "${output}" | grep -Eq "already (exists|checked out|used by worktree)" ); then
+        echo "${output}"
+        fail "expected git's already-exists/checked-out error"
+    fi
+    # State must not have an entry — we didn't get to wt_state_set.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("orphaned-branch")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry was written despite git failure"
+    fi
+    # Lockfile cleaned up (the trap fired on wt_die's exit).
+    [[ ! -e "${LOCK_FILE}" ]] || fail "lockfile lingering after failed add"
+}
+
+@test "orphaned git worktree: manual recovery then worktree add succeeds" {
+    # End-to-end recovery: confirm the documented manual path works.
+    local orphan_dir="${TMP_PARENT}/openemr-wt-recoverable"
+    git -C "${TMP_ROOT}" worktree add --quiet --no-track -b recoverable "${orphan_dir}" master >/dev/null
+
+    # Manual recovery step (would be documented for the user).
+    git -C "${TMP_ROOT}" worktree remove --force "${orphan_dir}"
+    git -C "${TMP_ROOT}" branch -D recoverable
+
+    # Now the add should succeed cleanly.
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=10 \
+        "${SCRIPT}" worktree add recoverable -b --env easy
+    assert_success
+    [[ "$(jq -r 'has("recoverable")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry not present after recovery"
+}

--- a/tests/bats/openemr-cmd/worktree_concurrent.bats
+++ b/tests/bats/openemr-cmd/worktree_concurrent.bats
@@ -140,3 +140,166 @@ dump_bg_logs() {
     [[ ! -f "${TMP_PARENT}/openemr-wt-cs-easy-light/docker/development-easy/.env"     ]] || fail "easy-light leaked into easy dir"
     [[ ! -f "${TMP_PARENT}/openemr-wt-cs-easy-redis/docker/development-easy/.env"     ]] || fail "easy-redis leaked into easy dir"
 }
+
+# --- same-branch concurrent state ops --------------------------------------
+# Same-branch concurrent operations (two removes, set-env vs remove, two
+# set-envs) each acquire the state lock. The expectation is serialization:
+# the first wins, the second sees the updated state (which may mean it
+# fails gracefully — "No worktree found" — or applies its mutation on top
+# of the first's). State must never end up corrupted.
+
+# Spawn `worktree remove --keep-volumes` in the background, auto-confirming
+# the interactive prompt with "y\n" on stdin.
+remove_in_bg() {
+    local branch=$1 rc_file=$2
+    local log_file="${rc_file}.log"
+    : > "${log_file}"
+    (
+        trap "echo \$? > '${rc_file}'" EXIT
+        printf 'y\n' | env \
+            PATH="${STUB_DIR}:${PATH}" \
+            OPENEMR_ROOT="${TMP_ROOT}" \
+            WORKTREE_PARENT="${TMP_PARENT}" \
+            WT_STATE_LOCK_TIMEOUT_S=30 \
+            "${SCRIPT}" worktree remove "${branch}" --keep-volumes > "${log_file}" 2>&1
+    ) &
+}
+
+# Spawn `worktree set-env <branch> <env>` in the background.
+set_env_in_bg() {
+    local branch=$1 env=$2 rc_file=$3
+    local log_file="${rc_file}.log"
+    : > "${log_file}"
+    (
+        trap "echo \$? > '${rc_file}'" EXIT
+        env \
+            PATH="${STUB_DIR}:${PATH}" \
+            OPENEMR_ROOT="${TMP_ROOT}" \
+            WORKTREE_PARENT="${TMP_PARENT}" \
+            WT_STATE_LOCK_TIMEOUT_S=30 \
+            "${SCRIPT}" worktree set-env "${branch}" "${env}" > "${log_file}" 2>&1
+    ) &
+}
+
+@test "two concurrent removes of the same branch: one wins, the other fails gracefully" {
+    # Add a worktree to remove.
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add same-branch-rm -b --env easy >/dev/null 2>&1
+    [[ -d "${TMP_PARENT}/openemr-wt-same-branch-rm" ]] || fail "fixture worktree not created"
+    [[ "$(jq -r 'has("same-branch-rm")' "${TMP_ROOT}/.worktrees.json")" = "true" ]] \
+        || fail "fixture state entry not present"
+
+    local rc_a="${TMP_PARENT}/rc-rm-a" rc_b="${TMP_PARENT}/rc-rm-b"
+    remove_in_bg same-branch-rm "${rc_a}"
+    remove_in_bg same-branch-rm "${rc_b}"
+    wait
+
+    local rc_a_val rc_b_val
+    rc_a_val=$(cat "${rc_a}" 2>/dev/null)
+    rc_b_val=$(cat "${rc_b}" 2>/dev/null)
+    # Exactly one should have succeeded; the other should have failed with
+    # "No worktree found" (state entry was removed by the winner before the
+    # loser acquired the lock).
+    local zeros=0
+    [[ "${rc_a_val}" = "0" ]] && zeros=$((zeros + 1))
+    [[ "${rc_b_val}" = "0" ]] && zeros=$((zeros + 1))
+    if (( zeros != 1 )); then
+        echo "--- a log ---"; cat "${rc_a}.log"
+        echo "--- b log ---"; cat "${rc_b}.log"
+        fail "expected exactly 1 successful remove, got ${zeros} (rc_a=${rc_a_val} rc_b=${rc_b_val})"
+    fi
+    # The loser should mention "No worktree found".
+    if [[ "${rc_a_val}" != "0" ]]; then
+        grep -q "No worktree found for branch 'same-branch-rm'" "${rc_a}.log" \
+            || { cat "${rc_a}.log"; fail "loser-a did not report 'No worktree found'"; }
+    fi
+    if [[ "${rc_b_val}" != "0" ]]; then
+        grep -q "No worktree found for branch 'same-branch-rm'" "${rc_b}.log" \
+            || { cat "${rc_b}.log"; fail "loser-b did not report 'No worktree found'"; }
+    fi
+    # State entry must be gone.
+    [[ "$(jq -r 'has("same-branch-rm")' "${TMP_ROOT}/.worktrees.json")" = "false" ]] \
+        || fail "state entry still present after concurrent removes"
+    # Lockfile cleaned up.
+    [[ ! -e "${TMP_ROOT}/.worktrees.json.lock" ]] || fail "state lockfile lingering"
+}
+
+@test "two concurrent set-env on the same branch (different envs): both succeed, final env is one of them" {
+    # Add a worktree on easy. Both set-env racers will target a different env.
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add same-branch-se -b --env easy >/dev/null 2>&1
+    [[ "$(jq -r '."same-branch-se".env' "${TMP_ROOT}/.worktrees.json")" = "easy" ]] \
+        || fail "fixture not on easy"
+
+    local rc_a="${TMP_PARENT}/rc-se-a" rc_b="${TMP_PARENT}/rc-se-b"
+    set_env_in_bg same-branch-se easy-light "${rc_a}"
+    set_env_in_bg same-branch-se easy-redis "${rc_b}"
+    wait
+
+    local rc_a_val rc_b_val
+    rc_a_val=$(cat "${rc_a}" 2>/dev/null)
+    rc_b_val=$(cat "${rc_b}" 2>/dev/null)
+    if [[ "${rc_a_val}" != "0" || "${rc_b_val}" != "0" ]]; then
+        echo "--- a log ---"; cat "${rc_a}.log"
+        echo "--- b log ---"; cat "${rc_b}.log"
+        fail "expected both set-env to succeed (rc_a=${rc_a_val} rc_b=${rc_b_val})"
+    fi
+    # Final env is one of the two — last writer wins, state is well-formed.
+    local final_env
+    final_env=$(jq -r '."same-branch-se".env' "${TMP_ROOT}/.worktrees.json")
+    [[ "${final_env}" = "easy-light" || "${final_env}" = "easy-redis" ]] \
+        || fail "final env '${final_env}' is not one of easy-light/easy-redis"
+    # State is parseable JSON (no torn write).
+    jq empty "${TMP_ROOT}/.worktrees.json" || fail "state file is corrupted JSON"
+    # Lockfile cleaned up.
+    [[ ! -e "${TMP_ROOT}/.worktrees.json.lock" ]] || fail "state lockfile lingering"
+}
+
+@test "set-env races with remove on the same branch: no corruption, never both succeed-and-leave-entry" {
+    # Add a worktree, then race a remove vs a set-env. One of three outcomes:
+    #   (1) set-env first, remove second → entry gone
+    #   (2) remove first, set-env second → set-env fails "No worktree found", entry gone
+    # Either way the final state has NO entry for the branch and the JSON is intact.
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add same-branch-mix -b --env easy >/dev/null 2>&1
+
+    local rc_rm="${TMP_PARENT}/rc-mix-rm" rc_se="${TMP_PARENT}/rc-mix-se"
+    remove_in_bg same-branch-mix "${rc_rm}"
+    set_env_in_bg same-branch-mix easy-light "${rc_se}"
+    wait
+
+    # Remove must always succeed (it acquires the lock and proceeds whether
+    # set-env got it first or not).
+    local rc_rm_val rc_se_val
+    rc_rm_val=$(cat "${rc_rm}" 2>/dev/null)
+    rc_se_val=$(cat "${rc_se}" 2>/dev/null)
+    if [[ "${rc_rm_val}" != "0" ]]; then
+        echo "--- rm log ---"; cat "${rc_rm}.log"
+        echo "--- se log ---"; cat "${rc_se}.log"
+        fail "remove failed (rc=${rc_rm_val}); should always succeed in this race"
+    fi
+    # State entry must be gone regardless of ordering.
+    [[ "$(jq -r 'has("same-branch-mix")' "${TMP_ROOT}/.worktrees.json")" = "false" ]] \
+        || fail "state entry still present after remove"
+    # JSON well-formed.
+    jq empty "${TMP_ROOT}/.worktrees.json" || fail "state file is corrupted JSON"
+    # Lockfile cleaned up.
+    [[ ! -e "${TMP_ROOT}/.worktrees.json.lock" ]] || fail "state lockfile lingering"
+    # If set-env lost the race, it must have failed gracefully (not crashed).
+    if [[ "${rc_se_val}" != "0" ]]; then
+        grep -q "No worktree found for branch 'same-branch-mix'" "${rc_se}.log" \
+            || { cat "${rc_se}.log"; fail "set-env loser did not report 'No worktree found'"; }
+    fi
+}

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -1157,6 +1157,9 @@ cmd_worktree_prune() {
     local state_content
     state_content=$(cat "${WT_STATE_FILE}")
     if [[ "${state_content}" == "{}" ]]; then
+        if ! ${dry_run}; then
+            wt_release_state_lock
+        fi
         echo "(no stale entries)"
         return 0
     fi

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.43"
+VERSION="1.0.44"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -247,7 +247,12 @@ wt_release_state_lock() {
 }
 
 wt_init_state() {
-    [[ -f "${WT_STATE_FILE}" ]] || echo '{}' > "${WT_STATE_FILE}"
+    # Treat a missing OR zero-byte file as uninitialized. A 0-byte file makes
+    # jq produce empty output on the read-modify-write path, so wt_state_set
+    # would `mv` an empty tmp file over the state and silently lose the entry
+    # it just thought it wrote. Initializing to `{}` makes all subsequent jq
+    # calls produce well-formed output.
+    [[ -s "${WT_STATE_FILE}" ]] || echo '{}' > "${WT_STATE_FILE}"
 }
 
 wt_state_get() {
@@ -695,6 +700,13 @@ cmd_worktree_add() {
     local offset dir dir_slug
     offset=$(wt_next_offset)
     dir_slug=$(wt_slug "${branch}")
+    # wt_slug strips everything outside [a-zA-Z0-9_-]. A branch made entirely
+    # of stripped chars (e.g. '!!!') produces an empty slug, which would create
+    # a worktree dir 'openemr-wt-' and a docker project 'openemr-' — both
+    # ambiguous and unsafe for state lookup.
+    if [[ -z "${dir_slug}" ]]; then
+        wt_die "Branch name '${branch}' contains no slug-safe characters [a-zA-Z0-9_-]"
+    fi
     dir="${WORKTREE_PARENT}/openemr-wt-${dir_slug}"
 
     wt_info "Creating git worktree for '${branch}' at ${dir}"
@@ -1131,6 +1143,15 @@ cmd_worktree_prune() {
     done
 
     wt_require_cmd jq git realpath
+    # Acquire the state lock for non-dry-run prunes: we iterate state
+    # entries and call wt_state_remove on stale ones. Without the lock,
+    # a concurrent `add` between our read of state and our writes could
+    # have its just-added entry pruned away as "stale" (its dir might
+    # not yet exist on disk, or `wt_validate_dir_safe` could fail
+    # mid-creation). --dry-run reads only and stays unlocked.
+    if ! ${dry_run}; then
+        wt_acquire_state_lock
+    fi
     wt_init_state
 
     local state_content
@@ -1167,6 +1188,10 @@ cmd_worktree_prune() {
     # the same branch.
     if ! ${dry_run} && [[ "${pruned}" -gt 0 ]]; then
         git -C "${OPENEMR_ROOT}" worktree prune 2>/dev/null || true
+    fi
+
+    if ! ${dry_run}; then
+        wt_release_state_lock
     fi
 
     if [[ "${pruned}" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Expands the openemr-cmd worktree bats suite by 28 tests across 6 new files + 2 extensions, and lands three small script fixes uncovered while writing them.

### New bats files
- **state_lock_crash_recovery.bats** — SIGKILL'd holder leaves the lockfile, next acquirer times out with the manual-cleanup hint, then manual `rm -f` recovery actually unblocks the next op. Also covers the orphaned-git-worktree case (registered worktree but no state entry).
- **state_corruption.bats** — empty / non-JSON / truncated / wrong-shape `.worktrees.json`. Pins that failing ops do **not** overwrite the user's broken state, and that the documented `rm -f` + retry recovery works.
- **branch_name_edges.bats** — slug collisions (`foo/bar` vs `foo-bar`), empty-slug rejection (`!!!`), leading-dash refusal, `HEAD`, 200-char branch, unicode-stripped slug.
- **docker_failure_propagation.bats** — `up` / `down` / `remove` all surface non-zero compose exit codes; failed remove leaves state + dir intact for retry.
- **exec_and_existing_edges.bats** — `exec` usage shape, unknown branch surfaces `No worktree found`, no-running-container hint mentions `worktree up`. Plus re-add refusal + `down`/`stop` on unknown branch.
- **lower_value_edges.bats** — `wt_next_offset` gap-filling (1,3 → 2), set-env no-op when current == new, set-env invalid env, `WT_STATE_LOCK_TIMEOUT_S=0` fail-fast under 2s.

### Extended bats
- **prune.bats** — prune now acquires the state lock during the iterate+remove critical section; `--dry-run` stays unlocked.
- **worktree_concurrent.bats** — same-branch concurrent ops: two `remove`s (one wins, one reports `No worktree found`), two `set-env`s to different envs (both succeed, last writer wins), `set-env` racing `remove`.

### Script changes (uncovered while writing tests)
1. **`cmd_worktree_prune` now wraps the iterate+remove section in `wt_acquire_state_lock`** so a concurrent `add` can't have its just-added entry pruned away mid-flight (its dir might not yet exist on disk, or `wt_validate_dir_safe` could fail mid-creation). `--dry-run` is read-only and stays unlocked. Closes the known follow-up from #823.
2. **`wt_init_state` treats a zero-byte state file as uninitialized.** Previously a 0-byte file made `jq` emit empty output on the read-modify-write path and `wt_state_set` would `mv` an empty tmp file over the state — silently losing the entry it just thought it wrote.
3. **`cmd_worktree_add` refuses a branch whose slug is empty** (e.g. `!!!`) rather than creating a worktree dir `openemr-wt-` and a docker project `openemr-` (both ambiguous and unsafe for state lookup).

### Harness bookkeeping
- `OC_SCRIPT_FUNCS_END` bumped to 1712 to track the new function-defs end.
- `.gitignore` `/tests/bats/test_helper/` — CI clones `bats-support` / `bats-assert` at runtime; ignoring them keeps local helper checkouts from showing up as untracked.
- `VERSION` 1.0.43 → 1.0.44.

## Test plan

- [x] Full hermetic bats suite passes locally — 173 tests, 0 failures
- [x] `shellcheck utilities/openemr-cmd/openemr-cmd` clean
- [ ] CI: `BATS openemr-cmd (ubuntu-22.04)` green
- [ ] CI: `BATS openemr-cmd (macos-14)` green
- [ ] CI: `ShellCheck` green
- [ ] CI: `e2e — add --start → healthy → down → remove` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree state initialization so missing/empty state no longer risks losing existing entries.
  * Added validation during worktree creation to reject branch names that would produce an unsafe/empty slug.
  * Strengthened state-lock handling for pruning, including correct lock acquisition/release during empty-state scenarios and more reliable behavior under concurrent operations.
* **Tests**
  * Added extensive end-to-end coverage for branch-name edge cases, Docker-related failure propagation, and concurrent worktree state mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->