### PR TITLE
test(ci): e2e hygiene — assert worktree list, git worktree, containers all clean after remove

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -458,6 +458,34 @@ jobs:
             echo "FAIL: worktree dir still on disk"
             exit 1
           fi
+          # `openemr-cmd worktree list` must not surface the removed
+          # branch row — the user-facing rendering reflects the cleanup.
+          # (The .worktrees.json check above is the source of truth;
+          # this catches a hypothetical regression where the list
+          # subcommand might re-introduce a removed entry from elsewhere.)
+          if openemr-cmd worktree list 2>&1 | grep -qE '^test-e2e[[:space:]]'; then
+            echo "FAIL: 'worktree list' still surfaces 'test-e2e'"
+            openemr-cmd worktree list
+            exit 1
+          fi
+          # git's worktree registration must be gone too — git owns
+          # the linked-worktree gitdir under .git/worktrees/<dir>/
+          # and would otherwise treat us as having a stale worktree
+          # to recover.
+          if git worktree list --porcelain | grep -qE "openemr-wt-test-e2e"; then
+            echo "FAIL: 'git worktree list' still has an entry"
+            git worktree list --porcelain
+            exit 1
+          fi
+          # Compose containers gone (volumes alone don't prove the
+          # whole stack is torn down — `down` without `-v` would leave
+          # containers gone but volumes preserved; we want both).
+          remaining_c=$(docker ps -aq --filter "label=com.docker.compose.project=openemr-test-e2e" | wc -l)
+          if [ "${remaining_c}" -ne 0 ]; then
+            echo "FAIL: ${remaining_c} containers still labeled with project=openemr-test-e2e:"
+            docker ps -a --filter "label=com.docker.compose.project=openemr-test-e2e"
+            exit 1
+          fi
           # Compose project's volumes should be gone (remove without
           # --keep-volumes calls `down --volumes` under the hood).
           remaining=$(docker volume ls -q --filter "name=openemr-test-e2e_" | wc -l)
@@ -466,7 +494,7 @@ jobs:
             docker volume ls --filter "name=openemr-test-e2e_"
             exit 1
           fi
-          echo "state clean"
+          echo "state clean (state + dir + list + git + containers + volumes)"
 
       - name: Diagnostics on failure
         if: failure()
@@ -697,7 +725,35 @@ jobs:
                   exit 1
               fi
           done
+          # `openemr-cmd worktree list` must not surface any of the
+          # three removed branches.
+          list_out=$(openemr-cmd worktree list 2>&1)
+          for branch in multi-easy multi-light multi-redis; do
+              if grep -qE "^${branch}[[:space:]]" <<< "${list_out}"; then
+                  echo "FAIL: 'worktree list' still surfaces '${branch}'"
+                  echo "${list_out}"
+                  exit 1
+              fi
+          done
+          # git worktree registrations also gone.
+          git_out=$(git worktree list --porcelain)
+          for dir in openemr-wt-multi-easy openemr-wt-multi-light openemr-wt-multi-redis; do
+              if grep -qE "${dir}" <<< "${git_out}"; then
+                  echo "FAIL: 'git worktree list' still has '${dir}'"
+                  echo "${git_out}"
+                  exit 1
+              fi
+          done
+          # Containers + volumes gone per project (label-based for
+          # containers; name-prefix for volumes since named volumes
+          # are filterable by name).
           for proj in openemr-multi-easy openemr-multi-light openemr-multi-redis; do
+              rem_c=$(docker ps -aq --filter "label=com.docker.compose.project=${proj}" | wc -l)
+              if [[ "${rem_c}" -ne 0 ]]; then
+                  echo "FAIL: ${rem_c} containers still labeled with project=${proj}:"
+                  docker ps -a --filter "label=com.docker.compose.project=${proj}"
+                  exit 1
+              fi
               rem=$(docker volume ls -q --filter "name=${proj}_" | wc -l)
               if [[ "${rem}" -ne 0 ]]; then
                   echo "FAIL: ${rem} volumes left for ${proj}"
@@ -705,7 +761,7 @@ jobs:
                   exit 1
               fi
           done
-          echo "all three stacks cleaned"
+          echo "all three stacks cleaned (state + dirs + list + git + containers + volumes)"
 
       - name: Diagnostics on failure
         if: failure()
@@ -1424,13 +1480,33 @@ jobs:
               echo "FAIL: worktree dir still on disk"
               exit 1
           fi
+          # User-facing `worktree list` must not surface the removed branch.
+          if openemr-cmd worktree list 2>&1 | grep -qE '^prek-e2e[[:space:]]'; then
+              echo "FAIL: 'worktree list' still surfaces 'prek-e2e'"
+              openemr-cmd worktree list
+              exit 1
+          fi
+          # git worktree registration also gone.
+          if git worktree list --porcelain | grep -qE "openemr-wt-prek-e2e"; then
+              echo "FAIL: 'git worktree list' still has an entry"
+              git worktree list --porcelain
+              exit 1
+          fi
+          # Containers gone (volumes alone don't prove the full stack
+          # is torn down).
+          remaining_c=$(docker ps -aq --filter "label=com.docker.compose.project=openemr-prek-e2e" | wc -l)
+          if [[ "${remaining_c}" -ne 0 ]]; then
+              echo "FAIL: ${remaining_c} containers still labeled with project=openemr-prek-e2e:"
+              docker ps -a --filter "label=com.docker.compose.project=openemr-prek-e2e"
+              exit 1
+          fi
           remaining=$(docker volume ls -q --filter "name=openemr-prek-e2e_" | wc -l)
           if [[ "${remaining}" -ne 0 ]]; then
               echo "FAIL: ${remaining} compose volumes left over"
               docker volume ls --filter "name=openemr-prek-e2e_"
               exit 1
           fi
-          echo "prek-e2e fully cleaned"
+          echo "prek-e2e fully cleaned (state + dir + list + git + containers + volumes)"
 
       - name: Diagnostics on failure
         if: failure()


### PR DESCRIPTION
## Summary

Strengthens the post-remove hygiene blocks in `test-bats-openemr-cmd-real-docker.yml` to assert the **user-facing surfaces** are clean, not just the state file + disk.

Existing hygiene blocks checked:
- ✅ State entry gone from `.worktrees.json`
- ✅ Worktree dir gone from disk
- ✅ Compose volumes gone

This PR adds three more, applied to all three worktree-based jobs (`worktree-lifecycle-e2e`, `worktree-multi-concurrent-e2e`, `prek-workflow-e2e`):

1. **`openemr-cmd worktree list` rendering** — the user-facing subcommand reads state but could in principle surface stale rows from elsewhere. Pin that it doesn't.
2. **`git worktree list --porcelain`** — git owns the linked-worktree gitdir under `.git/worktrees/<dir>/`; if `git worktree remove` silently fails or skips a prune, git's view diverges from ours. Pin git's view too.
3. **Containers via `--filter "label=com.docker.compose.project="`** — the volume check alone doesn't prove the full stack is torn down (`down` without `-v` would leave containers gone but volumes preserved). Check both for symmetry.

The `nonworktree-lifecycle-e2e` hygiene block already used label-based container + volume filters correctly — no change needed there.

## Why

This was surfaced by user audit after the recent permission-bug PR cycle. Each PR was implicitly trusting `worktree remove` to do the right thing on the user-facing side; the hygiene blocks only spot-checked disk + state. Adding the three assertions catches a class of regression (silent stale entries in `worktree list`, git-side worktree drift, half-torn-down stacks) that the existing checks wouldn't flag.

## Test plan

- [ ] All 5 e2e jobs pass — the stricter hygiene shouldn't trip on a properly-functioning `worktree remove`
- [ ] If a regression in `cmd_worktree_remove` ever introduces one of the new failure modes, the hygiene block fails loudly with a specific message identifying which surface drifted

No production code changed. Pure test scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened end-to-end cleanup verification after worktree removal.
  * Added post-removal checks to ensure removed branches/worktrees no longer appear in worktree listings, Git registrations, or Docker resources.
  * Expanded validation for concurrent and PREK scenarios to confirm containers and named volumes are fully removed.
  * Updated success messages to reflect complete cleanup coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->