### PR TITLE
test(openemr-cmd): deeper non-worktree bats — snapshot/capsule, webroot, LDAP, prek dispatch; 4 more set-u fixes

### DIFF
--- a/tests/bats/openemr-cmd/helpers.bash
+++ b/tests/bats/openemr-cmd/helpers.bash
@@ -79,7 +79,7 @@ STUB
 # If the script is restructured, bump this constant — the test
 # 'OC_SCRIPT_FUNCS_END points at end of function defs' in helpers_pure.bats
 # will fail loudly when it drifts.
-OC_SCRIPT_FUNCS_END=1744
+OC_SCRIPT_FUNCS_END=1741
 
 # Source ONLY the function definitions of openemr-cmd into the current shell.
 # Caller is responsible for setting OPENEMR_ROOT (and WT_STATE_FILE / others

--- a/tests/bats/openemr-cmd/prek_dispatch.bats
+++ b/tests/bats/openemr-cmd/prek_dispatch.bats
@@ -1,0 +1,140 @@
+# BATS: `openemr-cmd prek <args>` subcommand routing.
+#
+# Unlike the other devtools commands, prek runs Python pre-commit INSIDE
+# the openemr container at the openemr workdir. The dispatch chain (line
+# ~2304):
+#   1. wt_resolve_container_from_cwd: if cwd is inside a managed worktree
+#      from .worktrees.json, route to that worktree's openemr container.
+#      Otherwise return empty.
+#   2. Fall back to CONTAINER_ID (the global one resolved earlier).
+#   3. If still empty, surface a "no running openemr container" error.
+#   4. Otherwise: docker exec -w /var/www/localhost/htdocs/openemr -i <id>
+#      sh -c '<inline-script>' sh <args>
+#   5. The inline script substitutes actionlint-docker → actionlint-system
+#      ONLY for `run` / `install-hooks` subcommands (which read the config).
+#      All other subcommands (--version, --help, autoupdate, etc.) pass
+#      through unchanged.
+#
+# The inline script runs IN the container; our stub only records the
+# outer `docker exec` invocation. So these tests pin:
+#   - the outer dispatch shape (-w, -i, container id, sh -c, args)
+#   - the inline script contains the actionlint substitution logic
+#   - the no-container error path
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    CONTAINER=fixed-prek-target
+    export STUB_DIR CONTAINER
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+# Run via -d so CONTAINER_ID is fixed (skipping the auto-detect chain).
+oc_run() {
+    env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" -d "${CONTAINER}" "$@"
+}
+
+# --- outer dispatch shape --------------------------------------------------
+# The recorded docker.log captures `docker exec ...` invocations via
+# `echo "$@"`. The inline script for prek contains newlines, so a single
+# invocation spans multiple log lines: the FIRST line starts with
+# `exec -w /var/www/localhost/htdocs/openemr -i <id> sh -c`, the MIDDLE
+# lines are the inline script body, and the LAST line is the trailing
+# `sh <args>` (positional args to the inline sh). Anchor the
+# "trailing-args" check to the last line of the log.
+
+@test "prek run: 'docker exec -w /var/www/localhost/htdocs/openemr -i <id> sh -c <script> sh run'" {
+    run oc_run prek run
+    assert_success
+    grep -Fq "exec -w /var/www/localhost/htdocs/openemr -i ${CONTAINER} sh -c" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'exec -w .../openemr -i ${CONTAINER} sh -c' invocation"; }
+    grep -Eq '[[:space:]]sh run$' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected trailing 'sh run' (positional args to inline sh)"; }
+}
+
+@test "prek install-hooks: same outer dispatch, args pass through to inline sh" {
+    run oc_run prek install-hooks
+    assert_success
+    grep -Fq "exec -w /var/www/localhost/htdocs/openemr -i ${CONTAINER} sh -c" "${STUB_DIR}/docker.log" \
+        || fail "expected docker exec dispatch"
+    grep -Eq '[[:space:]]sh install-hooks$' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected trailing 'sh install-hooks'"; }
+}
+
+@test "prek run --all-files phpstan: args after the subcommand are also forwarded" {
+    run oc_run prek run --all-files phpstan
+    assert_success
+    grep -Fq "exec -w /var/www/localhost/htdocs/openemr -i ${CONTAINER} sh -c" "${STUB_DIR}/docker.log" \
+        || fail "expected docker exec dispatch"
+    grep -Eq '[[:space:]]sh run --all-files phpstan$' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected trailing 'sh run --all-files phpstan'"; }
+}
+
+@test "prek --version: pass-through path (no actionlint substitution required)" {
+    run oc_run prek --version
+    assert_success
+    grep -Fq "exec -w /var/www/localhost/htdocs/openemr -i ${CONTAINER} sh -c" "${STUB_DIR}/docker.log" \
+        || fail "expected docker exec dispatch"
+    grep -Eq '[[:space:]]sh --version$' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected trailing 'sh --version'"; }
+}
+
+# --- inline script contains the actionlint substitution + pass-through ----
+# The stub records the full `docker exec ... sh -c '<inline-script>' sh
+# <args>` line, including the inline script source. We grep that line for
+# the substitution signal so a refactor that drops the swap doesn't slip
+# past unnoticed.
+
+@test "prek dispatch: inline script substitutes actionlint-docker -> actionlint-system" {
+    run oc_run prek run
+    assert_success
+    grep -Fq "actionlint-docker" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing 'actionlint-docker' source"; }
+    grep -Fq "actionlint-system" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing 'actionlint-system' replacement"; }
+    grep -Fq "sed " "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing 'sed' substitution command"; }
+}
+
+@test "prek dispatch: inline script handles run + install-hooks vs the pass-through default" {
+    # The script's case body should mention 'run' and 'install-hooks'
+    # explicitly (the substitution subjects) AND `exec pre-commit "$@"`
+    # as the pass-through path. All three live in the same inline string,
+    # so grepping the recorded line covers the inline-script structure.
+    run oc_run prek run
+    assert_success
+    grep -Fq "run|install-hooks" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing 'run|install-hooks' case"; }
+    grep -Fq "exec pre-commit" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing 'exec pre-commit' pass-through"; }
+    # And the --config <tmp> form that's specific to the substituted-config path.
+    grep -Fq -- "--config" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "inline script missing '--config <tmp>' usage"; }
+}
+
+# --- no-container error path ----------------------------------------------
+
+@test "prek: when no container is running, surfaces 'no running openemr container'" {
+    # No -d, no auto-detected container (default empty DOCKER_PS_OUTPUT) →
+    # CONTAINER_ID is empty and the case-block check at line ~2331 fires.
+    # The script's container-resolution layer also surfaces its own error
+    # earlier (line ~2008) for commands that need CONTAINER_ID, so a bare
+    # `openemr-cmd prek` hits that path first. We assert the SECOND-line
+    # one fires when we bypass via -d empty-id... but -d requires a value.
+    # So we test the natural path: no -d, no running container → the
+    # earlier "Could not automatically determine target OpenEMR container"
+    # error fires before reaching prek's own check. That's expected — the
+    # outer check is more general.
+    run env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" prek run
+    assert_failure
+    assert_output --partial "Could not automatically determine target OpenEMR container"
+}

--- a/tests/bats/openemr-cmd/snapshot_capsule_commands.bats
+++ b/tests/bats/openemr-cmd/snapshot_capsule_commands.bats
@@ -1,0 +1,146 @@
+# BATS: snapshot + capsule commands — bs / rs / gc / pc.
+#
+# These dispatch to either run_devtools_in_docker (bs, rs → /root/devtools
+# backup|restore <name>) or docker cp directly (gc/pc copy capsule files
+# in/out of /snapshots/ in the container). Each command has a no-arg
+# usage hint with a specific exit code; this file pins both the dispatch
+# shape and the usage-exit-code contract.
+#
+# All four functions originally had the same set-u bug as ensure-version
+# (#829's ev fix): `local FOO="$1"` fired before the `$# != 1` check,
+# crashing with "unbound variable" instead of showing the help. Fixed
+# concurrently with this file; the no-arg tests pin the fix.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    CONTAINER=fixed-snapshot-target
+    export STUB_DIR CONTAINER
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run() {
+    env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" -d "${CONTAINER}" "$@"
+}
+
+# --- backup-snapshot / bs --------------------------------------------------
+
+@test "bs <name>: dispatches to /root/devtools backup <name>" {
+    run oc_run bs my-snapshot
+    assert_success
+    grep -Fq "/root/devtools backup my-snapshot" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '/root/devtools backup my-snapshot'"; }
+    grep -Fq "${CONTAINER}" "${STUB_DIR}/docker.log" || fail "container id missing"
+}
+
+@test "bs (no args): prints usage hint and exits 20 (no 'unbound variable' crash)" {
+    # Regression for the set-u bug that crashed with "unbound variable"
+    # before the user saw the help.
+    run oc_run bs
+    [[ "${status}" -eq 20 ]] || fail "expected exit 20; got ${status}"
+    assert_output --partial "Please provide a snapshot name"
+    assert_output --partial "backup-snapshot|bs"
+    refute_output --partial "unbound variable"
+}
+
+@test "bs: 'backup-snapshot' long form is equivalent to 'bs'" {
+    run oc_run backup-snapshot another-snap
+    assert_success
+    grep -Fq "/root/devtools backup another-snap" "${STUB_DIR}/docker.log" || fail "long form did not dispatch"
+}
+
+# --- restore-snapshot / rs -------------------------------------------------
+
+@test "rs <name>: dispatches to /root/devtools restore <name>" {
+    run oc_run rs my-restore
+    assert_success
+    grep -Fq "/root/devtools restore my-restore" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '/root/devtools restore my-restore'"; }
+}
+
+@test "rs (no args): prints usage hint and exits 21 (no 'unbound variable' crash)" {
+    run oc_run rs
+    [[ "${status}" -eq 21 ]] || fail "expected exit 21; got ${status}"
+    assert_output --partial "Please provide a restore snapshot name"
+    assert_output --partial "restore-snapshot|rs"
+    refute_output --partial "unbound variable"
+}
+
+@test "rs: 'restore-snapshot' long form is equivalent" {
+    run oc_run restore-snapshot something
+    assert_success
+    grep -Fq "/root/devtools restore something" "${STUB_DIR}/docker.log" || fail "long form did not dispatch"
+}
+
+# --- get-capsule / gc ------------------------------------------------------
+
+@test "gc <name>: 'docker cp <id>:/snapshots/<name> .'" {
+    run oc_run gc example.tgz
+    assert_success
+    grep -Eq "cp ${CONTAINER}:/snapshots/example\.tgz \.\$" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'docker cp <id>:/snapshots/example.tgz .'"; }
+}
+
+@test "gc <name> <host-dir>: 'docker cp <id>:/snapshots/<name> <host-dir>/'" {
+    run oc_run gc example.tgz /path/to/save
+    assert_success
+    grep -Fq "cp ${CONTAINER}:/snapshots/example.tgz /path/to/save/" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'docker cp <id>:/snapshots/example.tgz /path/to/save/'"; }
+}
+
+@test "gc (no args): prints usage hint and exits 19 (no 'unbound variable' crash)" {
+    run oc_run gc
+    [[ "${status}" -eq 19 ]] || fail "expected exit 19; got ${status}"
+    assert_output --partial "Please provide the capsule name"
+    assert_output --partial "get-capsule|gc"
+    refute_output --partial "unbound variable"
+}
+
+@test "gc: too many args (3+) also surfaces usage hint" {
+    run oc_run gc a b c
+    [[ "${status}" -eq 19 ]] || fail "expected exit 19; got ${status}"
+    assert_output --partial "Please provide the capsule name"
+}
+
+# --- put-capsule / pc ------------------------------------------------------
+
+@test "pc <existing-file>: 'docker cp <file> <id>:/snapshots/'" {
+    # pc checks that the file exists before docker cp. Create a real
+    # file in the test's cwd so the existence check passes.
+    local tmp_cap
+    tmp_cap=$(mktemp -p "${BATS_TMPDIR:-/tmp}" pc-cap.XXXXXX.tgz)
+    run oc_run pc "${tmp_cap}"
+    rm -f "${tmp_cap}"
+    assert_success
+    # docker cp <file> <id>:/snapshots/
+    grep -Fq "cp ${tmp_cap} ${CONTAINER}:/snapshots/" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected docker cp <file> <id>:/snapshots/"; }
+}
+
+@test "pc (no args): prints usage hint and exits 18 (no 'unbound variable' crash)" {
+    run oc_run pc
+    [[ "${status}" -eq 18 ]] || fail "expected exit 18; got ${status}"
+    assert_output --partial "Please provide the capsule file name"
+    assert_output --partial "put-capsule|pc"
+    refute_output --partial "unbound variable"
+}
+
+@test "pc <missing-file>: 'capsule file exists' error, exits 15" {
+    run oc_run pc /nonexistent/capsule-bats-test.tgz
+    [[ "${status}" -eq 15 ]] || fail "expected exit 15; got ${status}"
+    assert_output --partial "Please check whether the capsule file exists or not"
+    # And NO docker cp was issued.
+    if grep -Fq "cp /nonexistent" "${STUB_DIR}/docker.log"; then
+        cat "${STUB_DIR}/docker.log"
+        fail "docker cp was issued for a nonexistent file"
+    fi
+}

--- a/tests/bats/openemr-cmd/snapshot_capsule_commands.bats
+++ b/tests/bats/openemr-cmd/snapshot_capsule_commands.bats
@@ -115,9 +115,10 @@ oc_run() {
 
 @test "pc <existing-file>: 'docker cp <file> <id>:/snapshots/'" {
     # pc checks that the file exists before docker cp. Create a real
-    # file in the test's cwd so the existence check passes.
+    # file so the existence check passes. Use the full-path template form
+    # (portable across GNU + BSD mktemp; `-p <dir>` is GNU-only).
     local tmp_cap
-    tmp_cap=$(mktemp -p "${BATS_TMPDIR:-/tmp}" pc-cap.XXXXXX.tgz)
+    tmp_cap=$(mktemp "${BATS_TMPDIR:-/tmp}/pc-cap.XXXXXX.tgz")
     run oc_run pc "${tmp_cap}"
     rm -f "${tmp_cap}"
     assert_success

--- a/tests/bats/openemr-cmd/webroot_swagger_ldap.bats
+++ b/tests/bats/openemr-cmd/webroot_swagger_ldap.bats
@@ -1,0 +1,107 @@
+# BATS: webroot + multisite-swagger + LDAP toggle commands.
+#
+# cwb / cwo (change-webroot-blank / -openemr): set-webroot runs an in-container
+# sed against /etc/apache2/conf.d/openemr.conf, then `docker restart <id>`.
+# swtm (set-swagger-to-multisite): passes positional args to
+# /root/devtools set-swagger-to-multisite via run_devtools_in_docker.
+# el / dld (enable-ldap / disable-ldap): plain devtools passthroughs to
+# /root/devtools enable-ldap / disable-ldap.
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    STUB_DIR=$(oc_make_docker_stub_dir)
+    CONTAINER=fixed-webroot-target
+    export STUB_DIR CONTAINER
+}
+
+teardown() {
+    [[ -n "${STUB_DIR:-}" ]] && rm -rf "${STUB_DIR}"
+    return 0
+}
+
+oc_run() {
+    env PATH="${STUB_DIR}:${PATH}" "${SCRIPT}" -d "${CONTAINER}" "$@"
+}
+
+# --- webroot: cwb / cwo ----------------------------------------------------
+# Both invoke set-webroot, which (1) runs an in-container sed via
+# run_shell_command_in_docker (docker exec -i <id> sh -c "<sed ...>")
+# and then (2) docker restart <id>. The sed target string differs by
+# direction (blank vs openemr).
+
+@test "cwb (change-webroot-blank): sed to point apache at openemr/, then restart container" {
+    run oc_run cwb
+    assert_success
+    assert_output --partial "changing webroot to blank"
+    assert_output --partial "restarting openemr docker"
+    # Sed runs inside the container via 'exec -i <id> sh -c ...'.
+    grep -Fq "exec -i ${CONTAINER}" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected 'docker exec -i ${CONTAINER}' invocation"; }
+    grep -Fq "DocumentRoot /var/www/localhost/htdocs/openemr" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected sed to set DocumentRoot to .../openemr"; }
+    # docker restart <id> is the final step.
+    grep -Fq "restart ${CONTAINER}" "${STUB_DIR}/docker.log" \
+        || fail "expected 'docker restart ${CONTAINER}'"
+}
+
+@test "cwb: 'change-webroot-blank' long form is equivalent" {
+    run oc_run change-webroot-blank
+    assert_success
+    assert_output --partial "changing webroot to blank"
+    grep -Fq "restart ${CONTAINER}" "${STUB_DIR}/docker.log" || fail "long form did not restart"
+}
+
+@test "cwo (change-webroot-openemr): sed to set apache root to .../htdocs (blank webroot), then restart" {
+    run oc_run cwo
+    assert_success
+    assert_output --partial "changing webroot to openemr"
+    assert_output --partial "restarting openemr docker"
+    # The 'openemr' direction strips the /openemr suffix from DocumentRoot.
+    grep -Eq 'DocumentRoot /var/www/localhost/htdocs[^/]' "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected sed to set DocumentRoot WITHOUT /openemr suffix"; }
+    grep -Fq "restart ${CONTAINER}" "${STUB_DIR}/docker.log" || fail "expected 'docker restart'"
+}
+
+@test "cwo: 'change-webroot-openemr' long form is equivalent" {
+    run oc_run change-webroot-openemr
+    assert_success
+    assert_output --partial "changing webroot to openemr"
+}
+
+# --- swtm / set-swagger-to-multisite --------------------------------------
+
+@test "swtm <multisite-name>: dispatches to /root/devtools set-swagger-to-multisite <name>" {
+    run oc_run swtm my-multisite
+    assert_success
+    grep -Fq "/root/devtools set-swagger-to-multisite my-multisite" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected swtm devtool dispatch with arg"; }
+}
+
+@test "swtm: 'set-swagger-to-multisite' long form is equivalent" {
+    run oc_run set-swagger-to-multisite another-site
+    assert_success
+    grep -Fq "/root/devtools set-swagger-to-multisite another-site" "${STUB_DIR}/docker.log" \
+        || fail "long form did not dispatch"
+}
+
+# --- el / dld (enable / disable LDAP) -------------------------------------
+
+@test "el: dispatches to /root/devtools enable-ldap" {
+    run oc_run el
+    assert_success
+    grep -Fq "/root/devtools enable-ldap" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '/root/devtools enable-ldap'"; }
+    grep -Fq "${CONTAINER}" "${STUB_DIR}/docker.log" || fail "container id missing"
+}
+
+@test "dld: dispatches to /root/devtools disable-ldap" {
+    run oc_run dld
+    assert_success
+    grep -Fq "/root/devtools disable-ldap" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected '/root/devtools disable-ldap'"; }
+}

--- a/tests/bats/openemr-cmd/webroot_swagger_ldap.bats
+++ b/tests/bats/openemr-cmd/webroot_swagger_ldap.bats
@@ -62,8 +62,13 @@ oc_run() {
     assert_output --partial "changing webroot to openemr"
     assert_output --partial "restarting openemr docker"
     # The 'openemr' direction strips the /openemr suffix from DocumentRoot.
-    grep -Eq 'DocumentRoot /var/www/localhost/htdocs[^/]' "${STUB_DIR}/docker.log" \
-        || { cat "${STUB_DIR}/docker.log"; fail "expected sed to set DocumentRoot WITHOUT /openemr suffix"; }
+    # Match the sed REPLACEMENT (between the second and third @-separators),
+    # not the search pattern — both cwb and cwo's sed commands share the
+    # same search pattern `htdocs.*@`, so anchoring there would let cwb
+    # falsely pass as cwo. The replacement differs: cwo ends in `htdocs@g`,
+    # cwb ends in `htdocs/openemr@g`.
+    grep -Fq "@DocumentRoot /var/www/localhost/htdocs@g" "${STUB_DIR}/docker.log" \
+        || { cat "${STUB_DIR}/docker.log"; fail "expected sed replacement '...htdocs@g' (no /openemr suffix)"; }
     grep -Fq "restart ${CONTAINER}" "${STUB_DIR}/docker.log" || fail "expected 'docker restart'"
 }
 

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.46"
+VERSION="1.0.47"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -1573,34 +1573,33 @@ restart_couchdb_docker(){
 }
 
 creat_a_backup_snapshot(){
-    local BACKUP_FILE="$1"
+    # Check arg count BEFORE `local FOO="$1"` so a no-arg invocation
+    # prints the usage hint instead of crashing under set -u with
+    # "unbound variable". Same fix as ensure_current_ver_with_upgrade_ver.
     local BACKUP_FILE_CODE=20
     if [[ $# != 1 ]]; then
         echo 'Please provide a snapshot name.'
         echo 'e.g. openemr-cmd [backup-snapshot|bs] example'
         exit "${BACKUP_FILE_CODE}"
-    else
-        # Use the devtools function
-        run_devtools_in_docker "${CONTAINER_ID}" backup "${BACKUP_FILE}"
     fi
+    local BACKUP_FILE="$1"
+    run_devtools_in_docker "${CONTAINER_ID}" backup "${BACKUP_FILE}"
 }
 
 restore_from_a_snapshot(){
-    local BACKUP_FILE="$1"
+    # See creat_a_backup_snapshot for the arg-check-before-local rationale.
     local BACKUP_FILE_CODE=21
     if [[ $# != 1 ]]; then
         echo 'Please provide a restore snapshot name.'
         echo 'e.g. openemr-cmd [restore-snapshot|rs] example'
         exit "${BACKUP_FILE_CODE}"
-    else
-        # Use the devtools function
-        run_devtools_in_docker "${CONTAINER_ID}" restore "${BACKUP_FILE}"
     fi
+    local BACKUP_FILE="$1"
+    run_devtools_in_docker "${CONTAINER_ID}" restore "${BACKUP_FILE}"
 }
 
 copy_capsule_from_docker_to_host(){
-    local BACKUP_FILE="$1"
-    local BACKUP_HOST_DIR="${2:-}" #optional parameter, default to empty
+    # See creat_a_backup_snapshot for the arg-check-before-local rationale.
     local BACKUP_FILE_CODE=19
     if (( $# != 1 && $# != 2 )); then
         echo 'Please provide the capsule name.'
@@ -1608,32 +1607,31 @@ copy_capsule_from_docker_to_host(){
         echo 'An optional setting is the path to save to. If nothing provided, then will save in current directory.'
         echo 'e.g. openemr-cmd [get-capsule|gc] example.tgz /path/to/save'
         exit "${BACKUP_FILE_CODE}"
+    fi
+    local BACKUP_FILE="$1"
+    local BACKUP_HOST_DIR="${2:-}" # optional, default empty
+    if [[ -z "${BACKUP_HOST_DIR}" ]]; then
+        docker cp "${CONTAINER_ID}:/snapshots/${BACKUP_FILE}" .
     else
-        if [[ -z "${BACKUP_HOST_DIR}" ]]; then
-            docker cp "${CONTAINER_ID}:/snapshots/${BACKUP_FILE}" .
-        else
-            docker cp "${CONTAINER_ID}:/snapshots/${BACKUP_FILE}" "${BACKUP_HOST_DIR}/"
-        fi
+        docker cp "${CONTAINER_ID}:/snapshots/${BACKUP_FILE}" "${BACKUP_HOST_DIR}/"
     fi
 }
 
 copy_capsule_from_host_to_docker(){
-    # Need a capsule parameter
-    local BACKUP_FILE="$1"
+    # See creat_a_backup_snapshot for the arg-check-before-local rationale.
     local CP_CAP_DIR_DKR_CODE=15
     local BACKUP_FILE_CODE=18
     if [[ $# != 1 ]]; then
         echo 'Please provide the capsule file name (including path if applicable).'
         echo 'e.g. openemr-cmd [put-capsule|pc] example.tgz'
         exit "${BACKUP_FILE_CODE}"
-    else
-        if ! ls "${BACKUP_FILE}" &>/dev/null; then
-            echo 'Please check whether the capsule file exists or not'
-            exit "${CP_CAP_DIR_DKR_CODE}"
-        else
-            docker cp "${BACKUP_FILE}" "${CONTAINER_ID}:/snapshots/"
-        fi
     fi
+    local BACKUP_FILE="$1"
+    if ! ls "${BACKUP_FILE}" &>/dev/null; then
+        echo 'Please check whether the capsule file exists or not'
+        exit "${CP_CAP_DIR_DKR_CODE}"
+    fi
+    docker cp "${BACKUP_FILE}" "${CONTAINER_ID}:/snapshots/"
 }
 
 ensure_current_ver_with_upgrade_ver(){


### PR DESCRIPTION
## Summary

Continuation of #828 + #829's non-worktree coverage. 28 new tests across 3 files plus 4 small script fixes for the same set-u bug pattern uncovered in #829 (the `ev` fix).

## What's new (3 files, 28 tests)

| File | What it pins |
|---|---|
| `snapshot_capsule_commands.bats` | `bs`/`rs` → `/root/devtools backup|restore <name>`. `gc`/`pc` → `docker cp` in/out of `/snapshots/`. No-arg usage hints with their documented exit codes (20 / 21 / 19 / 18). `pc <missing-file>` exits 15 with the "capsule file exists" error. |
| `webroot_swagger_ldap.bats` | `cwb`/`cwo` run an in-container sed against apache's `openemr.conf` then `docker restart <id>`; `swtm <name>` passes through to `/root/devtools set-swagger-to-multisite`; `el`/`dld` are plain devtools passthroughs. |
| `prek_dispatch.bats` | Outer dispatch shape (`docker exec -w /var/www/localhost/htdocs/openemr -i <id> sh -c <inline> sh <args>`). Args pass-through for `run` / `install-hooks` / `--version`. Inline script contains the actionlint-docker → actionlint-system substitution + the `run|install-hooks` case + `exec pre-commit` pass-through. No-container error path. |

## 4 more set-u fixes (same pattern as the ev fix in #829)

`creat_a_backup_snapshot` / `restore_from_a_snapshot` / `copy_capsule_from_docker_to_host` / `copy_capsule_from_host_to_docker` all had `local FOO="$1"` (or `$2`) BEFORE their `$# != N` check. Under `set -u` that crashes with "unbound variable" when called with no args instead of showing the documented help. All four reorder the check ahead of the `local` assignments. Pinned by dedicated regression tests.

## Test plan

- [x] Full hermetic bats suite — 290 tests, 0 failures
- [x] `shellcheck utilities/openemr-cmd/openemr-cmd` clean
- [ ] CI: BATS openemr-cmd (ubuntu-22.04) green
- [ ] CI: BATS openemr-cmd (macos-14) green
- [ ] CI: ShellCheck green
- [ ] CI: e2e jobs green (script touched — workflow filter triggers)
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument handling for snapshot/capsule-related subcommands so missing inputs produce clean usage errors instead of `set -u` “unbound variable” crashes.
  * Hardened capsule copy behavior with earlier argument-count checks (including optional destination handling and consistent missing-file checks).
* **Tests**
  * Added/expanded BATS coverage for `prek` dispatch, snapshot/capsule command CLI contracts, webroot switching, Swagger-to-multisite, and LDAP enable/disable.
* **Chores**
  * Updated the `openemr-cmd` version to `1.0.47`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->