### PR TITLE
ci(claude-review): add caller for shared Claude PR review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,4 +17,4 @@ jobs:
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
     secrets:
-      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,20 @@
+# .github/workflows/claude-review.yml
+# Drop this IDENTICAL file into all FOUR repos:
+#   openemr, openemr-devops, website-openemr, demo_farm_openemr
+#
+# It forwards events to the shared reusable workflow in openemr/openemr.
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened]        # auto-review non-bot PRs on open
+  issue_comment:
+    types: [created]       # maintainers force a review with "@claude review"
+
+jobs:
+  call-review:
+    # Reusable workflow lives in openemr/openemr. Adjust the branch ref
+    # (@master vs @main) to match that repo's default branch.
+    uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,6 +13,14 @@ on:
 
 jobs:
   call-review:
+    # Reusable workflows can only reduce, not elevate, the caller job's
+    # permissions. Declare the same scopes the reusable's job needs so the
+    # effective GITHUB_TOKEN can actually post review comments.
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
     # Reusable workflow lives in openemr/openemr. Adjust the branch ref
     # (@master vs @main) to match that repo's default branch.
     uses: openemr/openemr/.github/workflows/claude-review-reusable.yml@master


### PR DESCRIPTION
## Summary

- Adds a thin caller at `.github/workflows/claude-review.yml` that forwards `pull_request: opened` and `issue_comment: created` events into the shared `workflow_call` reusable at `openemr/openemr/.github/workflows/claude-review-reusable.yml@master`.
- The identical caller is being placed in `openemr`, `website-openemr`, and `demo_farm_openemr` so all four repos share one review definition. Future prompt / model / permission tweaks happen once in `openemr/openemr` and apply everywhere.

## When it runs

- **Auto-review**: any non-bot PR when it is opened.
- **Manual / fork / bot escape hatch**: any PR when an `OWNER`/`MEMBER`/`COLLABORATOR` comments `@claude review`. This is the only path where the workflow secret is accessible on fork PRs.

## Required secret

`CLAUDE_CODE_OAUTH_TOKEN` must exist as an **organization secret** on `openemr` and be visible to this repo. It uses subscription auth against the separate programmatic credit — does not draw from interactive Claude Code limits.

## Test plan

- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` is visible to this repo.
- [ ] Confirm the openemr/openemr PR adding `claude-review-reusable.yml` has merged so `@master` resolves.
- [ ] After merge, open a small no-op PR here and confirm the "Claude PR Review" workflow runs and posts a review.
- [ ] From a maintainer account, comment `@claude review` on an existing PR and confirm the workflow re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new automated pull request review workflow.
  * Reviews now run when a non-bot pull request is opened or when a maintainer requests a review via comment.
  * The workflow uses a shared review process and securely passes the required access token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->