### PR TITLE
ci(deps): bump arduino/setup-task v2 → v3 + wire repo-token across release workflows

### DIFF
--- a/.github/workflows/build-patch.yml
+++ b/.github/workflows/build-patch.yml
@@ -113,9 +113,10 @@ jobs:
         php-version: '8.4'
 
     - name: Install Taskfile
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@v3
       with:
         version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install release tools
       run: task release:setup

--- a/.github/workflows/build-release-on-tag.yml
+++ b/.github/workflows/build-release-on-tag.yml
@@ -45,7 +45,9 @@ jobs:
           php-version: '8.5'
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install release-tools dependencies
         working-directory: tools/release

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -163,9 +163,10 @@ jobs:
         php-version: '8.5'
 
     - name: Install Taskfile
-      uses: arduino/setup-task@v2
+      uses: arduino/setup-task@v3
       with:
         version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Install release tools
       working-directory: devops-tools

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -53,7 +53,9 @@ jobs:
           php-version: '8.5'
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install release-tools dependencies
         working-directory: tools/release

--- a/.github/workflows/release-permissions-check.yml
+++ b/.github/workflows/release-permissions-check.yml
@@ -35,7 +35,9 @@ jobs:
           php-version: '8.5'
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Mint release App token
         id: app-token

--- a/.github/workflows/ship-release.yml
+++ b/.github/workflows/ship-release.yml
@@ -65,7 +65,9 @@ jobs:
           php-version: '8.5'
 
       - name: Install Task
-        uses: arduino/setup-task@v2
+        uses: arduino/setup-task@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Ship release
         working-directory: tools/release


### PR DESCRIPTION
Half of **G26** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md). Companion PR on \`openemr/website-openemr#188\` handles the sibling bump on the website-openemr side.

## Summary

Two changes across the six release-flow workflows in this repo:

1. **Bumps \`arduino/setup-task\` from \`v2\` to \`v3\`** — v2 targets Node.js 20 (deprecated, force-run on Node 24); v3 is the Node 24 native release.
2. **Wires \`repo-token: \${{ secrets.GITHUB_TOKEN }}\`** — the action's GitHub API calls (used to look up the Task release list before downloading the binary) now go through with authenticated request quota (5000/hr per-token) instead of the shared-IP anonymous quota (60/hr).

## Files touched

- \`.github/workflows/build-patch.yml\`
- \`.github/workflows/build-release.yml\`
- \`.github/workflows/build-release-on-tag.yml\`
- \`.github/workflows/release-announcements.yml\`
- \`.github/workflows/release-permissions-check.yml\`
- \`.github/workflows/ship-release.yml\`

## Concrete surface (originating incident)

On the **v8_2_0 tag-push cascade (2026-07-08)**, the \`Release Announcements (drafts)\` workflow's \`Install Task\` step failed with:

\`\`\`
##[error]API rate limit exceeded for 52.159.229.55.
(But here's the good news: Authenticated requests get a higher rate limit...)
\`\`\`

The anonymous 60/hr quota was exhausted because the runner IP was shared with other jobs simultaneously hitting the anonymous budget. Recovery required a workflow rerun once the hourly window reset. Under this change the same run would have been authenticated and unaffected by shared-IP anonymous exhaustion.

## Test plan

- [ ] CI (actionlint on all 6 workflow files)
- [ ] After merge: verify next release-related workflow run shows the \`Install Task\` step making authenticated API calls (X-RateLimit-Remaining reflects the per-token 5000/hr budget)
- [ ] After merge: verify Node deprecation warning no longer appears