### PR TITLE
test(openemr-cmd): deeper non-worktree bats — admin commands, maria-shell, worktree-label fallback

### DIFF
--- a/tests/bats/openemr-cmd/admin_commands.bats
+++ b/tests/bats/openemr-cmd/admin_commands.bats
@@ -1,0 +1,141 @@
+# BATS: non-worktree admin commands — docker-log (dl), docker-names (dn),
+# ensure-version (ev), encoding-collation (ec), maria-shell (ms),
+# import-random-patients (irp).
+#
+# These are NOT devtools passthroughs — each invokes a specific docker
+# command or sub-script. Pin the invocation shape via the docker stub.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    CONTAINER=fixed-admin-target
+    export STUB_DIR CONTAINER
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run() {
+    env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" -d "${CONTAINER}" "$@"
+}
+
+# --- docker-log / dl --------------------------------------------------------
+
+@test "dl: invokes 'docker logs <CONTAINER_ID>'" {
+    run oc_run dl
+    assert_success
+    grep -Fq "logs ${CONTAINER}" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'docker logs ${CONTAINER}' invocation"; }
+}
+
+@test "dl: 'docker-log' long form is equivalent" {
+    run oc_run docker-log
+    assert_success
+    grep -Fq "logs ${CONTAINER}" "${STUB_DIR}/docker.log" || fail "long form did not invoke 'docker logs'"
+}
+
+# --- docker-names / dn ------------------------------------------------------
+
+@test "dn (no arg): lists running + 'other status' containers via 'docker ps' / 'docker ps -a'" {
+    run oc_run dn
+    assert_success
+    # Output structure assertions — the function prints these banners.
+    assert_output --partial "Running Docker Names"
+    assert_output --partial "Other Docker Status Names"
+    # Stub recorded both `ps` (running) and `ps -a` (all) — the function
+    # uses both for the two sections.
+    grep -Eq "^ps " "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'ps' query"; }
+    grep -Eq "^ps -a " "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'ps -a' query"; }
+}
+
+@test "dn <name>: 'check single Docker Name' branch fires with the keyword in scope" {
+    # check_docker_names with 1 arg goes into the single-name branch.
+    run oc_run dn openemr
+    assert_success
+    assert_output --partial "Check the single Docker Name"
+    # 'docker ps -a' is the query in the single-name branch.
+    grep -Eq "^ps -a " "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'ps -a' for single-name check"; }
+}
+
+# --- import-random-patients / irp -----------------------------------------
+# Special-case: this is the one devtools subcommand where the script sets
+# ENV_VAR to a real value (OPENEMR_ENABLE_CCDA_IMPORT=1) before calling
+# run_devtools_in_docker. The -e flag must carry that var into the container.
+
+@test "irp: docker exec includes -e OPENEMR_ENABLE_CCDA_IMPORT=1" {
+    run oc_run irp
+    assert_success
+    grep -Fq "exec -e OPENEMR_ENABLE_CCDA_IMPORT=1" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '-e OPENEMR_ENABLE_CCDA_IMPORT=1' in invocation"; }
+    # And the dispatch target is /root/devtools import-random-patients.
+    grep -Fq "/root/devtools import-random-patients" "${STUB_DIR}/docker.log" \
+        || fail "expected '/root/devtools import-random-patients' devtool"
+}
+
+@test "irp: 'import-random-patients' long form is equivalent" {
+    run oc_run import-random-patients
+    assert_success
+    grep -Fq "exec -e OPENEMR_ENABLE_CCDA_IMPORT=1" "${STUB_DIR}/docker.log" || fail "long form did not set env var"
+}
+
+@test "non-irp devtools subcommands do NOT carry OPENEMR_ENABLE_CCDA_IMPORT" {
+    # The env-var set is isolated to irp/import-random-patients; other devtools
+    # (e.g. pst) must NOT inherit it. Pinning that scoping.
+    run oc_run pst
+    assert_success
+    if grep -Fq "OPENEMR_ENABLE_CCDA_IMPORT" "${STUB_DIR}/docker.log"; then
+        cat "${STUB_DIR}/docker.log"
+        fail "non-irp devtool leaked OPENEMR_ENABLE_CCDA_IMPORT into docker exec"
+    fi
+}
+
+# --- ensure-version / ev --------------------------------------------------
+# ev <version> dispatches to `/root/devtools upgrade <version>` via
+# run_devtools_in_docker.
+
+@test "ev <version>: dispatches to /root/devtools upgrade <version>" {
+    run oc_run ev 5.0.2
+    assert_success
+    grep -Fq "/root/devtools upgrade 5.0.2" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '/root/devtools upgrade 5.0.2' invocation"; }
+    grep -Fq "${CONTAINER}" "${STUB_DIR}/docker.log" || fail "ev did not target ${CONTAINER}"
+}
+
+@test "ev (no args): prints usage hint and exits 22 (no 'unbound variable' crash)" {
+    # Regression for a bug where `local FOO=\"$1\"` fired before the arg-count
+    # check, crashing under `set -u` with "unbound variable" before the user
+    # saw the helpful usage message. Fixed by reordering the check first.
+    run oc_run ev
+    [[ "${status}" -eq 22 ]] || fail "expected exit 22 (BACKUP_FILE_CODE); got ${status}"
+    assert_output --partial "Please provide the OpenEMR version"
+    assert_output --partial "ensure-version|ev"
+    refute_output --partial "unbound variable"
+}
+
+# --- encoding-collation / ec ----------------------------------------------
+# ec <encoding> <collation> dispatches to
+# `/root/devtools change-encoding-collation <encoding> <collation>`.
+
+@test "ec <encoding> <collation>: dispatches to /root/devtools change-encoding-collation <args>" {
+    run oc_run ec utf8mb4 utf8mb4_general_ci
+    assert_success
+    grep -Fq "/root/devtools change-encoding-collation utf8mb4 utf8mb4_general_ci" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected change-encoding-collation invocation"; }
+}
+
+@test "ec (no args): prints usage hint and exits 17 (CHARACTER_SET_COLLATION_CODE)" {
+    run oc_run ec
+    [[ "${status}" -eq 17 ]] || fail "expected exit 17; got ${status}"
+    assert_output --partial "Please provide two parameters"
+    assert_output --partial "encoding-collation|ec"
+}

--- a/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
+++ b/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
@@ -31,11 +31,15 @@ oc_make_docker_label_fallback_stub() {
     d=$(oc_mktempdir)
     log="${d}/docker.log"
     : > "${log}"
-    cat > "${d}/docker" <<'STUB'
+    # Unquoted heredoc so ${log} expands at write time; escape \$@/\$*/\$1
+    # so they stay literal in the stub script. Avoids needing `sed -i` later
+    # (sed -i is non-portable: GNU accepts no extension arg, BSD/macOS
+    # requires one).
+    cat > "${d}/docker" <<STUB
 #!/bin/sh
-echo "$@" >> STUBLOG
-args="$*"
-case "${args}" in
+echo "\$@" >> "${log}"
+args="\$*"
+case "\${args}" in
     "compose")
         exit 0
         ;;
@@ -45,7 +49,7 @@ case "${args}" in
     *"--filter id=wt-container-id"*)
         printf 'openemr-myworktree-openemr-1\n'
         ;;
-    *"--filter name=openemr-8-5"*|*"--filter name=openemr[_\\-]1"*|*"--filter name=couchdb"*|*"--filter name=mysql"*)
+    *"--filter name=openemr-8-5"*|*"--filter name=openemr[_\\\\-]1"*|*"--filter name=couchdb"*|*"--filter name=mysql"*)
         # Empty (no match) — forces the label-fallback path to be exercised.
         ;;
     *)
@@ -54,8 +58,6 @@ case "${args}" in
 esac
 exit 0
 STUB
-    # Replace STUBLOG placeholder with the absolute log path.
-    sed -i "s|STUBLOG|${log}|g" "${d}/docker"
     chmod +x "${d}/docker"
     echo "${d}"
 }

--- a/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
+++ b/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
@@ -1,0 +1,110 @@
+# BATS: container resolution — worktree-label fallback path.
+#
+# When neither INSANE_DEV_DOCKER (openemr-8-5[_\-]1) nor EASY_DEV_DOCKER
+# (openemr[_\-]1) name filters match, the script falls back to a label-
+# based query: `docker ps --filter label=com.docker.compose.service=openemr`,
+# then greps for compose-project names starting with "openemr-" and picks
+# the first matching container ID. The user sees a "Note: Targeting
+# worktree container '<name>'" hint encouraging explicit -d.
+#
+# This is the path that lets `openemr-cmd <devtool>` work without -d when
+# the only running openemr stack is a worktree-managed one (not the
+# default 'openemr' or 'openemr-8-5' compose project).
+#
+# container_resolution.bats covered the auto-detect-found and not-found
+# cases; this file fills in the middle case (auto-detect via label
+# fallback succeeded).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+# Stub that branches on the filter args:
+#   - --filter name=openemr-8-5... → empty
+#   - --filter name=openemr[_\-]1  → empty
+#   - --filter label=...service=openemr → "openemr-myworktree\twt-container-id"
+#   - --filter id=wt-container-id → "openemr-myworktree-openemr-1" (container name)
+#   - --filter name=mysql / couchdb → empty
+#   - 'compose' (plugin probe) → 0
+oc_make_docker_label_fallback_stub() {
+    local d log
+    d=$(oc_mktempdir)
+    log="${d}/docker.log"
+    : > "${log}"
+    cat > "${d}/docker" <<'STUB'
+#!/bin/sh
+echo "$@" >> STUBLOG
+args="$*"
+case "${args}" in
+    "compose")
+        exit 0
+        ;;
+    *"--filter label=com.docker.compose.service=openemr"*)
+        printf 'openemr-myworktree\twt-container-id\n'
+        ;;
+    *"--filter id=wt-container-id"*)
+        printf 'openemr-myworktree-openemr-1\n'
+        ;;
+    *"--filter name=openemr-8-5"*|*"--filter name=openemr[_\\-]1"*|*"--filter name=couchdb"*|*"--filter name=mysql"*)
+        # Empty (no match) — forces the label-fallback path to be exercised.
+        ;;
+    *)
+        # Any other ps / inspect / etc.
+        ;;
+esac
+exit 0
+STUB
+    # Replace STUBLOG placeholder with the absolute log path.
+    sed -i "s|STUBLOG|${log}|g" "${d}/docker"
+    chmod +x "${d}/docker"
+    echo "${d}"
+}
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_label_fallback_stub)
+    export STUB_DIR
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+@test "worktree-label fallback: when INSANE + EASY name filters miss, the label query picks the worktree container" {
+    # No -d. INSANE + EASY return empty. Label fallback returns
+    # 'openemr-myworktree\twt-container-id'. Script picks wt-container-id
+    # as CONTAINER_ID and prints the "Targeting worktree container" note.
+    # Then we dispatch a devtool to confirm wt-container-id is the target.
+    run env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" pst
+    assert_success
+    assert_output --partial "Note: Targeting worktree container"
+    assert_output --partial "openemr-myworktree-openemr-1"
+    assert_output --partial "Use -d to specify a different container"
+    # The devtool dispatch should have routed to wt-container-id.
+    grep -Fq "wt-container-id" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected exec into wt-container-id"; }
+    grep -Fq "/root/devtools phpstan" "${STUB_DIR}/docker.log" \
+        || fail "expected '/root/devtools phpstan' devtool"
+}
+
+@test "worktree-label fallback: -d <id> overrides the label-detected container" {
+    # Even when the label fallback would have picked wt-container-id, an
+    # explicit -d wins. Pinning that the -d override has higher priority
+    # than the label-based fallback.
+    run env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" -d explicit-override pst
+    assert_success
+    # The "Targeting worktree container" note STILL fires (the label
+    # fallback ran during initial CONTAINER_ID setup, before -d parsing).
+    # But the actual devtool exec target is the -d value.
+    grep -Fq "/root/devtools phpstan" "${STUB_DIR}/docker.log" \
+        || fail "expected '/root/devtools phpstan'"
+    grep -Fq "explicit-override" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected exec into 'explicit-override'"; }
+    # And wt-container-id should NOT appear in any exec line.
+    if grep -E '^exec .*wt-container-id|\sexec\s.*wt-container-id' "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
+        cat "${STUB_DIR}/docker.log"
+        fail "exec routed to label-fallback id despite -d override"
+    fi
+}

--- a/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
+++ b/tests/bats/openemr-cmd/container_resolution_worktree_fallback.bats
@@ -84,11 +84,13 @@ teardown() {
     assert_output --partial "Note: Targeting worktree container"
     assert_output --partial "openemr-myworktree-openemr-1"
     assert_output --partial "Use -d to specify a different container"
-    # The devtool dispatch should have routed to wt-container-id.
-    grep -Fq "wt-container-id" "${STUB_DIR}/docker.log" \
-        || { cat "${STUB_DIR}/docker.log"; fail "expected exec into wt-container-id"; }
-    grep -Fq "/root/devtools phpstan" "${STUB_DIR}/docker.log" \
-        || fail "expected '/root/devtools phpstan' devtool"
+    # The devtool dispatch should have routed to wt-container-id. Grep
+    # for the EXEC line specifically — a plain "wt-container-id" match
+    # would also hit the `docker ps --filter id=wt-container-id` lookup
+    # the script does to fetch the container name for the user-facing
+    # note, which doesn't prove the dispatch reached exec.
+    grep -Eq 'exec .*wt-container-id.* /root/devtools phpstan' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'exec ... wt-container-id ... /root/devtools phpstan'"; }
 }
 
 @test "worktree-label fallback: -d <id> overrides the label-detected container" {

--- a/tests/bats/openemr-cmd/maria_shell.bats
+++ b/tests/bats/openemr-cmd/maria_shell.bats
@@ -1,0 +1,66 @@
+# BATS: maria-shell (ms) — opens a shell in the mariadb container, NOT
+# the openemr container. This is one of the few subcommands that uses
+# MARIADB_CONTAINER_ID instead of CONTAINER_ID, so it exercises the
+# multi-container resolution path.
+#
+# MARIADB resolution (script lines ~1983-1995):
+#   1. Label-based via `docker ps --filter label=com.docker.compose.project=<X>
+#      --filter label=com.docker.compose.service=mysql` (when CONTAINER_ID
+#      is set, attempt project-scoped lookup first)
+#   2. Fallback: `docker ps --filter name=${MARIADB_DOCKER}` (mysql[_\-]1)
+#
+# Our docker stub treats all `ps --filter name=...` queries the same
+# (returning DOCKER_PS_OUTPUT), which is sufficient to exercise the
+# fallback path. The label-based path is skipped because our stub
+# doesn't implement `docker inspect --format ...` (returns empty).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    export STUB_DIR
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+@test "ms: invokes 'docker exec -it <MARIADB_CONTAINER_ID> /bin/bash'" {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        DOCKER_PS_OUTPUT="mariadb-resolved-id" \
+        "${SCRIPT}" -d openemr-target ms
+    assert_success
+    # The exec target uses the mariadb id (from DOCKER_PS_OUTPUT), not the -d
+    # openemr-target. Pinning that ms uses MARIADB_CONTAINER_ID, not
+    # CONTAINER_ID.
+    grep -Eq 'exec -it mariadb-resolved-id /bin/bash' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'exec -it mariadb-resolved-id /bin/bash'"; }
+}
+
+@test "ms: 'maria-shell' long form is equivalent" {
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        DOCKER_PS_OUTPUT="mariadb-id" \
+        "${SCRIPT}" -d openemr-target maria-shell
+    assert_success
+    grep -Eq 'exec -it mariadb-id /bin/bash' "${STUB_DIR}/docker.log" \
+        || fail "long form did not invoke 'docker exec -it mariadb-id /bin/bash'"
+}
+
+@test "ms: docker ps --filter for mariadb name pattern is issued during resolution" {
+    # Confirm the mariadb-specific resolution actually runs (proves the
+    # script isn't accidentally re-using the openemr CONTAINER_ID).
+    run env \
+        PATH="${STUB_DIR}:${PATH}" \
+        DOCKER_PS_OUTPUT="ignored-here" \
+        "${SCRIPT}" -d openemr-target ms
+    assert_success
+    grep -Eq 'ps --filter name=mysql' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'ps --filter name=mysql...' query"; }
+}

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.45"
+VERSION="1.0.46"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -1637,17 +1637,16 @@ copy_capsule_from_host_to_docker(){
 }
 
 ensure_current_ver_with_upgrade_ver(){
-    # Need a version parameter
-    local UPGRADE_FROM_VERSION="$1"
+    # Check arg count FIRST so a no-arg invocation prints the usage hint
+    # instead of crashing on `local FOO="$1"` under set -u ("unbound variable").
     local BACKUP_FILE_CODE=22
     if [[ $# != 1 ]]; then
         echo 'Please provide the OpenEMR version to upgrade database from.'
         echo 'e.g. openemr-cmd [ensure-version|ev] 5.0.2'
         exit "${BACKUP_FILE_CODE}"
-    else
-        # Use the devtools function
-        run_devtools_in_docker "${CONTAINER_ID}" upgrade "${UPGRADE_FROM_VERSION}"
     fi
+    local UPGRADE_FROM_VERSION="$1"
+    run_devtools_in_docker "${CONTAINER_ID}" upgrade "${UPGRADE_FROM_VERSION}"
 }
 
 change_db_character_set_and_collation(){


### PR DESCRIPTION
## Summary

Continuation of #828's non-worktree coverage. 16 new tests across 3 files, plus a small script fix surfaced by the new coverage.

## What's new (3 files, 16 tests)

| File | What it pins |
|---|---|
| `admin_commands.bats` | `dl`/`docker-log` → `docker logs <id>`; `dn`/`docker-names` no-arg (Running + Other-Status banners; `ps` + `ps -a` queries) and single-name (Check-the-single-Docker-Name branch + `ps -a`); `irp` sets `-e OPENEMR_ENABLE_CCDA_IMPORT=1` on the docker exec **and** other devtools don't inherit it; `ev` + `ec` happy paths plus their no-args usage hints with correct exit codes (22 / 17). |
| `maria_shell.bats` | `ms` / `maria-shell` dispatches `docker exec -it <MARIADB_CONTAINER_ID> /bin/bash`. Mariadb is resolved via the `--filter name=mysql...` fallback (not the openemr `CONTAINER_ID`), pinning multi-container resolution. |
| `container_resolution_worktree_fallback.bats` | When both `INSANE_DEV_DOCKER` and `EASY_DEV_DOCKER` name filters miss, the label-based fallback (`docker ps --filter label=com.docker.compose.service=openemr` → grep `^openemr-`) picks a worktree container and prints the "Targeting worktree container" note. Also pins `-d` still overrides the label-detected ID. |

## Fix surfaced by the new coverage

`ensure_current_ver_with_upgrade_ver` (the `ev` command) had `local UPGRADE_FROM_VERSION="$1"` BEFORE the `$# != 1` check. Under `set -u` that crashes with "unbound variable" when `ev` is invoked without args, instead of printing the usage hint the next branch is meant to surface. Reordered the check first; the no-args path now exits 22 (`BACKUP_FILE_CODE`) with the documented help text. Pinned by a dedicated regression test.

## Test plan

- [x] Full hermetic bats suite — 262 tests, 0 failures
- [x] `shellcheck utilities/openemr-cmd/openemr-cmd` clean
- [ ] CI: BATS openemr-cmd (ubuntu-22.04) green
- [ ] CI: BATS openemr-cmd (macos-14) green
- [ ] CI: ShellCheck green
- [ ] e2e jobs green (no changes to worktree code path, but the workflow filter triggers on the script edit)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `openemr-cmd` behavior for `ev` and `ec` when required arguments are missing, showing correct usage and avoiding crashes.
  * Refined container resolution/dispatch so the right target container is selected in worktree fallback scenarios and name overrides.

* **Tests**
  * Added BATS coverage for `openemr-cmd` admin command dispatch, including expected Docker invocation patterns and environment propagation rules.
  * Added BATS suites for worktree container fallback and MariaDB shell (`ms`/`maria-shell`) dispatch.

* **Chores**
  * Bumped `openemr-cmd` version to `1.0.46`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->