### PR TITLE
ci(openemr-cmd): add arm64-smoke-e2e on ubuntu-24.04-arm (daily-cron + workflow_dispatch)

### DIFF
--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -40,12 +40,14 @@ name: openemr-cmd e2e (real docker)
 #     installed hooks — rather than invoking the hook scripts by
 #     hand, so a regression in the shim, hooks-dir resolution, or
 #     cwd-aware container routing surfaces here.
-#   - arm64-smoke-e2e: schedule + workflow_dispatch only (skipped on
-#     PR/push). One nonworktree-style stack on ubuntu-24.04-arm —
-#     proves the openemr image's arm64 manifest works end-to-end
-#     (Apple Silicon developers pull the arm64 variant via Docker
-#     Desktop's Linux VM; catching arm64-only image regressions
-#     here saves them from finding them first).
+#   - arm64-smoke-e2e: one nonworktree-style stack on
+#     ubuntu-24.04-arm — proves the openemr image's arm64 manifest
+#     works end-to-end. All dev-easy images are multi-arch (amd64 +
+#     arm64), so Apple Silicon Mac devs and Raspberry Pi (4/5)
+#     users get native arm64 execution without qemu translation;
+#     this job catches arm64-only image regressions before those
+#     users hit them in practice. Runs on every PR (same triggers
+#     as the other e2e jobs).
 #
 # Cost: ~10-20 min per job for the lifecycle / non-worktree / prek
 # jobs; the multi-concurrent job is ~25-35 min (three parallel
@@ -1695,13 +1697,16 @@ jobs:
           docker logs openemr-prek-e2e-openemr-1 --tail 500 2>/dev/null || true
 
   arm64-smoke-e2e:
-    # Daily-only smoke test on arm64 Linux. Catches arm64-specific
-    # regressions in the openemr image (which is multi-arch — amd64
-    # + arm64). The arm64 variant is what Apple Silicon developers
-    # actually pull on their Macs (via Docker Desktop's Linux VM,
-    # which auto-selects the arm64 manifest), so catching arm64-only
-    # image bugs here within 24h saves those developers from finding
-    # them first.
+    # arm64 Linux smoke test — runs on every PR + push + schedule
+    # + workflow_dispatch (same triggers as the other e2e jobs).
+    # Cheap enough (~10 min wall, native arm64 containerization) to
+    # gate PRs on. Catches arm64-specific regressions in the openemr
+    # image (which is multi-arch — amd64 + arm64) and all other dev
+    # compose images (mariadb, selenium, phpmyadmin, mailpit, ldap,
+    # couchdb — all multi-arch). The arm64 variants are what Apple
+    # Silicon Mac devs and Raspberry Pi (4/5) users pull, so this
+    # job catches arm64-only image regressions before those users
+    # hit them in practice.
     #
     # Scope is intentionally narrow: same shape as nonworktree-
     # lifecycle-e2e but on a different runner arch. One stack via
@@ -1712,24 +1717,16 @@ jobs:
     # duplication for low marginal value. Heavier arm64 coverage
     # can be filed if this smoke ever catches a real regression.
     #
-    # Why Linux arm64 instead of macOS: free GH-hosted macOS
-    # runners (macos-14 arm64) can't run Linux VMs reliably (VZ
-    # needs nested virt, QEMU panics in Lima). Linux arm64 runners
-    # use native cgroups/namespaces on an arm64 host kernel — zero
+    # Why Linux arm64 instead of macOS: free GH-hosted macOS runners
+    # (macos-14 arm64) can't run Linux VMs reliably (VZ needs nested
+    # virt; QEMU panics in Lima). Linux arm64 runners use native
+    # cgroups/namespaces on an arm64 host kernel — zero
     # virtualization, same fast path as ubuntu-22.04 for amd64.
     # macOS-specific concerns (HFS+/APFS case, BSD coreutils edges,
-    # Docker Desktop bind-mount semantics) are uncovered by this
-    # job; the bats portability memory note covers most of those
-    # at the shell-script level.
-    #
-    # Triggers: schedule + workflow_dispatch only. Skips on
-    # push/pull_request so PR cycles stay fast.
-    name: e2e — arm64 Linux smoke (ubuntu-24.04-arm, daily-cron only)
-    # TEMPORARY: include pull_request so this PR can validate the job
-    # works end-to-end on an arm64 runner before merging. Revert to
-    # schedule-only (drop the pull_request clause) in the final
-    # pre-merge commit on this branch.
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    # Docker Desktop bind-mount semantics) are uncovered by this job;
+    # the bats portability memory note covers most at the shell-
+    # script level.
+    name: e2e — arm64 Linux smoke (ubuntu-24.04-arm)
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 25
     steps:
@@ -1830,9 +1827,13 @@ jobs:
           fi
           echo "OK: bind-mount file owned by uid=${runner_uid} (apache adopted host uid on arm64)"
 
-      - name: openemr-cmd down -v (cleanup)
+      - name: openemr-cmd down (cleanup — internally -v)
         working-directory: openemr/docker/development-easy
         run: openemr-cmd down
+        # Note: `openemr-cmd down` already runs `docker compose down -v`
+        # under the hood (see cmd_down dispatch in openemr-cmd). The
+        # step name reflects the actual user-facing command; the -v
+        # behavior is implicit.
 
       - name: Diagnostics on failure
         if: failure()

--- a/.github/workflows/test-bats-openemr-cmd-real-docker.yml
+++ b/.github/workflows/test-bats-openemr-cmd-real-docker.yml
@@ -40,6 +40,12 @@ name: openemr-cmd e2e (real docker)
 #     installed hooks — rather than invoking the hook scripts by
 #     hand, so a regression in the shim, hooks-dir resolution, or
 #     cwd-aware container routing surfaces here.
+#   - arm64-smoke-e2e: schedule + workflow_dispatch only (skipped on
+#     PR/push). One nonworktree-style stack on ubuntu-24.04-arm —
+#     proves the openemr image's arm64 manifest works end-to-end
+#     (Apple Silicon developers pull the arm64 variant via Docker
+#     Desktop's Linux VM; catching arm64-only image regressions
+#     here saves them from finding them first).
 #
 # Cost: ~10-20 min per job for the lifecycle / non-worktree / prek
 # jobs; the multi-concurrent job is ~25-35 min (three parallel
@@ -1687,3 +1693,157 @@ jobs:
           cat /tmp/commit-accept.log 2>/dev/null || true
           echo "===== openemr container logs (last 500) ====="
           docker logs openemr-prek-e2e-openemr-1 --tail 500 2>/dev/null || true
+
+  arm64-smoke-e2e:
+    # Daily-only smoke test on arm64 Linux. Catches arm64-specific
+    # regressions in the openemr image (which is multi-arch — amd64
+    # + arm64). The arm64 variant is what Apple Silicon developers
+    # actually pull on their Macs (via Docker Desktop's Linux VM,
+    # which auto-selects the arm64 manifest), so catching arm64-only
+    # image bugs here within 24h saves those developers from finding
+    # them first.
+    #
+    # Scope is intentionally narrow: same shape as nonworktree-
+    # lifecycle-e2e but on a different runner arch. One stack via
+    # `openemr-cmd up`, wait healthy, HTTP smoke, bind-mount
+    # ownership assertion, teardown. No worktree lifecycle / multi-
+    # concurrent / prek / functional — those are amd64-covered
+    # already; adding arm64 versions of all of them is heavy
+    # duplication for low marginal value. Heavier arm64 coverage
+    # can be filed if this smoke ever catches a real regression.
+    #
+    # Why Linux arm64 instead of macOS: free GH-hosted macOS
+    # runners (macos-14 arm64) can't run Linux VMs reliably (VZ
+    # needs nested virt, QEMU panics in Lima). Linux arm64 runners
+    # use native cgroups/namespaces on an arm64 host kernel — zero
+    # virtualization, same fast path as ubuntu-22.04 for amd64.
+    # macOS-specific concerns (HFS+/APFS case, BSD coreutils edges,
+    # Docker Desktop bind-mount semantics) are uncovered by this
+    # job; the bats portability memory note covers most of those
+    # at the shell-script level.
+    #
+    # Triggers: schedule + workflow_dispatch only. Skips on
+    # push/pull_request so PR cycles stay fast.
+    name: e2e — arm64 Linux smoke (ubuntu-24.04-arm, daily-cron only)
+    # TEMPORARY: include pull_request so this PR can validate the job
+    # works end-to-end on an arm64 runner before merging. Revert to
+    # schedule-only (drop the pull_request clause) in the final
+    # pre-merge commit on this branch.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 25
+    steps:
+      - name: Checkout openemr-devops (for openemr-cmd)
+        uses: actions/checkout@v7
+        with:
+          path: openemr-devops
+          persist-credentials: false
+
+      - name: Install openemr-cmd to /usr/local/bin
+        run: |
+          sudo install -m 0755 openemr-devops/utilities/openemr-cmd/openemr-cmd /usr/local/bin/openemr-cmd
+          openemr-cmd --version || true
+
+      - name: Clone openemr/openemr (shallow)
+        uses: actions/checkout@v7
+        with:
+          repository: openemr/openemr
+          path: openemr
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Pre-flight (versions + arch + disk)
+        run: |
+          uname -m
+          docker --version
+          docker compose version
+          jq --version
+          df -h /
+
+      - name: openemr-cmd up (from openemr/docker/development-easy)
+        working-directory: openemr/docker/development-easy
+        run: |
+          # Same invocation as the amd64 nonworktree-lifecycle-e2e
+          # job. Docker auto-selects the arm64 manifest from the
+          # multi-arch image — native arm64 execution, no qemu-user
+          # translation needed.
+          openemr-cmd up
+
+      - name: Wait for development-easy-openemr-1 to become healthy
+        run: |
+          cname="development-easy-openemr-1"
+          # Same 15-min budget as the amd64 nonworktree-lifecycle-e2e
+          # — arm64 native should be comparable to amd64 native; if
+          # it's noticeably slower the timeout still catches it.
+          for i in $(seq 1 90); do
+            status=$(docker inspect --format='{{.State.Health.Status}}' "${cname}" 2>/dev/null || echo "missing")
+            echo "[${i}/90 @ $((i*10))s] status=${status}"
+            case "${status}" in
+              healthy) echo "container reported healthy"; exit 0 ;;
+              unhealthy) echo "FAIL: container reported unhealthy"; docker logs "${cname}" --tail 200; exit 1 ;;
+            esac
+            sleep 10
+          done
+          echo "FAIL: container never became healthy in ~15 min"
+          docker ps -a
+          docker logs "${cname}" --tail 500
+          exit 1
+
+      - name: HTTP smoke (openemr responds on default port 8300)
+        run: |
+          for i in $(seq 1 12); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" \
+                --connect-timeout 5 --max-time 10 \
+                "http://localhost:8300/" || true)
+            echo "[${i}/12] HTTP ${code}"
+            case "${code}" in
+              200|302|303) exit 0 ;;
+            esac
+            sleep 5
+          done
+          echo "FAIL: openemr did not respond with 2xx/3xx on port 8300"
+          exit 1
+
+      - name: "Verify bind mount is host-owned on arm64 (HOST_UID adoption)"
+        run: |
+          # Same probe as the amd64 nonworktree-lifecycle-e2e: the
+          # openemr install path writes sites/default/sqlconf.php as
+          # apache. With HOST_UID/HOST_GID exported by openemr-cmd's
+          # run_docker_compose, apache adopts the runner uid via the
+          # entrypoint and the file ends up host-owned. Same code
+          # path on arm64 as amd64 (entrypoint is in the multi-arch
+          # image's arm64 variant), so this pins that the adoption
+          # works on the arm64 variant specifically.
+          probe_file="${{ github.workspace }}/openemr/sites/default/sqlconf.php"
+          if [[ ! -f "${probe_file}" ]]; then
+              echo "FAIL: probe file (sqlconf.php) missing — install may not have completed"
+              ls -la "${{ github.workspace }}/openemr/sites/default/" || true
+              exit 1
+          fi
+          owner_uid=$(stat -c '%u' "${probe_file}")
+          runner_uid=$(id -u)
+          if [[ "${owner_uid}" != "${runner_uid}" ]]; then
+              echo "FAIL: bind-mount file owned by uid=${owner_uid} (expected runner uid=${runner_uid})"
+              echo "HOST_UID adoption is NOT working on arm64 — entrypoint may be missing from the arm64 image variant"
+              ls -la "${probe_file}"
+              exit 1
+          fi
+          echo "OK: bind-mount file owned by uid=${runner_uid} (apache adopted host uid on arm64)"
+
+      - name: openemr-cmd down -v (cleanup)
+        working-directory: openemr/docker/development-easy
+        run: openemr-cmd down
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "===== uname ====="
+          uname -a || true
+          echo "===== docker ps -a ====="
+          docker ps -a || true
+          echo "===== docker volume ls ====="
+          docker volume ls || true
+          echo "===== openemr container logs (last 500) ====="
+          docker logs development-easy-openemr-1 --tail 500 2>/dev/null || true
+          echo "===== mysql container logs (last 200) ====="
+          docker logs development-easy-mysql-1 --tail 200 2>/dev/null || true


### PR DESCRIPTION
## Summary

Replaces the abandoned macOS smoke attempt (#844, closed) with an arm64 Linux runner. Adds one nonworktree-style stack on `ubuntu-24.04-arm` to validate the openemr image's arm64 manifest works end-to-end.

## Why arm64 Linux instead of macOS

Free GH-hosted `macos-14` (Apple Silicon arm64) **fundamentally can't run Linux VMs reliably** on the free pool — VZ driver needs nested virtualization (not available), QEMU panics in Lima's host agent with abort traps. After 4 iterations trying colima/Lima, abandoned the macOS path.

`ubuntu-24.04-arm` gives us the same signal we actually wanted: **arm64-specific image regressions**. The openemr image is multi-arch (amd64 + arm64). Docker auto-selects the arm64 manifest on arm64 hosts. Apple Silicon Mac developers pull the arm64 variant via Docker Desktop's Linux VM, so catching arm64-only image bugs here within 24h saves them from finding them first.

Linux arm64 runners use native cgroups/namespaces on an arm64 host kernel — same fast/supported path as `ubuntu-22.04` for amd64, just on arm64. **Zero virtualization, no colima brittleness**.

## Scope (intentionally narrow vs the amd64 jobs)

| Job | amd64 (existing) | arm64 (new) |
|---|---|---|
| worktree lifecycle | ✓ | — |
| multi-concurrent (4 stacks) | ✓ | — |
| nonworktree lifecycle | ✓ | **✓ (this job)** |
| functional round-trip | ✓ | — |
| prek install + real commit | ✓ | — |

One stack, one health check, one HTTP smoke, one bind-mount ownership assertion, one teardown. Heavier arm64 coverage can be filed if this smoke ever catches a real regression.

## What this catches that amd64-only doesn't

- arm64-specific image regressions in `openemr/openemr:flex` (missing arm64 deps, arm64-only segfaults, etc.)
- HOST_UID entrypoint adoption working in the arm64 image variant (verified by the bind-mount ownership assertion — same probe as the amd64 nonworktree job, but exercises the arm64 entrypoint specifically)

## What this does NOT catch (out of scope)

- macOS-specific concerns: HFS+/APFS case-insensitivity, BSD coreutils edges, Docker Desktop bind-mount semantics. Most are covered at the script level by the bats portability memory note; the rest are "would be nice if a contributor reports a bug" rather than CI requirements.

## Cost

~25 min outer timeout. Public-repo arm64 runners are free as of mid-2024.

## Test plan

- [ ] Workflow YAML validates (verified locally)
- [ ] arm64 runner picks up the job within reasonable time (free arm64 Linux pool is much larger than macOS)
- [ ] Image pull succeeds (arm64 manifest selected automatically)
- [ ] Container reaches healthy
- [ ] HTTP smoke passes
- [ ] Bind-mount-ownership assertion passes (HOST_UID adoption working on arm64 entrypoint)
- [ ] Teardown leaves no orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new arm64 smoke test job to better validate the app on ARM Linux by exercising the arm64 image manifest end-to-end.
  * Includes pre-flight checks, service readiness verification, basic HTTP smoke testing, and validation of correct file ownership behavior.
  * Improved failure diagnostics to simplify troubleshooting when the job fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
