### PR TITLE
feat(dispatch): openemr-tag schema now requires prev_release

### DIFF
--- a/tools/release/contracts/dispatch.schema.json
+++ b/tools/release/contracts/dispatch.schema.json
@@ -112,12 +112,13 @@
         },
         "tagData": {
             "type": "object",
-            "required": ["tag", "branch", "version"],
+            "required": ["tag", "branch", "version", "prev_release"],
             "additionalProperties": false,
             "properties": {
                 "tag": { "$ref": "#/definitions/tag" },
                 "branch": { "$ref": "#/definitions/branch" },
-                "version": { "$ref": "#/definitions/version" }
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
             }
         },
         "docsBinariesData": {

--- a/tools/release/tests/fixtures/dispatch/good-tag-test.json
+++ b/tools/release/tests/fixtures/dispatch/good-tag-test.json
@@ -5,8 +5,9 @@
     "actor": "openemr-release-bot",
     "dispatched_at": "2026-04-29T12:30:00Z",
     "data": {
-        "tag": "v8_1_0-test.abcdef0",
+        "tag": "v8_2_0-test.abcdef0",
         "branch": "rel-test",
-        "version": "8.1.0"
+        "version": "8.2.0",
+        "prev_release": "8.0.0"
     }
 }

--- a/tools/release/tests/fixtures/dispatch/good-tag.json
+++ b/tools/release/tests/fixtures/dispatch/good-tag.json
@@ -5,8 +5,9 @@
     "actor": "openemr-release-bot",
     "dispatched_at": "2026-04-29T12:30:00Z",
     "data": {
-        "tag": "v8_1_0",
-        "branch": "rel-810",
-        "version": "8.1.0"
+        "tag": "v8_2_0",
+        "branch": "rel-820",
+        "version": "8.2.0",
+        "prev_release": "8.0.0"
     }
 }

--- a/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good-overrides/contracts/dispatch.schema.json
@@ -112,12 +112,13 @@
         },
         "tagData": {
             "type": "object",
-            "required": ["tag", "branch", "version"],
+            "required": ["tag", "branch", "version", "prev_release"],
             "additionalProperties": false,
             "properties": {
                 "tag": { "$ref": "#/definitions/tag" },
                 "branch": { "$ref": "#/definitions/branch" },
-                "version": { "$ref": "#/definitions/version" }
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
             }
         },
         "docsBinariesData": {

--- a/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
+++ b/tools/release/tests/fixtures/vendored/good/contracts/dispatch.schema.json
@@ -112,12 +112,13 @@
         },
         "tagData": {
             "type": "object",
-            "required": ["tag", "branch", "version"],
+            "required": ["tag", "branch", "version", "prev_release"],
             "additionalProperties": false,
             "properties": {
                 "tag": { "$ref": "#/definitions/tag" },
                 "branch": { "$ref": "#/definitions/branch" },
-                "version": { "$ref": "#/definitions/version" }
+                "version": { "$ref": "#/definitions/version" },
+                "prev_release": { "$ref": "#/definitions/version" }
             }
         },
         "docsBinariesData": {


### PR DESCRIPTION
Canonical half of **G20** in [\`openemr/openemr:docs/release-mechanism-gaps.md\`](https://github.com/openemr/openemr/blob/master/docs/release-mechanism-gaps.md). Adds \`prev_release\` to the \`tagData\` block in the canonical dispatch envelope schema.

## Companion PRs

- [openemr/website-openemr#189](https://github.com/openemr/website-openemr/pull/189) — website-side envelope schema, jq builder, fixtures.
- [openemr/openemr#12887](https://github.com/openemr/openemr/pull/12887) — vendored copy of this schema + emitter update + tests.

**Order-of-merge:** this PR and #189 both must land before #12887. Until this PR merges, #12887's vendored-contract drift check fails against the canonical here. Until #189 merges, the openemr-tag emitter in #12887 would fail `validate-payload` on the consumer side.

## Problem

The \`openemr-tag\` envelope carried only \`tag / branch / version\`. Downstream on \`website-openemr\`, \`release-docs.yml\` gates its \"Generate acknowledgements\" and \"Generate release notes\" steps on \`if: prev_release != ''\`; both skipped every FINAL cut because \`openemr-tag\` never delivered the field. Recovery required an out-of-band \`openemr-rel-update\` dispatch to hit the sibling schema that does carry \`prev_release\`.

## Changes

1. **\`tools/release/contracts/dispatch.schema.json\`** — \`tagData\` block adds \`prev_release\` to \`required\` + \`properties\`. Typed as the shared \`#/definitions/version\`.
2. **\`tools/release/tests/fixtures/dispatch/good-tag.json\`** and **\`good-tag-test.json\`** — add \`\"prev_release\": \"8.0.0\"\` (so \`DispatchSchemaTest\`'s positive cases continue to pass) and bump \`8.1.0 / v8_1_0 / rel-810\` to \`8.2.0 / v8_2_0 / rel-820\`. 8.1.0 was cut as a prerelease and skipped -- never publicly released -- so using it as the canonical example implied a shipped 8.1.0 existed. 8.2.0 is a real released version. \`prev_release=8.0.0\` is the actual previous shipped release per \`website-openemr/data/releases.json\`'s FINAL entries.
3. **Vendored fixture schemas** (\`tests/fixtures/vendored/good/contracts/dispatch.schema.json\` + \`good-overrides/contracts/dispatch.schema.json\`) — mirror the tagData change so the drift-check self-test in \`vendored-contracts-self-test.yml\` continues to see them as matching canonical.

## Not touched

- \`TagDispatchPayload::fromEnvelope()\` in \`tools/release/src/\` still only reads \`version / tag / branch\` -- no devops-side consumer needs \`prev_release\` yet, so adding an accessor is out of scope. When a consumer (changelog generator, announcement renderer, etc.) needs it, add \`prev_release\` to the value object at that time. The schema change here is forward-compatible: extra data fields don't break existing consumers.

## Test plan

- [ ] CI (\`DispatchSchemaTest\` covers both \`good-tag*.json\` fixtures via glob discovery; \`VendoredFileCheckerTest\` covers the inline canonical/consumer comparison; \`vendored-contracts-self-test\` workflow covers the fixture-based drift check).
- [ ] After all three companion PRs land: verify the next release's \`openemr-tag\` dispatch carries \`prev_release\` in the payload → website-openemr's \`Generate acknowledgements\` + \`Generate release notes\` steps run instead of skipping → the FINAL release-docs PR contains both markdown files without a recovery dispatch.