### PR TITLE
test(openemr-cmd): deep-coverage worktree bats — 35 tests across 8 areas

### DIFF
--- a/tests/bats/openemr-cmd/add_base_forms.bats
+++ b/tests/bats/openemr-cmd/add_base_forms.bats
@@ -1,0 +1,159 @@
+# BATS: cmd_worktree_add --base form-by-form coverage of wt_resolve_base.
+#
+# wt_resolve_base recognizes URLs (http/git/ssh/file://) and forwards to
+# wt_fetch_to_sha; everything else is treated as a local git ref and
+# resolved via `git rev-parse --verify <arg>^{commit}`. The local path
+# covers branches, tags, SHAs, and remote-tracking refs. The default
+# canonical-fetch path (-b without --base) is covered in worktree_misc;
+# this file pins the --base matrix end-to-end.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+
+    # The fixture init creates ONE commit on master. Add a second commit
+    # so we have at least two distinct SHAs to point --base at.
+    echo "extra-content" > "${TMP_ROOT}/EXTRA.txt"
+    git -C "${TMP_ROOT}" add EXTRA.txt
+    git -C "${TMP_ROOT}" commit --quiet -m "second commit"
+    MASTER_TIP=$(git -C "${TMP_ROOT}" rev-parse HEAD)
+    MASTER_PREV=$(git -C "${TMP_ROOT}" rev-parse HEAD~1)
+    # Tag the previous commit. -m + GIT_*_NAME/EMAIL avoid the "no tag
+    # message" failure that hits when the local git config has
+    # tag.gpgSign or tag.forceSignAnnotated set.
+    GIT_AUTHOR_NAME=bats GIT_AUTHOR_EMAIL=bats@example.com \
+    GIT_COMMITTER_NAME=bats GIT_COMMITTER_EMAIL=bats@example.com \
+        git -C "${TMP_ROOT}" -c tag.gpgSign=false \
+            tag -a -m "fixture tag" fixture-tag "${MASTER_PREV}"
+
+    # Set up a second repo that the primary can fetch from as 'origin' or
+    # via a file:// URL. Cloning preserves history.
+    SECOND_ROOT="${TMP_PARENT}/second"
+    git clone --quiet --no-local "${TMP_ROOT}" "${SECOND_ROOT}"
+    # Give 'second' a uniquely-named branch so we can fetch it as
+    # second/distinct-branch from primary.
+    git -C "${SECOND_ROOT}" checkout --quiet -b distinct-branch
+    echo "second-only" > "${SECOND_ROOT}/SECOND.txt"
+    git -C "${SECOND_ROOT}" add SECOND.txt
+    git -C "${SECOND_ROOT}" -c user.email=bats@e.com -c user.name=bats \
+        -c commit.gpgsign=false commit --quiet -m "second-only commit"
+    SECOND_DISTINCT_TIP=$(git -C "${SECOND_ROOT}" rev-parse HEAD)
+
+    # Register 'second' as a remote of primary, and fetch so remote-tracking
+    # refs (refs/remotes/second/*) exist locally for wt_resolve_base to find.
+    git -C "${TMP_ROOT}" remote add second "${SECOND_ROOT}"
+    git -C "${TMP_ROOT}" fetch --quiet second
+
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT SECOND_ROOT STUB_DIR STATE_FILE \
+           MASTER_TIP MASTER_PREV SECOND_DISTINCT_TIP
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# Assert the worktree's HEAD matches the expected SHA.
+assert_worktree_head() {
+    local branch=$1 expected=$2
+    local wt_dir="${TMP_PARENT}/openemr-wt-${branch}"
+    local actual
+    actual=$(git -C "${wt_dir}" rev-parse HEAD)
+    [[ "${actual}" = "${expected}" ]] \
+        || fail "worktree '${branch}' HEAD is ${actual}, expected ${expected}"
+}
+
+# --- local refs (wt_resolve_base local-rev-parse branch) -------------------
+
+@test "--base <local-branch>: works (resolves 'master' via rev-parse)" {
+    oc_add base-local-branch -b --base master --env easy >/dev/null
+    assert_worktree_head base-local-branch "${MASTER_TIP}"
+}
+
+@test "--base <tag>: works (resolves an annotated/lightweight tag via rev-parse)" {
+    oc_add base-tag -b --base fixture-tag --env easy >/dev/null
+    assert_worktree_head base-tag "${MASTER_PREV}"
+}
+
+@test "--base <SHA>: works (resolves a full SHA via rev-parse)" {
+    oc_add base-sha -b --base "${MASTER_PREV}" --env easy >/dev/null
+    assert_worktree_head base-sha "${MASTER_PREV}"
+}
+
+@test "--base <short-SHA>: works (rev-parse expands abbreviated SHAs)" {
+    local short="${MASTER_PREV:0:8}"
+    oc_add base-short-sha -b --base "${short}" --env easy >/dev/null
+    assert_worktree_head base-short-sha "${MASTER_PREV}"
+}
+
+@test "--base <remote/branch>: works (resolves refs/remotes/<remote>/<branch>)" {
+    oc_add base-remote -b --base second/distinct-branch --env easy >/dev/null
+    assert_worktree_head base-remote "${SECOND_DISTINCT_TIP}"
+}
+
+# --- URL forms (wt_resolve_base URL branch → wt_fetch_to_sha) --------------
+
+@test "--base file://<url> (no #ref): fetches master from the URL" {
+    oc_add base-url-default -b --base "file://${SECOND_ROOT}" --env easy >/dev/null
+    # 'second' has its own master branch (from the clone), which still
+    # points at the primary's master tip pre-distinct-branch — i.e. the
+    # second commit we made. distinct-branch is separate.
+    local second_master
+    second_master=$(git -C "${SECOND_ROOT}" rev-parse master)
+    assert_worktree_head base-url-default "${second_master}"
+}
+
+@test "--base file://<url>#<branch>: fetches the named ref from the URL" {
+    oc_add base-url-ref -b --base "file://${SECOND_ROOT}#distinct-branch" --env easy >/dev/null
+    assert_worktree_head base-url-ref "${SECOND_DISTINCT_TIP}"
+}
+
+# --- error paths -----------------------------------------------------------
+
+@test "--base <nonexistent-ref>: dies with a hint about using --base <URL>#<ref>" {
+    run oc_add base-bogus -b --base no-such-ref-anywhere --env easy
+    assert_failure
+    assert_output --partial "does not resolve as a local git ref"
+    assert_output --partial "to fetch"
+    # No half-built state.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("base-bogus")' "${STATE_FILE}")" = "false" ]] \
+            || fail "bogus-base branch was written to state"
+    fi
+    [[ ! -d "${TMP_PARENT}/openemr-wt-base-bogus" ]] \
+        || fail "bogus-base worktree dir was created"
+}
+
+@test "--base requires a value (--base with no following arg dies)" {
+    # --base must be last; otherwise the next arg gets consumed as the value.
+    run oc_add base-empty -b --env easy --base
+    assert_failure
+    assert_output --partial "--base requires a value"
+}
+
+@test "--base only applies with -b (without -b, --base is rejected)" {
+    run oc_add base-without-b --base master --env easy
+    assert_failure
+    assert_output --partial "--base only applies with -b"
+}

--- a/tests/bats/openemr-cmd/add_compose_subdir_on_branch.bats
+++ b/tests/bats/openemr-cmd/add_compose_subdir_on_branch.bats
@@ -1,0 +1,120 @@
+# BATS: cmd_worktree_add when the branch (not the primary) is missing
+# pieces of the docker/ layout.
+#
+# cmd_worktree_add does an early sanity check on the PRIMARY repo's
+# compose subdir (line ~696), but the actual write happens against the
+# WORKTREE'S checkout. A branch can predate one of the env variants
+# (no docker/development-easy-light/) or be missing docker/library
+# entirely. Each case has a distinct contract:
+#
+#   - docker/library missing: wt_write_override resolves it via realpath
+#     and dies with "Missing directory: '<dir>/docker/library'"
+#     (existing guard, pinned here as a regression check too).
+#   - docker/development-<env>/ missing on the branch: cmd_worktree_add
+#     calls `mkdir -p` at line ~740, which CREATES the subdir. Then it
+#     writes .env + override into it. The resulting worktree has a
+#     synthesized compose dir with no docker-compose.yml. The error
+#     surfaces later, at `worktree up`, when docker compose tries to
+#     load the missing -f. This file pins that two-stage behavior so a
+#     future refactor that moves the error earlier is intentional.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Make a branch that mutates the checkout (delete a subdir) and commits.
+make_branch_without() {
+    local branch=$1 path_to_remove=$2
+    git -C "${TMP_ROOT}" checkout --quiet -b "${branch}" master
+    git -C "${TMP_ROOT}" rm -rq "${path_to_remove}"
+    git -C "${TMP_ROOT}" -c user.email=bats@e.com -c user.name=bats \
+        -c commit.gpgsign=false \
+        commit --quiet -m "drop ${path_to_remove}"
+    git -C "${TMP_ROOT}" checkout --quiet master
+}
+
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# --- docker/library missing on the branch ----------------------------------
+
+@test "add: branch without docker/library/ dies with 'Missing directory'" {
+    make_branch_without no-library docker/library
+    run oc_add wt-no-library --base no-library -b --env easy
+    assert_failure
+    assert_output --partial "Missing directory"
+    assert_output --partial "docker/library"
+    # No state entry written.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("wt-no-library")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written despite docker/library missing"
+    fi
+}
+
+# --- docker/development-<env>/ missing on the branch -----------------------
+
+@test "add: branch without docker/development-<env>/ silently synthesizes the dir (current contract)" {
+    # Branch lacks docker/development-easy-light. Add succeeds because
+    # cmd_worktree_add does `mkdir -p ${dir}/${compose_subdir}` after the
+    # checkout, and wt_write_env / wt_write_override only need the dir to
+    # exist (they don't check for an upstream docker-compose.yml).
+    make_branch_without no-easy-light docker/development-easy-light
+    run oc_add wt-no-easy-light --base no-easy-light -b --env easy-light
+    assert_success
+    # State entry written.
+    [[ "$(jq -r 'has("wt-no-easy-light")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry missing despite successful add"
+    # The compose dir was synthesized.
+    [[ -d "${TMP_PARENT}/openemr-wt-wt-no-easy-light/docker/development-easy-light" ]] \
+        || fail "compose subdir not created"
+    # .env + override are written.
+    [[ -f "${TMP_PARENT}/openemr-wt-wt-no-easy-light/docker/development-easy-light/.env" ]] \
+        || fail ".env not written"
+    [[ -f "${TMP_PARENT}/openemr-wt-wt-no-easy-light/docker/development-easy-light/docker-compose.override.yml" ]] \
+        || fail "override not written"
+    # docker-compose.yml is NOT magically created — the user's eventual
+    # `worktree up` will fail when docker compose tries to load it.
+    [[ ! -f "${TMP_PARENT}/openemr-wt-wt-no-easy-light/docker/development-easy-light/docker-compose.yml" ]] \
+        || fail "docker-compose.yml unexpectedly synthesized; that would be a contract change"
+}
+
+@test "add: synthesized compose dir leads to docker compose failure on 'worktree up'" {
+    # Companion to the above: surface where the error actually lands.
+    # The docker stub returns success for everything (which is realistic
+    # of what a real docker daemon would do up to the point of "this
+    # compose file doesn't exist"). To exercise the failure surface, we
+    # need to drive docker compose with a real -f that doesn't exist —
+    # since our stub ignores -f, the up call "succeeds" against the stub.
+    # Pin instead that the WORKING tree has the gap so any real docker
+    # invocation would fail.
+    make_branch_without no-easy docker/development-easy
+    run oc_add wt-up-will-fail --base no-easy -b --env easy
+    assert_success
+    [[ ! -f "${TMP_PARENT}/openemr-wt-wt-up-will-fail/docker/development-easy/docker-compose.yml" ]] \
+        || fail "docker-compose.yml present on branch that should lack it"
+}

--- a/tests/bats/openemr-cmd/add_existing_branch.bats
+++ b/tests/bats/openemr-cmd/add_existing_branch.bats
@@ -1,0 +1,139 @@
+# BATS: cmd_worktree_add <branch> (without -b) — check out an existing
+# local branch in a new worktree dir.
+#
+# Without -b, the script calls `git worktree add <dir> <branch>` directly.
+# Edge cases driven by git's behavior:
+#   - Branch doesn't exist → git fails with a clear "not a valid object name"
+#   - Branch is the currently-checked-out HEAD in the PRIMARY repo → git
+#     refuses ("already checked out").
+#   - Branch is checked out in ANOTHER existing worktree → git refuses
+#     ("already used by worktree").
+#
+# We don't re-validate git's own messages exhaustively; we just pin that
+# add fails cleanly with no half-built state.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Create an existing local branch in the primary repo (separate from master).
+make_local_branch() {
+    local branch=$1
+    git -C "${TMP_ROOT}" checkout --quiet -b "${branch}" master
+    echo "content-on-${branch}" > "${TMP_ROOT}/${branch}.txt"
+    git -C "${TMP_ROOT}" add "${branch}.txt"
+    git -C "${TMP_ROOT}" -c user.email=bats@e.com -c user.name=bats \
+        -c commit.gpgsign=false \
+        commit --quiet -m "init ${branch}"
+    git -C "${TMP_ROOT}" checkout --quiet master
+}
+
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# --- happy path ------------------------------------------------------------
+
+@test "add <existing-branch> (no -b): checks out the existing branch in a new worktree dir" {
+    make_local_branch existing-feature
+    # Capture the branch's tip SHA so we can verify the worktree HEAD.
+    local expected
+    expected=$(git -C "${TMP_ROOT}" rev-parse existing-feature)
+
+    run oc_add existing-feature --env easy
+    assert_success
+
+    # Worktree dir exists at the expected slug.
+    local wt_dir="${TMP_PARENT}/openemr-wt-existing-feature"
+    [[ -d "${wt_dir}" ]] || fail "worktree dir missing"
+    # HEAD matches the branch tip.
+    local actual
+    actual=$(git -C "${wt_dir}" rev-parse HEAD)
+    [[ "${actual}" = "${expected}" ]] \
+        || fail "HEAD is ${actual}, expected ${expected}"
+    # State entry created.
+    [[ "$(jq -r 'has("existing-feature")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry missing"
+}
+
+# --- error: branch doesn't exist -------------------------------------------
+
+@test "add <nonexistent-branch> (no -b): git fails cleanly, no state" {
+    run oc_add ghost-branch --env easy
+    assert_failure
+    # No state entry written.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("ghost-branch")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written for nonexistent branch"
+    fi
+    [[ ! -d "${TMP_PARENT}/openemr-wt-ghost-branch" ]] \
+        || fail "worktree dir created for nonexistent branch"
+}
+
+# --- error: branch already checked out in another worktree -----------------
+
+@test "add <branch>: refuses when branch is already checked out in another worktree" {
+    make_local_branch already-here
+    # First add succeeds.
+    oc_add already-here --env easy >/dev/null
+    # Second add (different slug-target) should fail because git refuses
+    # to check out the same branch in two worktrees.
+    # We can't easily change the on-disk slug for the same branch (the slug
+    # is deterministic from the branch name), but we can simulate by trying
+    # to add the SAME branch after manually removing the state entry — that
+    # way the script's own "already in state" check doesn't fire and we
+    # exercise git's refusal directly.
+    local tmp
+    tmp=$(mktemp)
+    jq 'del(."already-here")' "${STATE_FILE}" > "${tmp}"
+    mv "${tmp}" "${STATE_FILE}"
+
+    run oc_add already-here --env easy
+    assert_failure
+    if ! ( echo "${output}" | grep -Eq "already (exists|checked out|used by worktree)" ); then
+        echo "${output}"
+        fail "expected git's already-checked-out/used error"
+    fi
+}
+
+# --- branch checked out in PRIMARY repo as HEAD -----------------------------
+
+@test "add <master> (no -b): git refuses when branch is HEAD of the primary repo" {
+    # master is HEAD in primary (the fixture's default). Adding it to a
+    # worktree should be refused by git.
+    run oc_add master --env easy
+    assert_failure
+    if ! ( echo "${output}" | grep -Eq "already (exists|checked out|used by worktree)" ); then
+        echo "${output}"
+        fail "expected git's already-checked-out error for master"
+    fi
+    # No state entry.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("master")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written for primary HEAD"
+    fi
+}

--- a/tests/bats/openemr-cmd/add_start_failure.bats
+++ b/tests/bats/openemr-cmd/add_start_failure.bats
@@ -1,0 +1,119 @@
+# BATS: cmd_worktree_add --start failure behavior.
+#
+# Sequence:
+#   1. wt_state_set  (state entry written)
+#   2. wt_write_env  + wt_write_override  (compose files written)
+#   3. cmd_worktree_up  (docker compose up -d)
+#
+# If step 3 fails, set -e exits the script. State + dir + compose files
+# are already on disk; the partial stack-up may have left some containers
+# in a bad state. Pin the contract: state and dir survive, so a follow-up
+# `worktree up` retry or `worktree remove` is straightforward.
+#
+# NOTE: this is intentional non-atomic behavior — rolling back would
+# require deleting the worktree the user just created, which they might
+# not want (the only thing wrong is the docker stack, not the checkout).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+# Variant docker stub: 'compose' probe succeeds; any 'compose up' fails
+# with exit 9. Other compose subcommands also fail so a partial state
+# doesn't accidentally clean up via a sneaky `down` call.
+oc_make_docker_up_failing_stub_dir() {
+    local d log
+    d=$(oc_mktempdir)
+    log="${d}/docker.log"
+    : > "${log}"
+    cat > "${d}/docker" <<STUB
+#!/bin/sh
+echo "\$@" >> "${log}"
+if [ "\$#" = "1" ] && [ "\$1" = "compose" ]; then
+    exit 0
+fi
+case " \$* " in
+    *' up '*) exit 9 ;;
+    *' compose '*) exit 0 ;;
+esac
+exit 0
+STUB
+    chmod +x "${d}/docker"
+    echo "${d}"
+}
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_up_failing_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+@test "add --start: when docker compose up fails, state + dir + compose files survive (no rollback)" {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "${SCRIPT}" worktree add start-fail -b --env easy --start
+    assert_failure
+
+    # State entry present — wt_state_set already ran.
+    [[ -f "${STATE_FILE}" ]] || fail "state file missing"
+    [[ "$(jq -r 'has("start-fail")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry missing"
+    # Dir present and is a real git worktree (registered).
+    local wt_dir="${TMP_PARENT}/openemr-wt-start-fail"
+    [[ -d "${wt_dir}" ]] || fail "worktree dir missing"
+    git -C "${TMP_ROOT}" worktree list --porcelain \
+        | grep -Fqx "worktree ${wt_dir}" \
+        || fail "worktree not registered with git"
+    # Compose files written.
+    [[ -f "${wt_dir}/docker/development-easy/.env" ]] \
+        || fail ".env missing after failed --start"
+    [[ -f "${wt_dir}/docker/development-easy/docker-compose.override.yml" ]] \
+        || fail "override missing after failed --start"
+    # Lockfile cleaned up via EXIT trap.
+    [[ ! -e "${STATE_FILE}.lock" ]] || fail "lockfile lingering after failed --start"
+}
+
+@test "add --start failure: a follow-up 'worktree up' (without --start) can be retried" {
+    # The 'no rollback' contract above only matters if recovery actually
+    # works. Confirm that with the up-failing stub still in place, a
+    # subsequent 'worktree up' invocation reaches the same docker call
+    # path (i.e. up errors are surfaced, not swallowed) — same failure,
+    # not a different one. The user's recovery path is real.
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add retry-target -b --env easy --start
+    assert_failure
+    [[ "$(jq -r 'has("retry-target")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry missing after first failed add --start"
+    # Retry just the up — should also fail (stub still rejects compose up).
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree up retry-target
+    assert_failure
+    # State + dir still there.
+    [[ "$(jq -r 'has("retry-target")' "${STATE_FILE}")" = "true" ]] \
+        || fail "state entry gone after up retry"
+    [[ -d "${TMP_PARENT}/openemr-wt-retry-target" ]] \
+        || fail "dir gone after up retry"
+}

--- a/tests/bats/openemr-cmd/add_start_failure.bats
+++ b/tests/bats/openemr-cmd/add_start_failure.bats
@@ -75,11 +75,16 @@ teardown() {
     [[ "$(jq -r 'has("start-fail")' "${STATE_FILE}")" = "true" ]] \
         || fail "state entry missing"
     # Dir present and is a real git worktree (registered).
+    # macOS /tmp is a symlink to /private/tmp, so `git worktree list` reports
+    # the canonical path even when we constructed wt_dir against /tmp/...;
+    # canonicalize both sides before comparing.
     local wt_dir="${TMP_PARENT}/openemr-wt-start-fail"
     [[ -d "${wt_dir}" ]] || fail "worktree dir missing"
+    local wt_dir_real
+    wt_dir_real=$(cd "${wt_dir}" && pwd -P)
     git -C "${TMP_ROOT}" worktree list --porcelain \
-        | grep -Fqx "worktree ${wt_dir}" \
-        || fail "worktree not registered with git"
+        | grep -Fqx "worktree ${wt_dir_real}" \
+        || { git -C "${TMP_ROOT}" worktree list --porcelain; fail "worktree not registered with git (looking for ${wt_dir_real})"; }
     # Compose files written.
     [[ -f "${wt_dir}/docker/development-easy/.env" ]] \
         || fail ".env missing after failed --start"

--- a/tests/bats/openemr-cmd/fetch_to_sha_errors.bats
+++ b/tests/bats/openemr-cmd/fetch_to_sha_errors.bats
@@ -1,0 +1,109 @@
+# BATS: wt_fetch_to_sha error paths, surfaced through the canonical
+# fetch path of `worktree add -b` (no --base).
+#
+# wt_fetch_to_sha is reached either via WT_CANONICAL_URL (default -b
+# fetch) or via wt_resolve_base when --base looks like a URL. The
+# success paths are covered by worktree_misc and add_base_forms; this
+# file pins the failure modes.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+
+    # An empty-but-valid git repo (no branches, no master) for the
+    # "URL reachable, ref not present" scenario.
+    EMPTY_ROOT="${TMP_PARENT}/empty-repo"
+    mkdir -p "${EMPTY_ROOT}"
+    git -C "${EMPTY_ROOT}" init --quiet --bare
+
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT EMPTY_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=5 \
+        "$@" \
+        "${SCRIPT}" worktree add wt-fetch-fail -b --env easy
+}
+
+# --- WT_CANONICAL_URL unreachable ------------------------------------------
+
+@test "fetch: WT_CANONICAL_URL pointing at a nonexistent file:// path dies cleanly" {
+    run oc_add WT_CANONICAL_URL="file:///nonexistent/canonical-url-bats-test.git"
+    assert_failure
+    # The die-message surfaces the URL we tried (already covered in
+    # worktree_misc.bats); pin a second time here for the no-half-state
+    # part of the contract.
+    assert_output --partial "Failed to fetch master"
+    assert_output --partial "/nonexistent/canonical-url-bats-test.git"
+    # No half-built state or dir.
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("wt-fetch-fail")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written despite fetch failure"
+    fi
+    [[ ! -d "${TMP_PARENT}/openemr-wt-wt-fetch-fail" ]] \
+        || fail "worktree dir created despite fetch failure"
+    # Lockfile released by EXIT trap.
+    [[ ! -e "${STATE_FILE}.lock" ]] || fail "lockfile lingering"
+}
+
+# --- URL reachable but ref absent ------------------------------------------
+
+@test "fetch: URL reachable but ref absent (empty repo has no 'master') dies cleanly" {
+    # An empty bare repo: file:// is reachable, but 'master' doesn't exist.
+    run oc_add WT_CANONICAL_URL="file://${EMPTY_ROOT}"
+    assert_failure
+    assert_output --partial "Failed to fetch master"
+    assert_output --partial "${EMPTY_ROOT}"
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("wt-fetch-fail")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written despite ref-missing fetch failure"
+    fi
+}
+
+# --- --base URL form failure paths -----------------------------------------
+
+@test "--base file://<nonexistent>#<ref>: dies cleanly with no half-state" {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree add base-url-bad -b \
+            --base "file:///nonexistent/also-bogus.git#master" --env easy
+    assert_failure
+    assert_output --partial "Failed to resolve --base"
+    if [[ -f "${STATE_FILE}" ]]; then
+        [[ "$(jq -r 'has("base-url-bad")' "${STATE_FILE}")" = "false" ]] \
+            || fail "state entry written despite --base URL failure"
+    fi
+}
+
+@test "--base file://<reachable>#<nonexistent-ref>: dies cleanly" {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree add base-bad-ref -b \
+            --base "file://${EMPTY_ROOT}#no-such-branch" --env easy
+    assert_failure
+    assert_output --partial "Failed to resolve --base"
+}

--- a/tests/bats/openemr-cmd/list_rendering_edges.bats
+++ b/tests/bats/openemr-cmd/list_rendering_edges.bats
@@ -1,0 +1,109 @@
+# BATS: cmd_worktree_list rendering for state entries with awkward
+# characters. The list path walks state via `jq | @tsv` + read -r, then
+# printf-aligns columns. Pathological-but-possible state entries should
+# render without crashing or breaking out of the printf format.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_list() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree list
+}
+
+# --- unicode in branch name -------------------------------------------------
+
+@test "list: unicode branch name renders without crashing" {
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/résumé": {"offset": 1, "dir": "${TMP_PARENT}/openemr-wt-feature-rsum", "env": "easy"},
+  "feature/日本語": {"offset": 2, "dir": "${TMP_PARENT}/openemr-wt-feature-",     "env": "easy-light"}
+}
+JSON
+    run oc_list
+    assert_success
+    # Both entries appear in output. The branch column may be width-truncated
+    # by printf when the multi-byte char count exceeds 30 — we just check
+    # the branch name strings are present somewhere in the output.
+    assert_output --partial "feature/résumé"
+    assert_output --partial "feature/日本語"
+}
+
+# --- dir path with spaces ---------------------------------------------------
+
+@test "list: dir path containing spaces renders intact (no field splitting)" {
+    local spaced_parent="${TMP_PARENT}/has spaces"
+    mkdir -p "${spaced_parent}/openemr-wt-spaced"
+    cat > "${STATE_FILE}" <<JSON
+{
+  "feature/spaced": {"offset": 1, "dir": "${spaced_parent}/openemr-wt-spaced", "env": "easy"}
+}
+JSON
+    run oc_list
+    assert_success
+    # The full path (with the space) should appear verbatim in output.
+    assert_output --partial "${spaced_parent}/openemr-wt-spaced"
+    # And the branch name should still be present.
+    assert_output --partial "feature/spaced"
+}
+
+# --- very long branch name --------------------------------------------------
+
+@test "list: very long branch name does not break formatting" {
+    local long
+    long=$(printf 'b%.0s' {1..200})
+    cat > "${STATE_FILE}" <<JSON
+{
+  "${long}": {"offset": 1, "dir": "${TMP_PARENT}/openemr-wt-${long}", "env": "easy"}
+}
+JSON
+    run oc_list
+    assert_success
+    # printf "%-30s" left-pads, doesn't truncate. The long name should
+    # appear in full somewhere in the output.
+    assert_output --partial "${long}"
+}
+
+# --- many entries -----------------------------------------------------------
+
+@test "list: 25 entries all render in a single pass" {
+    # Build a state file with 25 entries. None of the dirs exist, so they
+    # all show as 'missing' — that's fine, we're testing the iteration
+    # path, not the status detection.
+    local entries=""
+    local i
+    for i in $(seq 1 25); do
+        if [[ -n "${entries}" ]]; then entries="${entries},"; fi
+        entries="${entries}\"branch-${i}\":{\"offset\":${i},\"dir\":\"${TMP_PARENT}/gone-${i}\",\"env\":\"easy\"}"
+    done
+    echo "{${entries}}" > "${STATE_FILE}"
+
+    run oc_list
+    assert_success
+    assert_output --partial "branch-1"
+    assert_output --partial "branch-25"
+    # Stale-count hint mentions the right total.
+    assert_output --partial "(25 stale state entries"
+}

--- a/tests/bats/openemr-cmd/race_up_during_remove.bats
+++ b/tests/bats/openemr-cmd/race_up_during_remove.bats
@@ -1,0 +1,125 @@
+# BATS: `worktree up` does NOT acquire the state lock.
+#
+# Today, only state-mutating ops (add / remove / set-env / prune) take
+# the lock. Read-and-act ops (up / down / start / stop / list) read
+# state without coordination. That means a `worktree up` can race with
+# a concurrent `worktree remove` on the same branch:
+#
+#   - If up reads state before remove's wt_state_remove runs, up sees
+#     the entry and proceeds to `docker compose up`, creating new
+#     containers AFTER remove already brought the old ones down. Once
+#     remove finishes, those new containers are orphaned (no state
+#     entry pointing at them).
+#
+# These tests PIN that current contract — there's no read-side
+# coordination — so any future change that adds a lock to `up` is an
+# intentional decision, not an accidental behavior shift. The race
+# itself is documented as a follow-up to revisit.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    LOCK_FILE="${STATE_FILE}.lock"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE LOCK_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add "$@"
+}
+
+# --- contract: up does not block on a held lock ---------------------------
+
+@test "race: 'worktree up' does NOT acquire the state lock (runs even when lock is held)" {
+    oc_add up-vs-lock -b --env easy >/dev/null
+    # Manually hold the lock as a different process would.
+    echo 99999 > "${LOCK_FILE}"
+
+    # With a very short timeout — if up tried to acquire the lock, it
+    # would time out in 1 second. The fact that it doesn't time out
+    # proves it doesn't acquire the lock.
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        "${SCRIPT}" worktree up up-vs-lock
+    # Should succeed (docker stub returns 0).
+    assert_success
+    refute_output --partial "Timed out waiting for state lock"
+    # Lockfile we placed manually still there — up did not touch it.
+    [[ -f "${LOCK_FILE}" ]] || fail "manual lockfile vanished after up; expected no-touch"
+    [[ "$(cat "${LOCK_FILE}")" = "99999" ]] || fail "manual holder PID overwritten"
+    rm -f "${LOCK_FILE}"
+}
+
+# --- companion: down / start / stop / list also don't acquire the lock ----
+# Pinning the broader contract so any future "add lock to read paths"
+# change has to update these explicitly.
+
+@test "race: 'worktree down' does NOT acquire the state lock" {
+    oc_add down-vs-lock -b --env easy >/dev/null
+    echo 99999 > "${LOCK_FILE}"
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        "${SCRIPT}" worktree down down-vs-lock --keep-volumes
+    assert_success
+    refute_output --partial "Timed out"
+    [[ -f "${LOCK_FILE}" ]] || fail "manual lockfile vanished after down"
+    rm -f "${LOCK_FILE}"
+}
+
+@test "race: 'worktree list' does NOT acquire the state lock" {
+    oc_add list-vs-lock -b --env easy >/dev/null
+    echo 99999 > "${LOCK_FILE}"
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_STATE_LOCK_TIMEOUT_S=1 \
+        "${SCRIPT}" worktree list
+    assert_success
+    refute_output --partial "Timed out"
+    assert_output --partial "list-vs-lock"
+    [[ -f "${LOCK_FILE}" ]] || fail "manual lockfile vanished after list"
+    rm -f "${LOCK_FILE}"
+}
+
+# --- contract: up after remove cleared state surfaces a clean error -------
+
+@test "race: 'worktree up' after the state entry is gone surfaces 'No worktree found'" {
+    # Simulate the post-remove state: state file exists but has no entry
+    # for the branch.
+    echo '{}' > "${STATE_FILE}"
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree up gone-branch
+    assert_failure
+    # wt_compose_cmd's wt_state_get returns empty → wt_die at line ~638.
+    assert_output --partial "No worktree found for branch 'gone-branch'"
+}

--- a/tests/bats/openemr-cmd/regen_happy.bats
+++ b/tests/bats/openemr-cmd/regen_happy.bats
@@ -1,0 +1,137 @@
+# BATS: cmd_worktree_regen happy path.
+#
+# regen calls wt_write_env + wt_write_override against the current state
+# entry — useful when the user has manually stomped the .env / override
+# files, or when wt_state_set has been hand-edited to a different env
+# and the files need to catch up. The failure paths (missing branch arg,
+# no state file, unknown branch) are pinned in worktree_lifecycle.bats;
+# this file covers the actual rewrite behavior.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    TMP_ROOT="${TMP_PARENT}/primary"
+    mkdir -p "${TMP_ROOT}"
+    oc_init_repo_with_fixtures "${TMP_ROOT}"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    STATE_FILE="${TMP_ROOT}/.worktrees.json"
+    export TMP_PARENT TMP_ROOT STUB_DIR STATE_FILE
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Add a worktree (helper for setting up fixtures).
+oc_add() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        WT_CANONICAL_URL="file://${TMP_ROOT}" \
+        "${SCRIPT}" worktree add "$@"
+}
+
+oc_regen() {
+    env \
+        PATH="${STUB_DIR}:${PATH}" \
+        OPENEMR_ROOT="${TMP_ROOT}" \
+        WORKTREE_PARENT="${TMP_PARENT}" \
+        "${SCRIPT}" worktree regen "$@"
+}
+
+# --- regen rewrites .env after a manual stomp -------------------------------
+
+@test "regen: rewrites .env back to the canonical contents after a manual stomp" {
+    oc_add regen-env -b --env easy >/dev/null
+    local env_file="${TMP_PARENT}/openemr-wt-regen-env/docker/development-easy/.env"
+    [[ -f "${env_file}" ]] || fail "fixture .env missing"
+    local before
+    before=$(cat "${env_file}")
+
+    # Stomp the file with garbage.
+    echo "STOMPED_GARBAGE=1" > "${env_file}"
+
+    run oc_regen regen-env
+    assert_success
+    assert_output --partial "Regenerating compose files for 'regen-env'"
+
+    # File restored to what cmd_worktree_add originally wrote.
+    [[ "$(cat "${env_file}")" = "${before}" ]] \
+        || { diff <(echo "${before}") "${env_file}"; fail ".env was not restored to original contents"; }
+}
+
+@test "regen: rewrites docker-compose.override.yml after a manual stomp" {
+    oc_add regen-override -b --env easy >/dev/null
+    local override="${TMP_PARENT}/openemr-wt-regen-override/docker/development-easy/docker-compose.override.yml"
+    [[ -f "${override}" ]] || fail "fixture override missing"
+    local before
+    before=$(cat "${override}")
+
+    # Stomp.
+    : > "${override}"
+
+    run oc_regen regen-override
+    assert_success
+    [[ "$(cat "${override}")" = "${before}" ]] \
+        || fail "override.yml was not restored to original contents"
+}
+
+@test "regen: when state was hand-edited to a different env, regen rewrites the files for the NEW env" {
+    # Add on easy, then hand-edit state to say easy-light. regen should
+    # write files into the easy-light compose subdir (state is source of
+    # truth for env; regen brings files in line).
+    oc_add regen-env-switch -b --env easy >/dev/null
+    local wt_dir="${TMP_PARENT}/openemr-wt-regen-env-switch"
+    [[ -f "${wt_dir}/docker/development-easy/.env" ]] || fail "easy .env not created by add"
+
+    # Hand-edit state to easy-light.
+    local tmp
+    tmp=$(mktemp)
+    jq '."regen-env-switch".env = "easy-light"' "${STATE_FILE}" > "${tmp}"
+    mv "${tmp}" "${STATE_FILE}"
+
+    run oc_regen regen-env-switch
+    assert_success
+    # easy-light files now exist (regen wrote them).
+    [[ -f "${wt_dir}/docker/development-easy-light/.env" ]] \
+        || fail "regen did not write easy-light .env after state edit"
+    [[ -f "${wt_dir}/docker/development-easy-light/docker-compose.override.yml" ]] \
+        || fail "regen did not write easy-light override after state edit"
+    # NOTE: regen does NOT delete the old env's files (the previous
+    # easy/.env is still on disk). Pinning that current behavior — if it
+    # changes, this assertion documents the contract was different before.
+    [[ -f "${wt_dir}/docker/development-easy/.env" ]] \
+        || fail "regen unexpectedly removed the old env's .env; that would be a contract change"
+}
+
+# --- regen against multi-entry state preserves other entries ---------------
+
+@test "regen: only touches the named branch's entry; other entries' files unaffected" {
+    oc_add regen-a -b --env easy >/dev/null
+    oc_add regen-b -b --env easy-light >/dev/null
+
+    local env_a="${TMP_PARENT}/openemr-wt-regen-a/docker/development-easy/.env"
+    local env_b="${TMP_PARENT}/openemr-wt-regen-b/docker/development-easy-light/.env"
+
+    local before_b
+    before_b=$(cat "${env_b}")
+
+    # Stomp BOTH files, but only regen 'a'.
+    echo "STOMPED_A=1" > "${env_a}"
+    echo "STOMPED_B=1" > "${env_b}"
+
+    run oc_regen regen-a
+    assert_success
+    # 'a' restored.
+    grep -q "STOMPED_A" "${env_a}" && fail "'a' was not regenerated"
+    # 'b' still stomped (we didn't regen it).
+    grep -q "STOMPED_B" "${env_b}" || fail "'b' was modified by regen of 'a'"
+}

--- a/tests/bats/openemr-cmd/regen_happy.bats
+++ b/tests/bats/openemr-cmd/regen_happy.bats
@@ -130,8 +130,12 @@ oc_regen() {
 
     run oc_regen regen-a
     assert_success
-    # 'a' restored.
-    grep -q "STOMPED_A" "${env_a}" && fail "'a' was not regenerated"
+    # 'a' restored — assert file presence first so a missing-file scenario
+    # (grep returns non-zero for "no match" AND for "no file") can't false-pass.
+    [[ -f "${env_a}" ]] || fail "'a' .env file missing after regen"
+    if grep -q "STOMPED_A" "${env_a}"; then
+        fail "'a' was not regenerated (STOMPED_A still present)"
+    fi
     # 'b' still stomped (we didn't regen it).
     grep -q "STOMPED_B" "${env_b}" || fail "'b' was modified by regen of 'a'"
 }


### PR DESCRIPTION
## Summary

Closing the remaining hermetic coverage gaps before pivoting to non-worktree openemr-cmd surface. **Pure additive — no script changes, no behavior changes.** Surfaces a few contracts that were previously implicit.

## What's new (8 files, 35 tests)

| File | What it pins |
|---|---|
| `regen_happy.bats` | regen rewrites .env + override after a manual stomp; regen after state was hand-edited to a different env writes files for the new env (and leaves the old env's files in place — current contract). |
| `add_base_forms.bats` | --base form-by-form coverage of `wt_resolve_base` — local branch, tag, full + short SHA, `remote/branch`, `file://` URL with and without `#ref`. Plus error paths (nonexistent ref hint, --base requires value, --base only with -b). |
| `add_start_failure.bats` | The no-rollback contract when `docker compose up` fails inside `--start` (state + dir + compose files survive so a follow-up `worktree up` can be retried). |
| `add_compose_subdir_on_branch.bats` | docker/library missing on the branch dies cleanly; `docker/development-<env>/` missing on the branch is silently synthesized via `mkdir -p` — the actual failure surfaces later at `worktree up`. Pinning that two-stage contract. |
| `add_existing_branch.bats` | Happy path of adding an existing local branch (no `-b`); nonexistent branch fails clean; branch checked out in another worktree fails; branch is primary's HEAD fails. |
| `fetch_to_sha_errors.bats` | `WT_CANONICAL_URL` pointing at a nonexistent file:// URL; URL reachable but ref missing (empty bare repo); same via --base URL forms. All die cleanly with no half-state. |
| `list_rendering_edges.bats` | Unicode branch names, dir paths with spaces, very long branch names, 25-entry state file. The list rendering path doesn't crash and the `@tsv` parsing doesn't leak. |
| `race_up_during_remove.bats` | Pins that `worktree up` / `down` / `list` do NOT acquire the state lock today (only state-mutating ops do). |

## Race surfaced as a known follow-up

The last file documents a real race window: `worktree up` could see a state entry that `worktree remove` is about to delete, and `docker compose up` would create new containers AFTER remove already brought the old ones down — orphan stack with no state pointing at it. The fix would acquire the lock around the state read in `cmd_worktree_up` (and the other read-only paths). Out of scope for this PR; this PR pins the current behavior so the fix is an intentional change rather than an accidental one.

## Test plan

- [x] Full hermetic bats suite — 211 tests, 0 failures
- [x] `shellcheck utilities/openemr-cmd/openemr-cmd` clean
- [ ] CI: BATS openemr-cmd (ubuntu-22.04) green
- [ ] CI: BATS openemr-cmd (macos-14) green
- [ ] CI: ShellCheck green
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for `worktree add`, `list`, `up/down`, and `regen`.
  * Added validation for `--base` resolution across local refs, remote refs, and `file://` URL forms, including missing-ref and malformed-argument failures.
  * Covered compose-subdirectory creation, failure behavior during `--start`, and cleanup/consistency when errors occur.
  * Strengthened rendering tests for edge-case branch names, spaced paths, long values, and larger state listings.
  * Added concurrency/locking race tests and manual-state recovery checks for `up`.
  * Added coverage for adding existing branches and branch-usage/primary-head failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->