### PR TITLE
fix(openemr-cmd): probe worktree dir for permission issues before any destructive op in remove

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -5,7 +5,9 @@ name: openemr-cmd e2e (real docker)
 # `openemr-cmd worktree add --start` against a real openemr/openemr
 # image. Two parallel jobs:
 #   - worktree-lifecycle-e2e: single-worktree happy path on env=easy,
-#     plus `worktree exec` end-to-end.
+#     plus `worktree exec` end-to-end and the A5 container-uid-on-
+#     remove probe contract (remove-without-chown bails cleanly with
+#     a chown hint, all state preserved; chown + retry succeeds).
 #   - worktree-multi-concurrent-e2e: two worktrees on env=easy-light
 #     running side-by-side, distinct ports + compose projects, exec
 #     routes each to its own container (no cross-talk).
@@ -161,18 +163,59 @@ jobs:
         working-directory: openemr
         run: openemr-cmd worktree down test-e2e --keep-volumes
 
-      - name: worktree remove test-e2e
+      - name: "worktree remove WITHOUT chown (expected: probe refuses, nothing destroyed)"
         working-directory: openemr
         run: |
-          # The openemr container writes files into the worktree's bind-mount
-          # volumes as a non-runner uid (apache, root, etc.). After the stack
-          # has run, those files exist on disk owned by uids the runner user
-          # can't touch — so `git worktree remove --force` (which does
-          # `rm -rf` under the hood) fails with Permission denied. Pre-chown
-          # the worktree dir so the removal can proceed.
-          # This is the same workaround devs hit when removing a worktree
-          # whose container wrote files as a non-host uid; CI is just the
-          # most reliable trigger for it.
+          # A5 contract: the openemr container writes files into the
+          # worktree's bind-mount as root/apache uids during startup. Before
+          # the permission-probe fix, the script would proceed past compose
+          # down --volumes + git worktree remove --force and only fail
+          # mid-rm — leaving partial state on disk. With the probe in place,
+          # remove must bail BEFORE any destructive op, with a clear chown
+          # hint and ALL state intact for retry.
+          set +e
+          echo y | openemr-cmd worktree remove test-e2e > /tmp/remove-out.txt 2>&1
+          rc=$?
+          set -e
+          cat /tmp/remove-out.txt
+          if [[ "${rc}" = "0" ]]; then
+              echo "FAIL: remove unexpectedly succeeded without sudo chown"
+              exit 1
+          fi
+          grep -q "is not writable by you" /tmp/remove-out.txt \
+              || { echo "FAIL: probe did not surface the writability hint"; exit 1; }
+          grep -q "sudo chown -R" /tmp/remove-out.txt \
+              || { echo "FAIL: probe did not surface the chown command"; exit 1; }
+          # Nothing destroyed: state entry preserved, dir preserved, volumes
+          # preserved (compose down --volumes never ran), lockfile released.
+          if ! jq -e '."test-e2e"' .worktrees.json >/dev/null; then
+              echo "FAIL: state entry missing after probe-refused remove"
+              cat .worktrees.json
+              exit 1
+          fi
+          if [[ ! -d "${{ github.workspace }}/openemr-wt-test-e2e" ]]; then
+              echo "FAIL: worktree dir gone after probe-refused remove"
+              exit 1
+          fi
+          if [[ -e ".worktrees.json.lock" ]]; then
+              echo "FAIL: state lockfile lingered after probe-refused remove"
+              ls -la .worktrees.json.lock
+              exit 1
+          fi
+          # Volumes still around (compose down --volumes did NOT run).
+          remaining=$(docker volume ls -q --filter "name=openemr-test-e2e_" | wc -l)
+          if [[ "${remaining}" = "0" ]]; then
+              echo "FAIL: volumes were purged despite probe refusing"
+              docker volume ls
+              exit 1
+          fi
+          echo "as expected: probe refused, ${remaining} volumes preserved, state intact"
+
+      - name: worktree remove test-e2e (with chown workaround)
+        working-directory: openemr
+        run: |
+          # Documented workaround: chown the worktree dir back to the runner
+          # uid so the probe + downstream destructive ops can succeed.
           sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}/openemr-wt-test-e2e"
           # `remove` prompts; pipe 'y' to confirm.
           echo y | openemr-cmd worktree remove test-e2e

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -79,7 +79,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1715
+OC_SCRIPT_FUNCS_END=1738
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -79,7 +79,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1738
+OC_SCRIPT_FUNCS_END=1744
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/remove_graceful.bats
+++ b/tests/bats/openemr-cmd/remove_graceful.bats
@@ -130,6 +130,73 @@ setup_full_worktree() {
     assert_output "false"
 }
 
+# --- A5: permission probe ---------------------------------------------------
+# Before any destructive op, cmd_worktree_remove walks the dir for unwritable
+# subdirectories (the symptom of container-uid files in the bind mount). If
+# any are found it bails with a chown hint, ensuring nothing has been
+# destroyed yet — state entry, dir contents, lockfile all preserved for
+# retry.
+
+@test "remove: probe refuses early when a subdir is unwritable (container-uid simulation)" {
+    setup_full_worktree feature-rm-probe -b
+    # Mimic the container-uid case: a subdir inside the worktree we can no
+    # longer write to. chmod 0500 means r-x for owner — we can read+enter,
+    # but cannot unlink children. rm -rf would fail with EACCES here.
+    local sub="${TMP_WT_PARENT}/openemr-wt-feature-rm-probe/uneditable-by-host"
+    mkdir -p "${sub}"
+    : > "${sub}/sentinel"
+    chmod 0500 "${sub}"
+
+    # Reset the docker.log so we can assert NO compose down was issued.
+    : > "${STUB_DIR}/docker.log"
+
+    run bash -c "echo y | env \
+        PATH='${STUB_DIR}:${PATH}' \
+        OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
+        WORKTREE_PARENT='${TMP_WT_PARENT}' \
+        '${SCRIPT}' worktree remove feature-rm-probe"
+
+    # Restore perms so teardown's rm -rf can clean up.
+    chmod 0700 "${sub}" 2>/dev/null || true
+
+    assert_failure
+    # Clear, actionable error mentioning the unwritable dir + chown hint.
+    assert_output --partial "is not writable by you"
+    assert_output --partial "sudo chown -R"
+    assert_output --partial "${sub}"
+    # Nothing destructive ran: no compose down, no rm of dir, state intact.
+    if grep -F -e " down " "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
+        cat "${STUB_DIR}/docker.log"
+        fail "compose down ran despite the permission probe failing"
+    fi
+    [[ -d "${TMP_WT_PARENT}/openemr-wt-feature-rm-probe" ]] \
+        || fail "worktree dir was removed despite the permission probe failing"
+    [[ -f "${sub}/sentinel" ]] || fail "sentinel inside unwritable subdir was deleted"
+    run jq -r 'has("feature-rm-probe")' "${STATE_FILE}"
+    assert_output "true"
+    # Lockfile released by the EXIT trap on wt_die.
+    [[ ! -e "${STATE_FILE}.lock" ]] \
+        || fail "state lockfile lingering after probe-refused remove"
+}
+
+@test "remove: probe is a no-op when all dirs are writable (happy path still works)" {
+    # The probe walks the tree but finds nothing unwritable, so it should
+    # not interfere with a normal remove. setup_full_worktree creates a
+    # worktree with default-perm dirs, so this is essentially the same as
+    # the default-remove test above — kept as an explicit regression guard
+    # in case the probe ever starts false-positiving.
+    setup_full_worktree feature-rm-probe-noop -b
+    run bash -c "echo y | env \
+        PATH='${STUB_DIR}:${PATH}' \
+        OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
+        WORKTREE_PARENT='${TMP_WT_PARENT}' \
+        '${SCRIPT}' worktree remove feature-rm-probe-noop"
+    assert_success
+    refute_output --partial "is not writable by you"
+    run jq -r 'has("feature-rm-probe-noop")' "${STATE_FILE}"
+    assert_output "false"
+}
+
 @test "remove: when state dir is outside WORKTREE_PARENT, validation refuses early (no destructive action)" {
     # Tamper with the state file so dir points OUTSIDE WORKTREE_PARENT.
     # wt_validate_dir (invoked inside wt_compose_cmd before any docker or

--- a/tests/bats/openemr-cmd/remove_graceful.bats
+++ b/tests/bats/openemr-cmd/remove_graceful.bats
@@ -138,6 +138,11 @@ setup_full_worktree() {
 # retry.
 
 @test "remove: probe refuses early when a subdir is unwritable (container-uid simulation)" {
+    # Root ignores DAC permissions — chmod 0500 still leaves the dir
+    # writable for uid 0, so the probe sees nothing wrong and the test's
+    # premise breaks. Skip when running as root (e.g., some CI images or
+    # rootless container test envs).
+    [[ "$(id -u)" -ne 0 ]] || skip "test relies on DAC permissions; uid 0 bypasses them"
     setup_full_worktree feature-rm-probe -b
     # Mimic the container-uid case: a subdir inside the worktree we can no
     # longer write to. chmod 0500 means r-x for owner — we can read+enter,

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.44"
+VERSION="1.0.45"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -833,6 +833,29 @@ cmd_worktree_remove() {
         wt_info "Note: docker resources (containers, volumes) for this stack may still exist."
         wt_info "  Clean them manually: docker compose -p openemr-${slug} down -v"
         return 0
+    fi
+
+    # Probe for permission issues BEFORE any destructive op. The openemr
+    # container writes files into the bind-mounted worktree as a non-host
+    # uid (root/apache), which makes subdirectories unwritable for the host
+    # user. If we proceed without catching that, we'd:
+    #   1. purge the compose volumes (wt_compose_cmd down --volumes),
+    #   2. let `git worktree remove --force` unregister the worktree, and
+    #   3. fail mid-rm with EACCES — leaving partial state on disk + a
+    #      state entry pointing at a no-longer-registered worktree, which
+    #      a chown+retry can't recover from (wt_validate_dir rejects the
+    #      now-orphan dir). Bail early with a clear chown hint instead.
+    # `find -type d ! -writable` checks access(2) for the current uid, so
+    # any directory we wouldn't be able to unlink children of is reported.
+    local unwritable
+    unwritable=$(find "${dir}" -type d ! -writable -print -quit 2>/dev/null || true)
+    if [[ -n "${unwritable}" ]]; then
+        # wt_die's exit triggers the wt_acquire_state_lock EXIT trap, which
+        # releases the lock — no manual release needed.
+        wt_die "Cannot remove worktree '${branch}': directory '${unwritable}' is not writable by you.
+This usually means the docker container wrote files into the worktree as a
+different uid (root/apache). Restore ownership and retry:
+    sudo chown -R \"\$(id -u):\$(id -g)\" '${dir}'"
     fi
 
     echo "This will remove worktree '${branch}' at ${dir}."

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -845,10 +845,16 @@ cmd_worktree_remove() {
     #      state entry pointing at a no-longer-registered worktree, which
     #      a chown+retry can't recover from (wt_validate_dir rejects the
     #      now-orphan dir). Bail early with a clear chown hint instead.
-    # `find -type d ! -writable` checks access(2) for the current uid, so
-    # any directory we wouldn't be able to unlink children of is reported.
-    local unwritable
-    unwritable=$(find "${dir}" -type d ! -writable -print -quit 2>/dev/null || true)
+    # `[[ -w ${d} ]]` uses access(2) for the current uid; we walk every
+    # subdir because `rm` needs write+execute on each PARENT to unlink
+    # children. Not using `find -writable` (GNU-only — BSD/macOS lacks it).
+    local unwritable=""
+    while IFS= read -r -d '' d; do
+        if [[ ! -w "${d}" ]]; then
+            unwritable="${d}"
+            break
+        fi
+    done < <(find "${dir}" -type d -print0 2>/dev/null || true)
     if [[ -n "${unwritable}" ]]; then
         # wt_die's exit triggers the wt_acquire_state_lock EXIT trap, which
         # releases the lock — no manual release needed.


### PR DESCRIPTION
## Problem

`cmd_worktree_remove` was not atomic. Its sequence is:

1. `wt_compose_cmd down --volumes` — purges compose volumes
2. `git worktree remove --force` — unregisters the worktree
3. `rm -rf <dir>` — cleans the filesystem
4. `wt_state_remove` — drops the state entry

When the docker container had written files into the bind-mounted worktree as a non-host uid (root/apache — universal on Linux CI and common on dev machines), step 3 failed with EACCES partway through. By then steps 1+2 had already run, so a chown + retry could not recover: `wt_validate_dir` inside the retry's `wt_compose_cmd` rejects the now-orphaned dir with "not a registered git worktree" and the script exits silently (stderr suppressed by `2>/dev/null` on the compose call).

This was surfaced while writing the e2e A5 contract test in #825 — that step had to be reverted in c5023ed because the retry didn't work. This PR addresses the root cause and brings the contract test back.

## Fix

Add a permission probe to `cmd_worktree_remove` **before any destructive op** and **before the user prompt** (no point asking `Continue? [y/N]` if we already know the rm will fail).

```bash
unwritable=$(find "${dir}" -type d ! -writable -print -quit 2>/dev/null || true)
if [[ -n "${unwritable}" ]]; then
    wt_die "Cannot remove worktree '${branch}': directory
'${unwritable}' is not writable by you. ... sudo chown -R \"\$(id -u):\$(id -g)\" '${dir}'"
fi
```

`find -type d ! -writable` checks `access(2)` for the current uid, so any directory we wouldn't be able to `unlink` children of is reported. Bailing early keeps state, compose volumes, and git worktree registration all intact; the user can chown + retry cleanly.

## Tests

- **`remove_graceful.bats` — probe refuses early when a subdir is unwritable**: fixture worktree with a `chmod 0500` subdir reproduces the container-uid case hermetically. Asserts the probe error, no `compose down` ran, dir + state + lockfile all preserved.
- **`remove_graceful.bats` — probe is a no-op when all dirs are writable**: explicit regression guard that the probe doesn't false-positive on the happy path.
- **e2e `test-bats-openemr-cmd-real-docker.yml` — A5 contract restored**: brings back the step reverted in #825. With the probe in place, `worktree remove` without chown now bails before destruction; assertions verify state, dir, lockfile, **and compose volumes** are all preserved. Then chown + retry succeeds normally.

## Test plan

- [x] Full hermetic bats suite — 176 tests, 0 failures
- [x] `shellcheck utilities/openemr-cmd/openemr-cmd` clean
- [x] YAML loads cleanly
- [ ] CI: BATS openemr-cmd (ubuntu-22.04) green
- [ ] CI: BATS openemr-cmd (macos-14) green
- [ ] CI: ShellCheck green
- [ ] CI: actionlint green
- [ ] CI: e2e lifecycle (now with A5 probe contract) green
- [ ] CI: e2e multi-worktree concurrent green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `openemr-cmd worktree remove` now runs a preflight permission probe and stops before any destructive actions if a subdirectory isn’t writable.
  * When blocked, it reports the likely ownership/permission mismatch and suggests a `sudo chown -R …` recovery-and-retry.

* **Bug Fixes**
  * Prevents teardown, worktree removal, and related cleanup steps when the permission probe fails, preserving state and lock/dir/volumes.

* **Tests / CI**
  * Added/extended BATS coverage for both blocked (early-fail) and allowed (no error) removal scenarios, including lockfile expectations.
  * Updated the related e2e workflow documentation comment and removal test case sequencing.

* **Chores**
  * Bumped `openemr-cmd` version to `1.0.45`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->