### PR TITLE
feat(openemr-cmd): HOST_UID in non-worktree mode; remove obsolete auto-chown shim

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -6,7 +6,7 @@ name: openemr-cmd e2e (real docker)
 #   - worktree-lifecycle-e2e: full worktree lifecycle on a single
 #     worktree — add → exec → set-env refusal → down/up restart →
 #     list status → regen → set-env env-switch (easy → easy-light) →
-#     auto-chown-driven remove. Covers all the user-facing worktree
+#     remove. Covers all the user-facing worktree
 #     operations against a real running stack.
 #   - worktree-multi-concurrent-e2e: three worktrees on three distinct
 #     envs (easy / easy-light / easy-redis) running side-by-side,
@@ -99,7 +99,7 @@ concurrency:
 
 jobs:
   worktree-lifecycle-e2e:
-    name: e2e — full worktree lifecycle (add → restart → set-env → regen → auto-chown remove)
+    name: e2e — full worktree lifecycle (add → restart → set-env → regen → remove)
     runs-on: ubuntu-22.04
     # 45 min to absorb three healthy-poll windows (initial add --start,
     # post-restart, post-set-env-switch to easy-light) plus the new

--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -422,25 +422,53 @@ jobs:
           echo "FAIL: easy-light openemr did not respond on port 8301"
           exit 1
 
-      - name: "worktree remove (container still running → auto-chown handles root files)"
+      - name: "Verify bind mount is host-owned (HOST_UID adoption working)"
+        run: |
+          # Pin the actual end-state of the HOST_UID passthrough chain:
+          # apache inside the container should have adopted the runner's
+          # uid via the entrypoint (openemr/openemr#12642 + #12647),
+          # which means files apache wrote during install should be
+          # owned by the runner on the host (NOT uid=1000).
+          #
+          # sites/default/sqlconf.php is touched by the openemr install
+          # path (writes DB credentials), so it's a reliable apache-
+          # written probe file. If HOST_UID adoption is broken, this
+          # file would still be owned by uid=1000 and the assertion
+          # below would fail loudly.
+          probe_file="${{ github.workspace }}/openemr-wt-test-e2e/sites/default/sqlconf.php"
+          if [[ ! -f "${probe_file}" ]]; then
+              echo "FAIL: probe file (sqlconf.php) missing — install may not have completed"
+              ls -la "${{ github.workspace }}/openemr-wt-test-e2e/sites/default/" || true
+              exit 1
+          fi
+          owner_uid=$(stat -c '%u' "${probe_file}")
+          runner_uid=$(id -u)
+          if [[ "${owner_uid}" != "${runner_uid}" ]]; then
+              echo "FAIL: bind-mount file owned by uid=${owner_uid} (expected runner uid=${runner_uid})"
+              echo "HOST_UID adoption is NOT working — apache may have stayed at uid=1000"
+              ls -la "${probe_file}"
+              exit 1
+          fi
+          echo "OK: bind-mount file owned by uid=${runner_uid} (apache adopted host uid)"
+
+      - name: "worktree remove (probe-only, no shim — HOST_UID adoption did the heavy lifting)"
         working-directory: openemr
         run: |
-          # Stack is up. The container has written root-owned files into
-          # the bind mount during startup/install. With the auto-chown step
-          # added in openemr-devops#833, `worktree remove` should now
-          # detect the running container, exec into it as root to chown
-          # the bind mount back to the host uid, then proceed with the
-          # destructive ops — without the user needing a manual
-          # `sudo chown -R` on the host. If the auto-chown ever breaks,
-          # the probe would fire here and remove would fail with the
-          # writability hint instead of succeeding.
+          # With HOST_UID adoption shipping universally, the apache-uid
+          # mismatch is gone at the source. The earlier #833 in-container
+          # auto-chown shim was removed — chowning host-uid → host-uid
+          # was a permanent no-op wasting docker exec time. The writability
+          # probe + the pre-create + the probe-loosening (from #838) are
+          # the safety net for any drift cases.
           echo y | openemr-cmd worktree remove test-e2e 2>&1 | tee /tmp/remove-out.txt
-          # Confirm the auto-chown step ran (banner present).
-          grep -q "Auto-chowning bind mount via container" /tmp/remove-out.txt \
-              || { echo "FAIL: auto-chown banner missing — script may have skipped the step"; exit 1; }
           # Remove succeeded (no probe-refused hint).
           if grep -q "is not writable by you" /tmp/remove-out.txt; then
-              echo "FAIL: probe fired despite container being available for auto-chown"
+              echo "FAIL: probe fired despite HOST_UID adoption being in place"
+              exit 1
+          fi
+          # Auto-chown banner should NOT appear (the shim is gone).
+          if grep -q "Auto-chowning bind mount via container" /tmp/remove-out.txt; then
+              echo "FAIL: auto-chown banner present — shim removal didn't apply"
               exit 1
           fi
 
@@ -694,19 +722,18 @@ jobs:
               fi
           done
 
-      - name: Down + remove all three worktrees (auto-chown handles container-written files)
+      - name: Down + remove all three worktrees (HOST_UID adoption covers everything)
         working-directory: openemr
         run: |
-          # Stacks still running → openemr-cmd's auto-chown step from
-          # #833 fires before each compose down to handle any apache-
-          # written files in the bind mount.
+          # Stacks still running. With HOST_UID adoption working end-to-
+          # end (openemr-devops#840 + openemr#12642), apache writes bind-
+          # mount files as the runner uid — nothing needs chowning before
+          # remove. The earlier #833 auto-chown shim was removed.
           #
-          # Volume mount-point dirs (ccdaservice/node_modules etc.)
-          # are now host-owned from the start: `worktree add` pre-
-          # creates them via wt_precreate_volume_mountpoints so docker
-          # attaches the named volumes without creating root-owned
-          # host dirs. The previous CI workaround (a pre-remove
-          # `sudo chown -R`) is no longer needed.
+          # Volume mount-point dirs (ccdaservice/node_modules etc.) are
+          # host-owned from the start via wt_precreate_volume_mountpoints
+          # (#838). Probe loosening (#838) accepts any empty root-owned
+          # legacy dirs. Together: clean remove with no chown dance.
           echo y | openemr-cmd worktree remove multi-easy
           echo y | openemr-cmd worktree remove multi-light
           echo y | openemr-cmd worktree remove multi-redis
@@ -864,6 +891,30 @@ jobs:
           done
           echo "FAIL: openemr did not respond with 2xx/3xx on port 8300"
           exit 1
+
+      - name: "Verify bind mount is host-owned (HOST_UID adoption working in non-worktree)"
+        run: |
+          # Same assertion as the worktree-lifecycle-e2e job's bind-mount-
+          # ownership check, but for the non-worktree path: `openemr-cmd
+          # up` from openemr/docker/development-easy/ should auto-export
+          # HOST_UID/HOST_GID via run_docker_compose, so apache adopts
+          # the runner's uid and writes bind-mount files as runner —
+          # NOT uid=1000.
+          probe_file="${{ github.workspace }}/openemr/sites/default/sqlconf.php"
+          if [[ ! -f "${probe_file}" ]]; then
+              echo "FAIL: probe file (sqlconf.php) missing — install may not have completed"
+              ls -la "${{ github.workspace }}/openemr/sites/default/" || true
+              exit 1
+          fi
+          owner_uid=$(stat -c '%u' "${probe_file}")
+          runner_uid=$(id -u)
+          if [[ "${owner_uid}" != "${runner_uid}" ]]; then
+              echo "FAIL: bind-mount file owned by uid=${owner_uid} (expected runner uid=${runner_uid})"
+              echo "HOST_UID adoption is NOT working — apache may have stayed at uid=1000"
+              ls -la "${probe_file}"
+              exit 1
+          fi
+          echo "OK: bind-mount file owned by uid=${runner_uid} (apache adopted host uid)"
 
       - name: "openemr-cmd e (auto-detected container): exec sentinel"
         working-directory: openemr/docker/development-easy
@@ -1442,11 +1493,13 @@ jobs:
           [[ ! -f openemr-prek-probe.txt ]] \
               || { echo "FAIL: probe file still on disk after reset"; ls -la; exit 1; }
 
-      - name: worktree remove prek-e2e (auto-chown handles container-owned files)
+      - name: worktree remove prek-e2e (HOST_UID adoption — no shim, no chown dance)
         working-directory: openemr
         run: |
-          # Stack is still up; the auto-chown step from #833 fixes
-          # the bind mount's apache-owned files before remove proceeds.
+          # Stack still up. With HOST_UID adopted by apache, bind-mount
+          # files are host-owned and remove proceeds without the earlier
+          # #833 auto-chown shim (removed once adoption made it a
+          # permanent no-op).
           echo y | openemr-cmd worktree remove prek-e2e
 
       - name: prek-uninstall (cleans the shim hooks from the shared .git/hooks)

--- a/tests/bats/openemr-cmd/host_uid_nonworktree.bats
+++ b/tests/bats/openemr-cmd/host_uid_nonworktree.bats
@@ -1,0 +1,168 @@
+# BATS: non-worktree `up` exports HOST_UID/HOST_GID and pre-creates
+# volume mount-point dirs.
+#
+# Companion to host_uid_compose.bats (which covers the worktree-side
+# emit via wt_write_override). This file pins the parallel mechanism
+# for the non-worktree path: `openemr-cmd up` invoked from a
+# docker/development-*/ directory should:
+#   1. Export HOST_UID/HOST_GID for compose's env interpolation
+#      (consumed by the openemr service's environment block, added in
+#      openemr/openemr#12647).
+#   2. Pre-create host-side dirs for named-volume mount points under
+#      the webroot bind mount (same defense as wt_precreate_volume_
+#      mountpoints, but for the base repo path).
+
+load '../test_helper/bats-support/load'
+load '../test_helper/bats-assert/load'
+load 'helpers'
+
+# Build a docker stub that records compose-invocation environment
+# vars to a side-file (`docker.env`) alongside the existing arg log.
+# The standard oc_make_docker_stub_dir only records args; we need
+# env for these tests.
+mk_env_recording_stub() {
+    local d log env_log
+    d=$(oc_mktempdir)
+    log="${d}/docker.log"
+    env_log="${d}/docker.env"
+    : > "${log}"
+    : > "${env_log}"
+    cat > "${d}/docker" <<STUB
+#!/bin/sh
+echo "\$@" >> "${log}"
+case " \$* " in
+    *' ps '*) [ -n "\${DOCKER_PS_OUTPUT-}" ] && echo "\${DOCKER_PS_OUTPUT}" ;;
+esac
+# Record HOST_UID/HOST_GID at every invocation — used by the env-
+# export assertions below to confirm the script exported them before
+# calling the compose binary.
+env | grep -E '^HOST_(UID|GID)=' >> "${env_log}" || true
+exit 0
+STUB
+    chmod +x "${d}/docker"
+    echo "${d}"
+}
+
+setup() {
+    SCRIPT="$(oc_script_path)"
+    [[ -x "$SCRIPT" ]] || skip "openemr-cmd script not found"
+    TMP_PARENT=$(oc_mktempdir)
+    BASE_REPO="${TMP_PARENT}/openemr"
+    mkdir -p "${BASE_REPO}/docker/development-easy"
+    # Realistic compose with volume mounts (mirrors openemr master).
+    cat > "${BASE_REPO}/docker/development-easy/docker-compose.yml" <<'COMPOSE'
+services:
+  openemr:
+    volumes:
+    - ${OPENEMR_DIR:-../..}:/var/www/localhost/htdocs/openemr:rw
+    - assetvolume:/var/www/localhost/htdocs/openemr/public/assets:rw
+    - nodemodules:/var/www/localhost/htdocs/openemr/node_modules:rw
+    - vendordir:/var/www/localhost/htdocs/openemr/vendor:rw
+    - logvolume:/var/log
+    environment:
+      HOST_UID: "${HOST_UID:-1000}"
+      HOST_GID: "${HOST_GID:-1000}"
+COMPOSE
+    export TMP_PARENT BASE_REPO
+}
+
+teardown() {
+    [[ -n "${TMP_PARENT:-}" ]] && rm -rf "${TMP_PARENT}"
+    return 0
+}
+
+# --- HOST_UID/HOST_GID export ---------------------------------------------
+
+@test "non-worktree up: exports HOST_UID/HOST_GID for docker compose" {
+    local stub_dir expected_uid expected_gid
+    stub_dir=$(mk_env_recording_stub)
+    expected_uid=$(id -u)
+    expected_gid=$(id -g)
+
+    # Invoke `openemr-cmd up` from the dev-compose dir against the stub.
+    run env -i HOME="${HOME:-/tmp}" PATH="${stub_dir}:${PATH}" \
+        bash -c "cd '${BASE_REPO}/docker/development-easy' && '${SCRIPT}' up"
+    assert_success
+
+    # The stub's env_log should contain HOST_UID + HOST_GID matching
+    # the runner's current uid/gid.
+    [[ -f "${stub_dir}/docker.env" ]] || fail "stub didn't record env"
+    grep -qE "^HOST_UID=${expected_uid}$" "${stub_dir}/docker.env" \
+        || { echo "--- docker.env ---"; cat "${stub_dir}/docker.env"; fail "HOST_UID=${expected_uid} not exported"; }
+    grep -qE "^HOST_GID=${expected_gid}$" "${stub_dir}/docker.env" \
+        || { echo "--- docker.env ---"; cat "${stub_dir}/docker.env"; fail "HOST_GID=${expected_gid} not exported"; }
+
+    rm -rf "${stub_dir}"
+}
+
+@test "non-worktree up: respects user-exported HOST_UID/HOST_GID (doesn't override)" {
+    local stub_dir
+    stub_dir=$(mk_env_recording_stub)
+
+    # User explicitly exports HOST_UID/HOST_GID before running.
+    # Script should use those values, NOT auto-derive from id -u.
+    run env -i HOME="${HOME:-/tmp}" PATH="${stub_dir}:${PATH}" \
+        HOST_UID=2000 HOST_GID=2000 \
+        bash -c "cd '${BASE_REPO}/docker/development-easy' && '${SCRIPT}' up"
+    assert_success
+
+    grep -qE "^HOST_UID=2000$" "${stub_dir}/docker.env" \
+        || { echo "--- docker.env ---"; cat "${stub_dir}/docker.env"; fail "user HOST_UID=2000 was overridden"; }
+    grep -qE "^HOST_GID=2000$" "${stub_dir}/docker.env" \
+        || { echo "--- docker.env ---"; cat "${stub_dir}/docker.env"; fail "user HOST_GID=2000 was overridden"; }
+
+    rm -rf "${stub_dir}"
+}
+
+# --- Non-worktree pre-create ---------------------------------------------
+
+@test "non-worktree up: pre-creates host-side volume mount-point dirs in the base repo" {
+    local stub_dir
+    stub_dir=$(mk_env_recording_stub)
+
+    # Confirm the dirs don't exist BEFORE `up`.
+    [[ ! -d "${BASE_REPO}/public/assets" ]] || fail "fixture: public/assets exists pre-up"
+    [[ ! -d "${BASE_REPO}/node_modules" ]] || fail "fixture: node_modules exists pre-up"
+    [[ ! -d "${BASE_REPO}/vendor" ]] || fail "fixture: vendor exists pre-up"
+
+    run env -i HOME="${HOME:-/tmp}" PATH="${stub_dir}:${PATH}" \
+        bash -c "cd '${BASE_REPO}/docker/development-easy' && '${SCRIPT}' up"
+    assert_success
+
+    # All host-side mount-point dirs created.
+    [[ -d "${BASE_REPO}/public/assets" ]] || fail "pre-create missed public/assets"
+    [[ -d "${BASE_REPO}/node_modules" ]] || fail "pre-create missed node_modules"
+    [[ -d "${BASE_REPO}/vendor" ]] || fail "pre-create missed vendor"
+    # Out-of-webroot mount target NOT created on the host (only
+    # /var/log inside the container; nothing on the host).
+    [[ ! -d "${BASE_REPO}/var" ]] || fail "out-of-webroot dir wrongly created"
+
+    rm -rf "${stub_dir}"
+}
+
+@test "non-worktree up: pre-create is idempotent against existing dirs (including root-owned legacy cruft)" {
+    local stub_dir
+    stub_dir=$(mk_env_recording_stub)
+
+    # Simulate legacy base-repo state: vendor dir already exists.
+    # mkdir is the same effect as if a previous `up` had created it
+    # (or in the real-world case, an older docker daemon had created
+    # it as root); the bats test can't sudo to create as root, but
+    # the script's mkdir-then-accept logic doesn't distinguish — it
+    # just needs the dir to exist as a real directory.
+    mkdir -p "${BASE_REPO}/vendor"
+    echo "preserve-me" > "${BASE_REPO}/vendor/marker.txt"
+
+    run env -i HOME="${HOME:-/tmp}" PATH="${stub_dir}:${PATH}" \
+        bash -c "cd '${BASE_REPO}/docker/development-easy' && '${SCRIPT}' up"
+    assert_success
+
+    # Existing dir + content preserved (mkdir -p is a no-op on existing dirs).
+    [[ -d "${BASE_REPO}/vendor" ]] || fail "existing vendor dir wrongly removed"
+    [[ -f "${BASE_REPO}/vendor/marker.txt" ]] || fail "marker wrongly removed"
+    [[ "$(cat "${BASE_REPO}/vendor/marker.txt")" = "preserve-me" ]] || fail "marker content changed"
+    # Other dirs still created.
+    [[ -d "${BASE_REPO}/public/assets" ]] || fail "pre-create missed public/assets"
+
+    rm -rf "${stub_dir}"
+}

--- a/tests/bats/openemr-cmd/remove_graceful.bats
+++ b/tests/bats/openemr-cmd/remove_graceful.bats
@@ -232,7 +232,10 @@ setup_full_worktree() {
     # No `docker exec` invocation of any kind (proves the script
     # didn't sneak any side effects past the prompt; also serves as
     # a regression guard against any future shim re-introduction).
-    if grep -F "exec -u root" "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
+    # Match the `exec` subcommand broadly (any flags, any user) — the
+    # earlier `exec -u root` check was too narrow and would miss a
+    # `docker exec --tty <id> chown ...` variant.
+    if grep -qE '^(exec|exec[[:space:]])' "${STUB_DIR}/docker.log"; then
         cat "${STUB_DIR}/docker.log"
         fail "remove fired a docker exec before the prompt; aborted remove left side effects"
     fi
@@ -264,9 +267,11 @@ setup_full_worktree() {
     refute_output --partial "Auto-chowning bind mount via container"
     # No `docker exec` of any kind (chown or otherwise) should have
     # been issued by the remove flow itself. compose down is invoked
-    # via `docker compose`, not `docker exec`, so this remains a
-    # specific shim guard.
-    if grep -F "exec -u root" "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
+    # via `docker compose` (compose subcommand), not `docker exec`,
+    # so matching the `exec` subcommand broadly remains a specific
+    # shim guard against any future `docker exec` re-introduction
+    # regardless of flag shape.
+    if grep -qE '^(exec|exec[[:space:]])' "${STUB_DIR}/docker.log"; then
         cat "${STUB_DIR}/docker.log"
         fail "remove invoked docker exec for chown — shim re-introduced?"
     fi

--- a/tests/bats/openemr-cmd/remove_graceful.bats
+++ b/tests/bats/openemr-cmd/remove_graceful.bats
@@ -165,13 +165,13 @@ setup_full_worktree() {
     chmod 0700 "${sub}" 2>/dev/null || true
 
     assert_failure
-    # Clear, actionable error mentioning the unwritable dir + BOTH
-    # recovery options (start-stack auto-chown OR manual sudo chown).
+    # Clear, actionable error mentioning the unwritable dir + the
+    # sudo-chown recovery option (the only option now — the earlier
+    # in-container auto-chown shim was removed once HOST_UID adoption
+    # made it obsolete; for users on pre-HOST_UID images, sudo chown
+    # is the manual workaround).
     assert_output --partial "is not writable by you"
     assert_output --partial "${sub}"
-    # Option 1: start the stack first, auto-chown handles it.
-    assert_output --partial "openemr-cmd worktree up"
-    # Option 2: manual host-side sudo chown.
     assert_output --partial "sudo chown -R"
     # Nothing destructive ran: no compose down, no rm of dir, state intact.
     if grep -F -e " down " "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
@@ -206,42 +206,35 @@ setup_full_worktree() {
     assert_output "false"
 }
 
-# --- Auto-chown via container before destruction --------------------------
-# When the openemr container is still running, cmd_worktree_remove asks it
-# (as root, in-container) to chown the bind-mounted worktree back to the
-# host uid/gid BEFORE the destructive ops. This eliminates the manual
-# `sudo chown -R` step that users would otherwise hit when the container
-# wrote root-owned files (e.g. after drid). The A5 probe remains the
-# safety net for cases where the chown wasn't possible.
+# --- Confirmation prompt + no auto-chown shim ----------------------------
+# The earlier #833 in-container auto-chown shim was removed once HOST_UID
+# adoption (#840 + openemr/openemr#12642 + #12647) made the shim's
+# host-uid → host-uid chown a permanent no-op. The probe + the pre-create
+# + the probe-loosening (#838) are the safety net for any drift cases.
+# These tests pin the user-prompt behavior + the "no chown shim" contract.
 
-@test "remove: aborted at the prompt leaves NO side effects (no auto-chown, no destruction)" {
-    # The auto-chown sequence runs AFTER the user's y/N confirmation.
-    # If the user aborts, the container's ownership of bind-mounted files
-    # must stay exactly as it was — chowning to the host uid would leave
-    # apache (inside the container) unable to write to its own files on
-    # hosts where host-uid != container-apache-uid (uid 1000), effectively
-    # breaking the stack for continued use.
+@test "remove: aborted at the prompt leaves NO side effects (no destruction)" {
+    # If the user aborts at the y/N confirmation, NOTHING runs after
+    # the prompt — no compose down, no git worktree remove, no state
+    # mutation. Pin the contract: aborted remove leaves the worktree
+    # exactly as it was.
     setup_full_worktree feature-rm-abort -b
     local wt_dir
     wt_dir=$(jq -r '.["feature-rm-abort"].dir' "${STATE_FILE}")
     : > "${STUB_DIR}/docker.log"
-    # Pipe 'n' to the prompt to abort; DOCKER_PS_OUTPUT is set so that
-    # IF the auto-chown step were misplaced before the prompt, the chown
-    # invocation would be recorded — its absence below proves the reorder.
     run bash -c "echo n | env \
         PATH='${STUB_DIR}:${PATH}' \
         OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
         WORKTREE_PARENT='${TMP_WT_PARENT}' \
-        DOCKER_PS_OUTPUT='fake-openemr-container-id' \
         '${SCRIPT}' worktree remove feature-rm-abort"
     assert_success
     assert_output --partial "Aborted."
-    # The auto-chown banner must NOT have fired.
-    refute_output --partial "Auto-chowning bind mount via container"
-    # The chown docker exec must NOT have been recorded.
+    # No `docker exec` invocation of any kind (proves the script
+    # didn't sneak any side effects past the prompt; also serves as
+    # a regression guard against any future shim re-introduction).
     if grep -F "exec -u root" "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
         cat "${STUB_DIR}/docker.log"
-        fail "auto-chown fired before the prompt; aborted remove left side effects"
+        fail "remove fired a docker exec before the prompt; aborted remove left side effects"
     fi
     # And nothing destructive: dir still on disk, state entry still present.
     [[ -d "${wt_dir}" ]] || fail "worktree dir gone after aborted remove"
@@ -249,109 +242,38 @@ setup_full_worktree() {
     assert_output "true"
 }
 
-@test "remove: when container is running, docker exec chown is invoked with host uid:gid" {
-    setup_full_worktree feature-rm-autochown -b
+@test "remove: never invokes docker exec for chown (shim removed)" {
+    # Regression guard: the #833 in-container auto-chown shim was
+    # removed once HOST_UID adoption made it a permanent no-op
+    # (chowning host-uid → host-uid). If anyone ever re-introduces
+    # that shim, this test fires loudly. DOCKER_PS_OUTPUT is set so
+    # the script COULD find a target container — proving the absence
+    # of the docker exec is a deliberate choice, not just "no container
+    # was available".
+    setup_full_worktree feature-rm-no-shim -b
     local wt_dir
-    wt_dir=$(jq -r '.["feature-rm-autochown"].dir' "${STATE_FILE}")
+    wt_dir=$(jq -r '.["feature-rm-no-shim"].dir' "${STATE_FILE}")
     : > "${STUB_DIR}/docker.log"
-    # DOCKER_PS_OUTPUT is what the stub returns for any `docker ps ...`
-    # query; the openemr-cmd auto-chown step uses that filter to find the
-    # worktree's openemr container.
-    local uid gid
-    uid=$(id -u)
-    gid=$(id -g)
     run bash -c "echo y | env \
         PATH='${STUB_DIR}:${PATH}' \
         OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
         WORKTREE_PARENT='${TMP_WT_PARENT}' \
         DOCKER_PS_OUTPUT='fake-openemr-container-id' \
-        '${SCRIPT}' worktree remove feature-rm-autochown"
+        '${SCRIPT}' worktree remove feature-rm-no-shim"
     assert_success
-    # User-facing message confirms the auto-chown ran.
-    assert_output --partial "Auto-chowning bind mount via container"
-    assert_output --partial "uid=${uid}"
-    # The recorded docker invocation is the chown with the right shape:
-    # exec -u root <id> chown -R <uid>:<gid> /var/www/.../openemr
-    grep -Fq "exec -u root fake-openemr-container-id chown -R ${uid}:${gid} /var/www/localhost/htdocs/openemr" \
-        "${STUB_DIR}/docker.log" \
-        || { cat "${STUB_DIR}/docker.log"; fail "expected docker exec chown invocation not recorded"; }
-    # And the core outcome: the worktree directory itself is gone.
-    [[ ! -e "${wt_dir}" ]] || fail "worktree directory still exists: ${wt_dir}"
-}
-
-@test "remove: when container is NOT running, auto-chown step is skipped silently" {
-    setup_full_worktree feature-rm-no-container -b
-    local wt_dir
-    wt_dir=$(jq -r '.["feature-rm-no-container"].dir' "${STATE_FILE}")
-    : > "${STUB_DIR}/docker.log"
-    # DOCKER_PS_OUTPUT empty → the chown lookup returns nothing → step skipped.
-    run bash -c "echo y | env \
-        PATH='${STUB_DIR}:${PATH}' \
-        OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
-        WORKTREE_PARENT='${TMP_WT_PARENT}' \
-        '${SCRIPT}' worktree remove feature-rm-no-container"
-    assert_success
-    # No "Auto-chowning" message; no chown invocation in log.
     refute_output --partial "Auto-chowning bind mount via container"
+    # No `docker exec` of any kind (chown or otherwise) should have
+    # been issued by the remove flow itself. compose down is invoked
+    # via `docker compose`, not `docker exec`, so this remains a
+    # specific shim guard.
     if grep -F "exec -u root" "${STUB_DIR}/docker.log" >/dev/null 2>&1; then
         cat "${STUB_DIR}/docker.log"
-        fail "auto-chown ran despite no container being detected"
+        fail "remove invoked docker exec for chown — shim re-introduced?"
     fi
-    # And remove still succeeded — state entry gone, dir gone.
-    run jq -r 'has("feature-rm-no-container")' "${STATE_FILE}"
+    # Remove still succeeds end-to-end.
+    run jq -r 'has("feature-rm-no-shim")' "${STATE_FILE}"
     assert_output "false"
     [[ ! -e "${wt_dir}" ]] || fail "worktree directory still exists: ${wt_dir}"
-}
-
-@test "remove: auto-chown failure is non-fatal — probe is still the safety net" {
-    # Use a stub variant where `docker exec` returns non-zero (simulating a
-    # chown failure inside the container). The remove flow should still
-    # complete: chown failure is logged + ignored, probe finds no
-    # unwritable dirs (since the fixture doesn't have any), destructive
-    # ops proceed.
-    local failing_stub
-    failing_stub=$(oc_mktempdir)
-    cat > "${failing_stub}/docker" <<'STUB'
-#!/bin/sh
-echo "$@" >> STUBLOG
-# Plugin probe must succeed so check_docker_compose_install picks compose.
-if [ "$1" = "compose" ] && [ "$#" = "1" ]; then exit 0; fi
-# `ps` queries return the fake container id so the auto-chown reaches exec.
-case " $* " in
-    *' ps '*) echo 'fake-id-but-exec-will-fail' ;;
-esac
-# Fail `docker exec ...` so the auto-chown returns non-zero. The script's
-# `|| true` should swallow this and continue.
-if [ "$1" = "exec" ]; then exit 17; fi
-exit 0
-STUB
-    sed -i.bak "s|STUBLOG|${failing_stub}/docker.log|g" "${failing_stub}/docker" 2>/dev/null \
-        || sed -i "" "s|STUBLOG|${failing_stub}/docker.log|g" "${failing_stub}/docker"
-    rm -f "${failing_stub}/docker.bak"
-    : > "${failing_stub}/docker.log"
-    chmod +x "${failing_stub}/docker"
-
-    setup_full_worktree feature-rm-chown-fails -b
-    local wt_dir
-    wt_dir=$(jq -r '.["feature-rm-chown-fails"].dir' "${STATE_FILE}")
-    # Re-record the docker log against the failing stub (setup_full_worktree
-    # used the original STUB_DIR for the `add`; the remove below uses the
-    # failing stub).
-    run bash -c "echo y | env \
-        PATH='${failing_stub}:${PATH}' \
-        OPENEMR_ROOT='${TMP_OPENEMR_ROOT}' \
-        WORKTREE_PARENT='${TMP_WT_PARENT}' \
-        '${SCRIPT}' worktree remove feature-rm-chown-fails"
-    assert_success
-    # The chown invocation WAS attempted (proves the failure wasn't a
-    # silent skip), even though it returned non-zero.
-    grep -Fq "exec -u root fake-id-but-exec-will-fail chown" "${failing_stub}/docker.log" \
-        || { cat "${failing_stub}/docker.log"; fail "auto-chown attempt not recorded"; }
-    # Remove still succeeded — state gone, dir gone.
-    run jq -r 'has("feature-rm-chown-fails")' "${STATE_FILE}"
-    assert_output "false"
-    [[ ! -e "${wt_dir}" ]] || fail "worktree directory still exists: ${wt_dir}"
-    rm -rf "${failing_stub}"
 }
 
 # --- existing tamper guard ------------------------------------------------

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -1001,14 +1001,11 @@ cmd_worktree_remove() {
         # releases the lock — no manual release needed.
         wt_die "Cannot remove worktree '${branch}': directory '${unwritable}' is not writable by you.
 This usually means the docker container wrote files into the worktree as a
-different uid (root/apache). Two ways to recover:
-  (1) Start the stack first; the auto-chown step will fix permissions
-      from inside the container, then re-run remove:
-          openemr-cmd worktree up '${branch}'
-          openemr-cmd worktree remove '${branch}'
-  (2) Or restore ownership manually on the host (requires sudo):
-          sudo chown -R \"\$(id -u):\$(id -g)\" '${dir}'
-          openemr-cmd worktree remove '${branch}'"
+different uid (root/apache) — most commonly when the openemr image
+predates HOST_UID/HOST_GID entrypoint support (openemr/openemr#12642+).
+Recover by chowning manually on the host (requires sudo):
+    sudo chown -R \"\$(id -u):\$(id -g)\" '${dir}'
+    openemr-cmd worktree remove '${branch}'"
     fi
 
     wt_info "Stopping Docker stack"

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -18,7 +18,7 @@ set -euo pipefail
 #################################################################################################
 
 # Increment the version when modify script
-VERSION="1.0.49"
+VERSION="1.0.50"
 
 # ============================================================================
 # WORKTREE STATE MANAGEMENT
@@ -668,37 +668,47 @@ OVEOF
 # after openemr/) and out-of-webroot mounts (/var/log, /couchdb/data, etc.).
 wt_precreate_volume_mountpoints() {
     local dir=$1 env=$2
-    local compose_subdir compose_file
+    local compose_subdir
     compose_subdir=$(wt_compose_subdir "${env}")
-    compose_file="${dir}/${compose_subdir}/docker-compose.yml"
+    precreate_volume_mountpoints_at "${dir}/${compose_subdir}/docker-compose.yml" "${dir}"
+}
+
+# Lower-level version of wt_precreate_volume_mountpoints used by both
+# the worktree (wt_precreate_volume_mountpoints) and non-worktree
+# (run_docker_compose's up path) call sites. Takes the compose file
+# path + the host-side bind-mount root, parses named-volume mounts
+# targeting paths under /var/www/localhost/htdocs/openemr/, and
+# pre-creates the matching host dirs as the current user.
+#
+# Walks rel_path component-by-component instead of `mkdir -p
+# ${root}/${rel_path}` — plain mkdir -p follows existing symlink
+# components, so a malicious branch that committed e.g.
+# `public -> /etc` would cause us to create `etc/assets` on the host.
+# The walk refuses to descend through any symlink or non-directory.
+# Abandons the current mount target (continue 2) on any mismatch
+# without aborting the whole pre-create pass.
+#
+# Idempotent: existing host-owned dirs are accepted. Existing root-
+# owned dirs are also accepted (mkdir fails-EEXIST, fall-through
+# verifies it's a real dir) — we don't sudo-chown them because that
+# would require host root and surprise the user. Documented one-shot
+# cleanup for existing root-owned cruft in the base repo:
+# `sudo chown -R "$(id -u):$(id -g)" <openemr-checkout-dir>`.
+precreate_volume_mountpoints_at() {
+    local compose_file=$1 bind_root=$2
     [[ -f "${compose_file}" ]] || return 0
+    [[ -d "${bind_root}" ]] || return 0
 
     local container_path rel_path cur part
     local -a rel_parts
     while IFS= read -r container_path; do
         rel_path="${container_path#/var/www/localhost/htdocs/openemr/}"
-        # Refuse `..` components in the relative path — a malicious
-        # compose file could try to traverse outside the worktree via
-        # `/var/www/localhost/htdocs/openemr/../../etc`. The regex
-        # below requires `/openemr/` followed by `[^:]+` so the parser
-        # filters most pathological inputs, but belt+suspenders here.
+        # Refuse `..` components — defense-in-depth (the regex below
+        # already filters most pathological inputs).
         if [[ "${rel_path}" == *..* ]] || [[ -z "${rel_path}" ]]; then
             continue
         fi
-        # Walk the rel_path component-by-component instead of `mkdir -p
-        # ${dir}/${rel_path}`. Plain mkdir -p follows existing symlink
-        # components, so a malicious branch that committed e.g.
-        # `public -> /etc` would cause us to create `etc/assets` on
-        # the host. The wt_write_override symlink guards (for docker/
-        # and the compose subdir) don't cover this surface; this
-        # walk extends the same defense to every volume mount target.
-        #
-        # For each component: refuse if it exists as a symlink or as
-        # a non-directory regular file/special; otherwise mkdir (or
-        # accept that it already exists as a real dir). On any
-        # mismatch, abandon this mount target (continue 2 to the next
-        # while-loop iteration) without aborting the whole pre-create.
-        cur="${dir}"
+        cur="${bind_root}"
         rel_parts=()
         IFS=/ read -r -a rel_parts <<< "${rel_path}"
         for part in "${rel_parts[@]}"; do
@@ -709,7 +719,9 @@ wt_precreate_volume_mountpoints() {
             fi
             mkdir "${cur}" 2>/dev/null || {
                 # mkdir failed: tolerate the "already exists as real
-                # dir" case (idempotent); abandon on anything else.
+                # dir" case (idempotent — including the root-owned
+                # case for legacy base-repo users); abandon on anything
+                # else.
                 [[ -d "${cur}" && ! -L "${cur}" ]] || continue 2
             }
         done
@@ -928,55 +940,20 @@ cmd_worktree_remove() {
     read -rp "Continue? [y/N] " confirm
     [[ "${confirm}" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
-    # Best-effort auto-chown: when the openemr container is still running,
-    # ask it (as root) to chown the bind-mounted worktree back to the host
-    # uid/gid before we try to remove anything. The container writes files
-    # as root during install / drid / other admin paths; on hosts where
-    # the operator's uid != the container's apache uid, those files become
-    # unreadable + unremovable from the host side. Doing the chown from
-    # INSIDE the container (where it has root) sidesteps the manual
-    # `sudo chown -R` step that users would otherwise hit. The probe below
-    # is still the safety net — it catches anything chown missed (container
-    # not running, root-owned files outside the openemr workdir, etc.).
+    # Probe for permission issues before the destructive ops. With
+    # HOST_UID/HOST_GID now passed through compose (openemr-devops#840
+    # for worktree, openemr-devops#TBD for non-worktree) and adopted by
+    # apache inside the container (openemr/openemr#12642), the bind mount
+    # stays host-owned throughout — the probe is the safety net for
+    # users still on pre-HOST_UID openemr images. The probe loosening
+    # accepts empty root-owned mount-point dirs left over from older
+    # docker runs (openemr-devops#838), so the only remaining failure
+    # case is genuinely unwritable non-empty content — recoverable via
+    # the sudo-chown hint in the error message below.
     #
-    # Status note: with HOST_UID/HOST_GID now passed through compose
-    # (wt_write_override, requires openemr image with the entrypoint
-    # change from openemr#12642+), apache adopts the host uid at boot
-    # and this chown is a no-op (chowning host-uid → host-uid). Kept
-    # as a back-compat shim for users still on pre-HOST_UID images
-    # and for any drift cases the entrypoint adoption misses.
-    #
-    # Runs AFTER the user's y/N confirmation, not before. The chown is
-    # observable side effect for hosts where host-uid != container-apache-uid
-    # (the bind mount's ownership changes to the host user; apache in the
-    # container then cannot write to those files). On abort, that side
-    # effect would leave the stack effectively broken for continued use.
-    # Confirming first means abort genuinely leaves no trace.
-    local slug=""
-    slug=$(wt_slug "${branch}")
-    local autochown_id=""
-    autochown_id=$(docker ps \
-        --filter "label=com.docker.compose.project=openemr-${slug}" \
-        --filter "label=com.docker.compose.service=openemr" \
-        --format '{{.ID}}' 2>/dev/null | head -n 1 || true)
-    if [[ -n "${autochown_id}" ]]; then
-        # Capture uid/gid once (shellcheck SC2312: don't mask command
-        # substitution return values inside an expanded string).
-        local host_uid host_gid
-        host_uid=$(id -u)
-        host_gid=$(id -g)
-        wt_info "Auto-chowning bind mount via container (uid=${host_uid} gid=${host_gid})"
-        # `|| true`: chown failures are non-fatal; the probe below catches
-        # any unwritable dirs the chown couldn't fix.
-        docker exec -u root "${autochown_id}" \
-            chown -R "${host_uid}:${host_gid}" /var/www/localhost/htdocs/openemr \
-            2>/dev/null || true
-    fi
-
-    # Probe for permission issues before the destructive ops. After the
-    # auto-chown step above, this usually passes — but it remains as the
-    # safety net for: (a) container wasn't running, (b) root-owned files
-    # outside /var/www/localhost/htdocs/openemr, (c) chown itself failed.
+    # (The earlier #833 in-container auto-chown shim was removed once
+    # HOST_UID adoption made it a permanent no-op — chown host-uid →
+    # host-uid was just wasted docker exec time on every remove.)
     # If we proceed without catching that, we'd:
     #   1. purge the compose volumes (wt_compose_cmd down --volumes),
     #   2. let `git worktree remove --force` unregister the worktree, and
@@ -1655,6 +1632,22 @@ run_docker_compose() {
         echo "Error: Docker Compose command not determined." >&2
         exit 1
     fi
+    # Export HOST_UID/HOST_GID so the openemr service's compose-side
+    # environment block (added in openemr/openemr#12647) can interpolate
+    # them. Apache inside the container then adopts these uids at startup
+    # via the entrypoint from openemr/openemr#12642, eliminating bind-mount
+    # uid-mismatch bugs for any host whose uid != 1000 (CI runners, multi-
+    # user dev boxes, distros that start uids at 1001+, macOS via Docker
+    # Desktop). Respects user pre-exports (e.g. `export HOST_UID=...` in
+    # ~/.profile) — only auto-derives from id -u when unset.
+    #
+    # Worktree mode already bakes these into wt_write_override's
+    # override.yml (openemr-devops#840); this covers the non-worktree path
+    # (`openemr-cmd up`/`down`/`start`/`stop` invoked from a docker/*/ dir).
+    # Pre-HOST_UID-aware compose files silently drop the env vars —
+    # backwards compatible.
+    export HOST_UID="${HOST_UID:-$(id -u)}"
+    export HOST_GID="${HOST_GID:-$(id -g)}"
     # Execute the stored command with provided arguments
     "${DOCKER_COMPOSE_CMD[@]}" "$@"
 }
@@ -2203,6 +2196,22 @@ esac
 # For the shift usage, it used to cover the insane env.
 case "${FIRST_ARG}" in
     up)
+        # Pre-create host-side dirs for any named-volume mount points
+        # targeting paths under the webroot bind mount, BEFORE compose
+        # up. Same defense as worktree mode (wt_precreate_volume_
+        # mountpoints) — without this, docker daemon creates the
+        # missing mount-point dirs on the host as root:root 0755 on
+        # first attach, accumulating cruft in the base repo that
+        # later sudo-chown is needed to clean up. The compose file
+        # is in cwd; the bind mount root is ../.. per the
+        # ${OPENEMR_DIR:-../..} default in the dev compose files.
+        if [[ -f "${PWD}/docker-compose.yml" ]] && [[ -d "${PWD}/../.." ]]; then
+            # Resolve bind root once (avoid SC2312 inside the call).
+            bind_root_resolved=$("${OE_REALPATH_M[@]}" "${PWD}/../..")
+            precreate_volume_mountpoints_at \
+                "${PWD}/docker-compose.yml" \
+                "${bind_root_resolved}"
+        fi
         run_docker_compose up -d
         ;;
     down)

--- a/utilities/openemr-cmd/openemr-cmd
+++ b/utilities/openemr-cmd/openemr-cmd
@@ -2199,15 +2199,27 @@ case "${FIRST_ARG}" in
         # mountpoints) — without this, docker daemon creates the
         # missing mount-point dirs on the host as root:root 0755 on
         # first attach, accumulating cruft in the base repo that
-        # later sudo-chown is needed to clean up. The compose file
-        # is in cwd; the bind mount root is ../.. per the
-        # ${OPENEMR_DIR:-../..} default in the dev compose files.
-        if [[ -f "${PWD}/docker-compose.yml" ]] && [[ -d "${PWD}/../.." ]]; then
-            # Resolve bind root once (avoid SC2312 inside the call).
-            bind_root_resolved=$("${OE_REALPATH_M[@]}" "${PWD}/../..")
-            precreate_volume_mountpoints_at \
-                "${PWD}/docker-compose.yml" \
-                "${bind_root_resolved}"
+        # later sudo-chown is needed to clean up.
+        #
+        # The compose file is in cwd; the bind mount root follows
+        # ${OPENEMR_DIR:-../..} from the dev compose files. Respecting
+        # OPENEMR_DIR means a user who points the openemr checkout
+        # elsewhere via that env var gets their REAL checkout pre-
+        # created, not a phantom one at cwd/../..
+        if [[ -f "${PWD}/docker-compose.yml" ]]; then
+            bind_root_input="${OPENEMR_DIR:-../..}"
+            # Resolve relative paths against cwd (compose's own
+            # interpretation of relative volume sources).
+            if [[ "${bind_root_input}" != /* ]]; then
+                bind_root_input="${PWD}/${bind_root_input}"
+            fi
+            if [[ -d "${bind_root_input}" ]]; then
+                # Resolve once (avoid SC2312 inside the call).
+                bind_root_resolved=$("${OE_REALPATH_M[@]}" "${bind_root_input}")
+                precreate_volume_mountpoints_at \
+                    "${PWD}/docker-compose.yml" \
+                    "${bind_root_resolved}"
+            fi
         fi
         run_docker_compose up -d
         ;;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `openemr-cmd up` now forwards `HOST_UID`/`HOST_GID` into Docker (when not set) to preserve host ownership for non-worktree runs.
  * Non-worktree startup pre-creates required host bind-mount directories before bringing containers up.
* **Bug Fixes**
  * Worktree removal now uses a safer permission probe and no longer relies on the in-container auto-chown step, with updated messaging and tolerance for leftover empty mount dirs.
* **Tests**
  * Added/updated BATS and CI workflow coverage to validate `HOST_UID`/`HOST_GID` behavior and the revised removal flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Cross-repo dependency

Depends on **openemr/openemr#12647** (now landed). The flex image already pins HOST_UID entrypoint support (from openemr/openemr#12642 via the #12644 dependabot bump); #12647 added the compose-side env declaration so the exported HOST_UID actually reaches the openemr service. **No additional image release needed** — all moving pieces in place once both PRs land.

## What's tested end-to-end in CI

- **Worktree mode**: `worktree-lifecycle-e2e` asserts `sites/default/sqlconf.php` is owned by the runner uid after install — proves apache adopted HOST_UID via wt_write_override's env block + entrypoint adoption.
- **Non-worktree mode**: `nonworktree-lifecycle-e2e` asserts the same against `openemr/sites/default/sqlconf.php` — proves run_docker_compose's export reaches the openemr service via #12647's env block + entrypoint adoption.
