### PR TITLE
ci(openemr-cmd): run real-docker e2e daily on master to catch upstream drift

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -45,7 +45,8 @@ name: openemr-cmd e2e (real docker)
 # separate runners, so wall time is bounded by the slowest. Runs on
 # every PR that touches openemr-cmd or this workflow file — slower
 # PR cycle is the deliberate trade for catching regressions before
-# merge rather than after.
+# merge rather than after. Also runs once daily on master (see
+# schedule trigger below) to catch upstream drift between PRs.
 
 on:
   push:
@@ -60,6 +61,21 @@ on:
       - '.github/workflows/test-bats-openemr-cmd-real-docker.yml'
       - 'utilities/openemr-cmd/openemr-cmd'
       - 'utilities/openemr-cmd/openemr-cmd-h'
+  # Daily run on the default branch to catch upstream drift that the
+  # path-filtered push/pull_request triggers miss:
+  #   - openemr/openemr master rewrites the /root/devtools interface
+  #     (the kind of cross-repo contract drift that produced #832 /
+  #     openemr#12632)
+  #   - openemr container image republish (apache uid, alpine version,
+  #     pre-commit toolchain)
+  #   - GitHub-hosted runner image updates (docker daemon, jq, etc.)
+  # 06:17 UTC = ~1am ET / ~7am CET — quiet for both US and EU. The
+  # off-the-minute (17) avoids the cron-stampede at minute :00 across
+  # GH Actions globally. Public-repo runners are unmetered, so the
+  # 5-job parallel run is free; only cost is reviewer attention on
+  # genuine upstream-drift failures.
+  schedule:
+    - cron: '17 6 * * *'
   workflow_dispatch:
 
 # Read-only GITHUB_TOKEN — the workflow only clones public repos, pulls a


### PR DESCRIPTION
## Summary

Adds a daily \`schedule\` trigger (06:17 UTC) to the real-docker e2e workflow. The existing path-filtered \`push\`/\`pull_request\` triggers only fire when \`openemr-cmd\` or this workflow file changes — they miss upstream drift entirely.

**What the daily run catches:**
- \`openemr/openemr\` master drift — e.g., \`/root/devtools\` interface changes of the kind that produced #832 / openemr#12632
- \`openemr/openemr\` container image republish (apache uid, alpine version, pre-commit toolchain)
- GitHub-hosted runner image updates (docker daemon, jq, etc.)

All five existing jobs run on the schedule unchanged. The \`functional-roundtrip-e2e\` job is the highest-value one here — its drid → irp → bs → gc → pc → rs flow is what would surface a real upstream contract break within 24h instead of waiting for the next devops PR.

**Time choice:** 06:17 UTC = ~1am ET / ~7am CET, quiet for both US and EU. The off-the-minute \`:17\` avoids the cron-stampede at \`:00\` across GH Actions globally.

**Cost:** \$0 — public-repo runners are unmetered. The only cost is reviewer attention on genuine upstream-drift failures, which is exactly the signal we want.

**Concurrency:** unchanged. The existing group (\`workflow + ref\`) with \`cancel-in-progress: false\` for non-PR events means schedule + push share the master ref but in-progress runs are kept (sequential master history preserved).

## Test plan

- [ ] Workflow file YAML still validates (verified locally via Python yaml.safe_load)
- [ ] CI on this PR runs the 5 jobs as usual (the schedule trigger doesn't fire on PRs; just the existing push/pull_request paths)
- [ ] First scheduled run lands tomorrow at 06:17 UTC; confirm via Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a daily scheduled workflow run to help catch unexpected integration issues earlier.
  * Kept the existing on-push and pull request checks intact while expanding automated coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->