### PR TITLE
feat(release): add release-targets-changed dispatch event to canonical schema

### DIFF
--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -8,13 +8,14 @@
     "additionalProperties": false,
     "properties": {
         "event": {
-            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "description": "Dispatch event name. Conductor emits the first three (rel-cut/rel-update/tag) plus release-targets-changed; website-openemr emits openemr-docs-binaries to website-openemr-files.",
             "type": "string",
             "enum": [
                 "openemr-rel-cut",
                 "openemr-rel-update",
                 "openemr-tag",
-                "openemr-docs-binaries"
+                "openemr-docs-binaries",
+                "release-targets-changed"
             ]
         },
         "repo": {
@@ -64,6 +65,12 @@
             "properties": {
                 "event": { "const": "openemr-docs-binaries" },
                 "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "release-targets-changed" },
+                "data": { "$ref": "#/definitions/releaseTargetsChangedData" }
             }
         }
     ],
@@ -129,6 +136,12 @@
                     }
                 }
             }
+        },
+        "releaseTargetsChangedData": {
+            "description": "Notification that openemr/openemr's .github/release-targets.yml was updated on master. Carries no event-specific fields; the envelope's sha/actor/dispatched_at fully identify the change. Consumers (e.g. demo_farm_openemr's auto-derive bot) re-read the file directly from openemr/openemr@master.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
         }
     }
 }

--- a/tools/release/tests/Contracts/DispatchSchemaTest.php
+++ b/tools/release/tests/Contracts/DispatchSchemaTest.php
@@ -26,11 +26,12 @@ final class DispatchSchemaTest extends TestCase
      */
     public static function goodFixtures(): iterable
     {
-        yield 'openemr-rel-cut'        => ['good-rel-cut.json'];
-        yield 'openemr-rel-update'     => ['good-rel-update.json'];
-        yield 'openemr-tag'            => ['good-tag.json'];
-        yield 'openemr-tag (test)'     => ['good-tag-test.json'];
-        yield 'openemr-docs-binaries'  => ['good-docs-binaries.json'];
+        yield 'openemr-rel-cut'           => ['good-rel-cut.json'];
+        yield 'openemr-rel-update'        => ['good-rel-update.json'];
+        yield 'openemr-tag'               => ['good-tag.json'];
+        yield 'openemr-tag (test)'        => ['good-tag-test.json'];
+        yield 'openemr-docs-binaries'     => ['good-docs-binaries.json'];
+        yield 'release-targets-changed'   => ['good-release-targets-changed.json'];
     }
 
     /**
@@ -38,10 +39,11 @@ final class DispatchSchemaTest extends TestCase
      */
     public static function badFixtures(): iterable
     {
-        yield 'openemr-rel-cut missing prev_release'    => ['bad-rel-cut.json', 'prev_release'];
-        yield 'openemr-rel-update non-hex sha'          => ['bad-rel-update.json', 'sha'];
-        yield 'openemr-tag with dotted version'         => ['bad-tag.json', 'tag'];
-        yield 'openemr-docs-binaries empty files array' => ['bad-docs-binaries.json', 'files'];
+        yield 'openemr-rel-cut missing prev_release'      => ['bad-rel-cut.json', 'prev_release'];
+        yield 'openemr-rel-update non-hex sha'            => ['bad-rel-update.json', 'sha'];
+        yield 'openemr-tag with dotted version'           => ['bad-tag.json', 'tag'];
+        yield 'openemr-docs-binaries empty files array'   => ['bad-docs-binaries.json', 'files'];
+        yield 'release-targets-changed with stray data key' => ['bad-release-targets-changed.json', 'stray_field'];
     }
 
     #[DataProvider('goodFixtures')]

--- a/tools/release/tests/fixtures/dispatch/bad-release-targets-changed.json
+++ b/tools/release/tests/fixtures/dispatch/bad-release-targets-changed.json
@@ -1,0 +1,10 @@
+{
+    "event": "release-targets-changed",
+    "repo": "openemr/openemr",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:30:00Z",
+    "data": {
+        "stray_field": "x"
+    }
+}

--- a/tools/release/tests/fixtures/dispatch/good-release-targets-changed.json
+++ b/tools/release/tests/fixtures/dispatch/good-release-targets-changed.json
@@ -1,0 +1,8 @@
+{
+    "event": "release-targets-changed",
+    "repo": "openemr/openemr",
+    "sha": "abcdef0123456789abcdef0123456789abcdef01",
+    "actor": "openemr-release-bot",
+    "dispatched_at": "2026-04-29T12:30:00Z",
+    "data": {}
+}

--- a/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
@@ -8,13 +8,14 @@
     "additionalProperties": false,
     "properties": {
         "event": {
-            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "description": "Dispatch event name. Conductor emits the first three (rel-cut/rel-update/tag) plus release-targets-changed; website-openemr emits openemr-docs-binaries to website-openemr-files.",
             "type": "string",
             "enum": [
                 "openemr-rel-cut",
                 "openemr-rel-update",
                 "openemr-tag",
-                "openemr-docs-binaries"
+                "openemr-docs-binaries",
+                "release-targets-changed"
             ]
         },
         "repo": {
@@ -64,6 +65,12 @@
             "properties": {
                 "event": { "const": "openemr-docs-binaries" },
                 "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "release-targets-changed" },
+                "data": { "$ref": "#/definitions/releaseTargetsChangedData" }
             }
         }
     ],
@@ -129,6 +136,12 @@
                     }
                 }
             }
+        },
+        "releaseTargetsChangedData": {
+            "description": "Notification that openemr/openemr's .github/release-targets.yml was updated on master. Carries no event-specific fields; the envelope's sha/actor/dispatched_at fully identify the change. Consumers (e.g. demo_farm_openemr's auto-derive bot) re-read the file directly from openemr/openemr@master.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
         }
     }
 }

--- a/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
@@ -8,13 +8,14 @@
     "additionalProperties": false,
     "properties": {
         "event": {
-            "description": "Dispatch event name. Conductor emits the first three; website-openemr emits openemr-docs-binaries to website-openemr-files.",
+            "description": "Dispatch event name. Conductor emits the first three (rel-cut/rel-update/tag) plus release-targets-changed; website-openemr emits openemr-docs-binaries to website-openemr-files.",
             "type": "string",
             "enum": [
                 "openemr-rel-cut",
                 "openemr-rel-update",
                 "openemr-tag",
-                "openemr-docs-binaries"
+                "openemr-docs-binaries",
+                "release-targets-changed"
             ]
         },
         "repo": {
@@ -64,6 +65,12 @@
             "properties": {
                 "event": { "const": "openemr-docs-binaries" },
                 "data": { "$ref": "#/definitions/docsBinariesData" }
+            }
+        },
+        {
+            "properties": {
+                "event": { "const": "release-targets-changed" },
+                "data": { "$ref": "#/definitions/releaseTargetsChangedData" }
             }
         }
     ],
@@ -129,6 +136,12 @@
                     }
                 }
             }
+        },
+        "releaseTargetsChangedData": {
+            "description": "Notification that openemr/openemr's .github/release-targets.yml was updated on master. Carries no event-specific fields; the envelope's sha/actor/dispatched_at fully identify the change. Consumers (e.g. demo_farm_openemr's auto-derive bot) re-read the file directly from openemr/openemr@master.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {}
         }
     }
 }


### PR DESCRIPTION
## What

Adds a 5th dispatch event, `release-targets-changed`, to the canonical
`tools/release/contracts/dispatch.schema.json`:

- `event` enum gains `"release-targets-changed"`
- `event` description updated to enumerate the conductor's outputs
- New `oneOf` arm pairing the event with a new data definition
- New `releaseTargetsChangedData` definition (empty schema with
  `additionalProperties: false` — no event-specific fields)

Plus 2 fixtures and 2 provider entries in `DispatchSchemaTest`:

- `good-release-targets-changed.json` — valid envelope, `"data": {}`
- `bad-release-targets-changed.json` — same envelope with a stray
  `data.stray_field` (exercises `additionalProperties: false`)

## Why

The new event signals that openemr/openemr's `.github/release-targets.yml`
was updated on master. demo_farm_openemr's auto-derive bot
(demo_farm_openemr#141, already landed) consumes it to re-read the file
and reconcile its derived target matrix.

The envelope's `sha`/`actor`/`dispatched_at` fully identify the change,
so the data payload is intentionally empty.

This is the **canonical side**. openemr/openemr#12657 carries the vendor
side (vendored schema copy + workflow + Dispatcher PHP); the vendor-drift
check from #12619 currently fails on #12657 because the vendored copy
diverges from this canonical. Once this PR lands, #12657 can rebase and
the drift check passes.

## Companion PRs

- openemr/openemr#12657 — vendored copy of this schema + workflow that
  emits the event + `Dispatcher` PHP that builds the envelope
- demo_farm_openemr#141 — listener for the new event (already landed)

## No PHP behavior change in this repo

openemr-devops doesn't consume `release-targets-changed` itself; this is
purely the canonical-schema side that the vendor-drift check in
openemr/openemr validates against. No changes to `bin/`, no changes to
`src/`, no changes to workflows.

## Test plan

- [x] `python3 -m json.tool` clean on the modified schema
- [x] `python3 -m json.tool` clean on both new fixtures
- [x] PHPUnit `DispatchSchemaTest` — 11 tests, 16 assertions, all green
  (2 new test cases: `release-targets-changed` validates, stray data
  field is rejected with `stray_field` in the error message)
- [ ] CI green on this PR
- [ ] After this lands: openemr/openemr#12657 rebase + drift check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new release dispatch event type, including validation for empty event data.
* **Bug Fixes**
  * Enhanced dispatch payload validation to correctly reject unexpected fields for the new event type.
* **Tests**
  * Added fixtures and contract test coverage for both valid and invalid examples of the new dispatch event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->